### PR TITLE
Add Central US to list of supported agent private network locations

### DIFF
--- a/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/azuredeploy.json
+++ b/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/azuredeploy.json
@@ -14,6 +14,7 @@
       "defaultValue": "eastus2",
       "allowedValues": [
         "australiaeast",
+        "centralus",
         "eastus",
         "eastus2",
         "francecentral",

--- a/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicep
+++ b/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicep
@@ -5,6 +5,7 @@ Standard Setup Network Secured Steps for main.bicep
 @description('Location for all resources.')
 @allowed([
     'australiaeast'
+    'centralus'
     'eastus'
     'eastus2'
     'francecentral'


### PR DESCRIPTION
In alignment with documentation, add Central US as a supported region for private network locations.