### PR TITLE
Create quickstart dotNET files 

### DIFF
--- a/samples-v2/microsoft/csharp/quickstart/AgentService.cs
+++ b/samples-v2/microsoft/csharp/quickstart/AgentService.cs
@@ -1,4 +1,4 @@
-/ This sample combines each step of creating and running agents and conversations into a single example.
+// This sample combines each step of creating and running agents and conversations into a single example.
 // In practice, you would typically separate these steps into different applications.
 //
 #:package Azure.AI.Agents@2.*-*
@@ -18,7 +18,7 @@ string MODEL_DEPLOYMENT = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_M
 string AGENT_NAME = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_AGENT_NAME")
     ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_AGENT_NAME'");
 
-AgentsClient agentsClient = new(new Uri(RAW_PROJECT_ENDPOINT), new AzureCliCredential());
+AgentClient agentsClient = new(new Uri(RAW_PROJECT_ENDPOINT), new AzureCliCredential());
 OpenAIClient openAIClient = agentsClient.GetOpenAIClient();
 OpenAIResponseClient responseClient = openAIClient.GetOpenAIResponseClient(MODEL_DEPLOYMENT);
 
@@ -30,7 +30,7 @@ AgentDefinition agentDefinition = new PromptAgentDefinition(MODEL_DEPLOYMENT)
 {
     Instructions = "You are a foo bar agent. In EVERY response you give, ALWAYS include both `foo` and `bar` strings somewhere in the response.",
 };
-AgentVersion newAgentVersion = await agentsClient.CreateAgentVersionAsync(AGENT_NAME, agentDefinition);
+AgentVersion newAgentVersion = await agentsClient.CreateAgentVersionAsync(AGENT_NAME, options: new(agentDefinition));
 
 //
 // Create a conversation to maintain state between calls

--- a/samples-v2/microsoft/csharp/quickstart/nuget.config
+++ b/samples-v2/microsoft/csharp/quickstart/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="Azure SDK for .NET Dev Feed" value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json" protocolVersion="3"/>
+  </packageSources>
+</configuration>

--- a/samples-v2/microsoft/csharp/quickstart/quickstart-chat-with-agent.cs
+++ b/samples-v2/microsoft/csharp/quickstart/quickstart-chat-with-agent.cs
@@ -1,0 +1,43 @@
+#:package Azure.AI.Projects@2.0.0-alpha.20251104.9
+#:package Azure.AI.Agents@2.*-*
+#:package Azure.Identity@1.*
+#:package OpenAI@2.6.*
+#:property PublishAot=false
+#:property NoWarn=OPENAI001
+
+using Azure.AI.Projects;
+using Azure.AI.Agents;
+using Azure.Identity;
+using OpenAI;
+using OpenAI.Responses;
+
+string AZURE_AI_FOUNDRY_PROJECT_ENDPOINT = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT")
+    ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_PROJECT_ENDPOINT'");
+string MODEL_DEPLOYMENT_NAME = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_MODEL_DEPLOYMENT_NAME")
+    ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_MODEL_DEPLOYMENT_NAME'");
+string AGENT_NAME = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_AGENT_NAME")
+    ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_AGENT_NAME'");
+
+AIProjectClient projectClient = new(new Uri(AZURE_AI_FOUNDRY_PROJECT_ENDPOINT), new AzureCliCredential());
+AgentClient agentClient = projectClient.GetAgentClient();
+OpenAIClient openAIClient = agentClient.GetOpenAIClient();
+OpenAIResponseClient responseClient = openAIClient.GetOpenAIResponseClient(MODEL_DEPLOYMENT_NAME);
+// Optional Step: Create a conversation to use with the agent
+ConversationClient conversations = agentClient.GetConversationClient();
+AgentConversation conversation = conversations.CreateConversation();
+
+ResponseCreationOptions responseCreationOptions = new();
+responseCreationOptions.SetAgentReference(new AgentReference(AGENT_NAME));
+responseCreationOptions.SetConversationReference(conversation.Id);
+// Chat with the agent to answer questions
+OpenAIResponse response = responseClient.CreateResponse(
+    [ResponseItem.CreateUserMessageItem("What is the size of France in square miles?")],
+    responseCreationOptions);
+
+Console.WriteLine(response.GetOutputText());
+// Optional Step: Ask a follow-up question in the same conversation
+response = responseClient.CreateResponse(
+    [ResponseItem.CreateUserMessageItem("And what is the capital city?")],
+    responseCreationOptions);
+
+Console.WriteLine(response.GetOutputText());

--- a/samples-v2/microsoft/csharp/quickstart/quickstart-create-agent.cs
+++ b/samples-v2/microsoft/csharp/quickstart/quickstart-create-agent.cs
@@ -1,0 +1,32 @@
+#:package Azure.AI.Agents@2.*-*
+#:package Azure.Identity@1.*
+#:property PublishAot=false
+#:property NoWarn=OPENAI001
+
+using Azure.AI.Agents;
+using Azure.Identity;
+
+string PROJECT_ENDPOINT = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT")
+    ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_PROJECT_ENDPOINT'");
+string MODEL_DEPLOYMENT_NAME = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_MODEL_DEPLOYMENT_NAME")
+    ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_MODEL_DEPLOYMENT_NAME'");
+string AGENT_NAME = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_AGENT_NAME")
+    ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_AGENT_NAME'");
+
+AgentClient agentClient = new(new Uri(PROJECT_ENDPOINT), new AzureCliCredential(),);
+
+AgentDefinition agentDefinition = new PromptAgentDefinition(MODEL_DEPLOYMENT_NAME)
+{
+    Instructions = "You are a helpful assistant that answers general questions",
+};
+
+AgentVersion newAgentVersion = agentClient.CreateAgentVersion(
+    AGENT_NAME,
+    options: new(agentDefinition));
+
+var agentVersions = agentClient.GetAgentVersions(AGENT_NAME);
+foreach (AgentVersion oneAgentVersion in agentVersions)
+{
+    Console.WriteLine($"Agent: {oneAgentVersion.Id}, Name: {oneAgentVersion.Name}, Version: {oneAgentVersion.Version}");
+}
+

--- a/samples-v2/microsoft/csharp/quickstart/quickstart-responses.cs
+++ b/samples-v2/microsoft/csharp/quickstart/quickstart-responses.cs
@@ -1,0 +1,31 @@
+#:package Azure.AI.Projects@2.0.0-alpha.20251104.9
+#:package Azure.AI.Agents@2.*-*
+#:package Azure.Identity@1.*
+#:package OpenAI@2.6.*
+#:property PublishAot=false
+#:property NoWarn=OPENAI001
+
+using Azure.AI.Projects;
+using Azure.AI.Agents;
+using Azure.Identity;
+using OpenAI;
+using OpenAI.Responses;
+
+string AZURE_AI_FOUNDRY_PROJECT_ENDPOINT = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_PROJECT_ENDPOINT")
+    ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_PROJECT_ENDPOINT'");
+string MODEL_DEPLOYMENT_NAME = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_MODEL_DEPLOYMENT_NAME")
+    ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_MODEL_DEPLOYMENT_NAME'");
+string AGENT_NAME = Environment.GetEnvironmentVariable("AZURE_AI_FOUNDRY_AGENT_NAME")
+    ?? throw new InvalidOperationException("Missing environment variable 'AZURE_AI_FOUNDRY_AGENT_NAME'");
+
+AIProjectClient projectClient = new(new Uri(AZURE_AI_FOUNDRY_PROJECT_ENDPOINT), new AzureCliCredential());
+AgentClient agentClient = projectClient.GetAgentClient();
+OpenAIClient openAIClient = agentClient.GetOpenAIClient();
+OpenAIResponseClient responseClient = openAIClient.GetOpenAIResponseClient(MODEL_DEPLOYMENT_NAME);
+
+ResponseCreationOptions responseCreationOptions = new();
+
+List<ResponseItem> items = [ResponseItem.CreateUserMessageItem("What is the size of France in square miles?")];
+OpenAIResponse response = await responseClient.CreateResponseAsync(items, responseCreationOptions);
+
+Console.WriteLine(response.GetOutputText());


### PR DESCRIPTION

The `csharp/quickstart` folder contains a `nuget.config` that includes this feed for building and running the standalone single-file programs (.NET 10 required).
To run the quickstart samples, first set the required environment variables (e.g. via `export` (*NIX/Bash) or `$env:**=**` (PowerShell)):

| Variable | Description | Example |
|---|---|---|
| `AZURE_AI_FOUNDRY_PROJECT_ENDPOINT` | The full URL pointing to your AI Foundry project resource, including the project name. | `https://<YOUR-RESOURCE-NAME>.services.ai.azure.com/api/projects/<YOUR-PROJECT-NAME>` |
| `AZURE_AI_FOUNDRY_MODEL_DEPLOYMENT` | When applicable, the model deployment to use in the sample. | `gpt-4.1-mini` |
| `AZURE_AI_FOUNDRY_AGENT_NAME` | The name to use when creating or retrieving the agent for the sample. | `MyAgent` |



Then  use `dotnet run <filename>`.