### PR TITLE
fix: add AI Foundry account purger to prevent subnet deletion issues

### DIFF
--- a/samples/microsoft/infrastructure-setup-terraform/15a-private-network-standard-agent-setup/code/main.tf
+++ b/samples/microsoft/infrastructure-setup-terraform/15a-private-network-standard-agent-setup/code/main.tf
@@ -169,7 +169,8 @@ resource "azapi_resource" "ai_search" {
 ##
 resource "azapi_resource" "ai_foundry" {
   depends_on = [
-    azurerm_subnet.subnet_agent
+    azurerm_subnet.subnet_agent,
+    azapi_resource_action.purge_ai_foundry
   ]
 
   type                      = "Microsoft.CognitiveServices/accounts@2025-06-01"
@@ -762,4 +763,22 @@ resource "azurerm_role_assignment" "storage_blob_data_owner_ai_foundry_project" 
     AND @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringLikeIgnoreCase '*-azureml-agent')
   )
   EOT
+}
+
+## Added AI Foundry account purger to avoid running into InUseSubnetCannotBeDeleted-lock caused by the agent subnet delegation.
+## The azapi_resource_action.purge_ai_foundry (only gets executed during destroy) purges the AI foundry account removing /subnets/snet-agent/serviceAssociationLinks/legionservicelink so the agent subnet can get properly removed.
+
+resource "azapi_resource_action" "purge_ai_foundry" {
+  method      = "DELETE"
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/aifoundry${random_string.unique.result}"
+  type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
+  when        = "destroy"
+
+  depends_on = [time_sleep.purge_ai_foundry_cooldown]
+}
+
+resource "time_sleep" "purge_ai_foundry_cooldown" {
+  destroy_duration = "900s" # 10-15m is enough time to let the backend remove the /subnets/snet-agent/serviceAssociationLinks/legionservicelink
+
+  depends_on = [azurerm_subnet.subnet_agent]
 }

--- a/samples/microsoft/infrastructure-setup-terraform/15a-private-network-standard-agent-setup/code/main.tf
+++ b/samples/microsoft/infrastructure-setup-terraform/15a-private-network-standard-agent-setup/code/main.tf
@@ -1,6 +1,11 @@
 ########## Create infrastructure resources
 ##########
 
+## Get subscription data
+##
+
+data "azurerm_client_config" "current" {}
+
 ## Create a random string
 ##
 resource "random_string" "unique" {
@@ -770,7 +775,7 @@ resource "azurerm_role_assignment" "storage_blob_data_owner_ai_foundry_project" 
 
 resource "azapi_resource_action" "purge_ai_foundry" {
   method      = "DELETE"
-  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.this.location}/resourceGroups/${azurerm_resource_group.this.name}/deletedAccounts/aifoundry${random_string.unique.result}"
+  resource_id = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/providers/Microsoft.CognitiveServices/locations/${azurerm_resource_group.rg.location}/resourceGroups/${azurerm_resource_group.rg.name}/deletedAccounts/aifoundry${random_string.unique.result}"
   type        = "Microsoft.Resources/resourceGroups/deletedAccounts@2021-04-30"
   when        = "destroy"
 


### PR DESCRIPTION
- Added AI Foundry account purger to avoid running into `InUseSubnetCannotBeDeleted`-lock caused by the agent subnet delegation.
- The `azapi_resource_action.purge_ai_foundry` (only gets executed during destroy) purges the AI foundry account removing `/subnets/snet-agent/serviceAssociationLinks/legionservicelink` so the agent subnet can get properly removed.

The destruction sequence is as follows:

1. Destroy `azapi_resource.ai_foundry`.
2. Purge using `azapi_resource_action.purge_ai_foundry`.
3. Wait 15 minutes using `time_sleep.purge_ai_foundry_cooldown`.
4. Remove `azurerm_subnet.subnet_agent`.

Reference test deployments see https://github.com/Azure/terraform-azurerm-avm-ptn-aiml-ai-foundry.

<img width="1549" height="136" alt="image" src="https://github.com/user-attachments/assets/5529d55a-7160-4929-90c2-fa235afcd1a8" />
