### PR TITLE
Allowing users to create agent with existing Vnet while having their own Private DNS zones

### DIFF
--- a/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/README.md
+++ b/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/README.md
@@ -76,10 +76,11 @@ Note: If not provided, the following resources will be created automatically for
 
 1. **Use Existing Virtual Network and Subnets**
 
-To use an existing VNet and subnets, set the existingVnetResourceId parameter to the full Azure Resource ID of the target VNet, and provide the names of the two required subnets. Example:
+To use an existing VNet and subnets, set the existingVnetResourceId parameter to the full Azure Resource ID of the target VNet, and provide the names of the two required subnets. If the existing VNet is associated with private DNS zones, set the existingDnsZonesResourceGroup paramater to the resource group name in which the zones are located. Example:
 - param ExistingVnetResourceId = "/subscriptions/<subscription-id>/resourceGroups/<resource-group-name>/providers/Microsoft.Network/virtualNetworks/<vnet-name>" 
 - param agentSubnetName string = 'agent-subnet'
 - param peSubnetName string = 'pe-subnet'
+- param existingDnsZonesResourceGroup = '<private dns zone resource group name>'
 
 💡 Ensure both subnets already exist within the specified VNet. If they do not, you must also set createAgentSubnet and/or createPeSubnet to true and provide valid CIDR prefixes for creation. 
 

--- a/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/azuredeploy.parameters.json
+++ b/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/azuredeploy.parameters.json
@@ -67,6 +67,9 @@
     },
     "projectCapHost": {
       "value": ""
+    },
+    "existingDnsZonesResourceGroup": {
+      "value": ""
     }
   }
 }

--- a/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicep
+++ b/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicep
@@ -66,7 +66,7 @@ param existingVnetResourceId string = ''
 @description('Address space for the VNet (only used for new VNet)')
 param vnetAddressPrefix string = '192.168.0.0/16'
 
-@description('Address prefix for the agent subnet. The default value is 192.168.0.0/24 but you can choose any size /26 or any class like 10.0.0.0 or 152.168.0.0')
+@description('Address prefix for the agent subnet. The default value is 192.168.0.0/24 but you can choose any size /26 or any class like 10.0.0.0 or 172.168.0.0')
 param agentSubnetPrefix string = '192.168.0.0/24'
 
 @description('Address prefix for the private endpoint subnet')

--- a/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicep
+++ b/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicep
@@ -66,7 +66,7 @@ param existingVnetResourceId string = ''
 @description('Address space for the VNet (only used for new VNet)')
 param vnetAddressPrefix string = '192.168.0.0/16'
 
-@description('Address prefix for the agent subnet. The default value is 192.168.0.0/24 but you can choose any size /26 or any class like 10.0.0.0 or 172.168.0.0')
+@description('Address prefix for the agent subnet. The default value is 192.168.0.0/24 but you can choose any size /26 or any class like 10.0.0.0 or 152.168.0.0')
 param agentSubnetPrefix string = '192.168.0.0/24'
 
 @description('Address prefix for the private endpoint subnet')
@@ -78,6 +78,10 @@ param aiSearchResourceId string = ''
 param azureStorageAccountResourceId string = ''
 @description('The Cosmos DB Account full ARM Resource ID. This is an optional field, and if not provided, the resource will be created.')
 param azureCosmosDBAccountResourceId string = ''
+
+//New Param for resource group of Private DNS zones
+@description('Optional: Resource group containing existing private DNS zones. If specified, DNS zones will not be created.')
+param existingDnsZonesResourceGroup string = ''
 
 var projectName = toLower('${firstProjectName}${uniqueSuffix}')
 var cosmosDBName = toLower('${aiServices}${uniqueSuffix}cosmosdb')
@@ -224,6 +228,7 @@ module privateEndpointAndDNS 'modules-network-secured/private-endpoint-and-dns.b
       aiSearchResourceGroupName: aiSearchServiceResourceGroupName // Resource Group for AI Search Service
       storageAccountResourceGroupName: azureStorageResourceGroupName // Resource Group for Storage Account
       storageAccountSubscriptionId: azureStorageSubscriptionId // Subscription ID for Storage Account
+      existingDnsZonesResourceGroup: existingDnsZonesResourceGroup //adding Existing DNS RG
     }
     dependsOn: [
     aiSearch      // Ensure AI Search exists
@@ -368,3 +373,4 @@ dependsOn: [
   storageContainersRoleAssignment
   ]
 }
+

--- a/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicepparam
+++ b/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicepparam
@@ -20,6 +20,7 @@ param agentSubnetName = 'agent-subnet'
 param aiSearchResourceId = ''
 param azureStorageAccountResourceId = ''
 param azureCosmosDBAccountResourceId = ''
+param existingDnsZonesResourceGroup = ''
 
 // Network configuration: only used when existingVnetResourceId is not provided
 // These addresses are only used when creating a new VNet and subnets

--- a/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/modules-network-secured/validate-existing-resources.bicep
+++ b/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/modules-network-secured/validate-existing-resources.bicep
@@ -58,3 +58,33 @@ output cosmosDBResourceGroupName string = cosmosDBResourceGroupName
 
 output azureStorageSubscriptionId string = azureStorageSubscriptionId
 output azureStorageResourceGroupName string = azureStorageResourceGroupName
+
+// Adding DNS Zone Check
+
+@description('Name of the resource group to check for Private DNS zones')
+param existingDnsResourceGroup string
+
+@description('List of private DNS zone names to validate')
+param dnsZoneNames array
+
+var dnsZoneTypes = [
+  'Microsoft.Network/privateDnsZones'
+]
+
+// Output whether each DNS zone exists
+output dnsZoneExists array = [
+  for zoneName in dnsZoneNames: {
+    name: zoneName
+    exists: resourceExists('Microsoft.Network/privateDnsZones', zoneName, existingDnsResourceGroup)
+  }
+]
+
+// Helper function to check existence
+function resourceExists(resourceType: string, name: string, rg: string): bool {
+  // Use the existing resource reference to check
+  var res = existing resource dnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+    name: name
+    scope: resourceGroup(rg)
+  }
+  return !empty(res.id)
+}


### PR DESCRIPTION
Add conditions to allow a user to pass RG where their dns zones reside so that the template no longer fails with below error when using existing vnet that already has private DNS zones.

"A virtual network cannot be linked to multiple zones with overlapping namespaces. You tried to link virtual network with 'privatelink.blob.core.windows.net' and 'privatelink.blob.core.windows.net' zones. (Code: BadRequest)"



