### PR TITLE
Clarify network parameter behavior for new vs existing VNet (prevent CIDR overlap / InUsePrefix issues)

### DIFF
--- a/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicepparam
+++ b/samples/microsoft/infrastructure-setup/15-private-network-standard-agent-setup/main.bicepparam
@@ -42,9 +42,26 @@ param dnsZoneNames = [
 ]
 
 
-// Network configuration: only used when existingVnetResourceId is not provided
-// These addresses are only used when creating a new VNet and subnets
-// If you provide existingVnetResourceId, these values will be ignored
+// Network configuration (behavior depends on `existingVnetResourceId`)
+//
+// - NEW VNet (existingVnetResourceId is empty):
+//     The values below are used to CREATE the VNet and the two subnets.
+//     Provide explicit, non-overlapping CIDR ranges when creating a new VNet.
+//
+// - EXISTING VNet (existingVnetResourceId is provided):
+//     The module will reference the existing VNet. Subnet handling depends on the
+//     values you provide:
+//       * If `agentSubnetPrefix` or `peSubnetPrefix` are empty, the module may
+//         auto-derive subnet CIDRs from the existing VNet's address space
+//         (using cidrSubnet). This can produce /24 (or configured) subnets
+//         starting at index 0, 1, etc.
+//       * If you provide explicit subnet prefixes, the module will attempt to
+//         create or update subnets with those prefixes in the existing VNet.
+//
+// Important operational notes and risks (when existingVnetResourceId is provided):
+// - Avoid CIDR overlaps with any existing subnets in the target VNet. Overlap
+//   leads to `NetcfgSubnetRangesOverlap` and failed deployments.
+// - For highest safety when using an existing VNet, supply the existing `agentSubnetPrefix` and `peSubnetPrefix`. 
 param vnetAddressPrefix = ''
 param agentSubnetPrefix = ''
 param peSubnetPrefix = ''


### PR DESCRIPTION
- What
  - Improve and expand comments for network parameters in main.bicepparam to explicitly describe different behaviors when deploying with a new VNet vs. reusing an existing VNet.
  - Add operational warnings and recommended pre-deployment checks to prevent common deployment failures (e.g. InUsePrefixCannotBeDeleted, NetcfgSubnetRangesOverlap).

- Why
  - Users deploying into an existing VNet previously encountered failures because templates attempted to create/modify subnets with overlapping CIDRs or tried to delete prefixes that had active allocations. Better inline documentation reduces accidental misconfiguration.

- Impact
  - Documentation-only change (no runtime/template logic modified). Safe to merge.
  - Recommends best practices (pass both existing `agentSubnetPrefix` and `peSubnetPrefix` when possible, check for overlaps).

- How to validate
  - None required for the change itself (comment-only). 