### PR TITLE
Fix and improve python samples for hosted agents

### DIFF
--- a/samples/microsoft/python/getting-started-agents/hosted-agents/echo-agent/agent.yaml
+++ b/samples/microsoft/python/getting-started-agents/hosted-agents/echo-agent/agent.yaml
@@ -1,15 +1,16 @@
 # Unique identifier/name for this agent
 name: echo-agent
 # Brief description of what this agent does
-description: |-
-  This Agent just returns an echo from the user input.
-  It is useful for testing and debugging.
+description: >
+  This sample demonstrates how to create a custom AI agent that echoes user input.
+  It is useful for testing, debugging, and learning how to build custom agents.
 metadata:
   # Categorization tags for organizing and discovering agents
   tags:
-    - example
-    - utility
-    - basic-example
+    - AI Agent Hosting
+    - Azure AI AgentServer
+    - Custom Agent Implementation
+    - Microsoft Agent Framework
 template:
   name: echo-agent
   # The type of agent - "hosted" for HOBO, "container" for COBO

--- a/samples/microsoft/python/getting-started-agents/hosted-agents/msft-docs-agent/agent.yaml
+++ b/samples/microsoft/python/getting-started-agents/hosted-agents/msft-docs-agent/agent.yaml
@@ -1,9 +1,12 @@
 name: MicrosoftLearnMCPAgent
-description: This Agent can perform web searches and retrieve the latest information from Bing.
+description: This Agent can access and search Microsoft Learn documentation using MCP (Model Context Protocol) with tool call approval.
 metadata:
   tags:
-    - example
-    - learning
+    - AI Agent Hosting
+    - Azure AI AgentServer
+    - MCP
+    - Microsoft Agent Framework
+    - Tool Call Approval
   authors:
     - jeomhove
 template:

--- a/samples/microsoft/python/getting-started-agents/hosted-agents/web-search-agent/agent.yaml
+++ b/samples/microsoft/python/getting-started-agents/hosted-agents/web-search-agent/agent.yaml
@@ -6,8 +6,11 @@ metadata:
       content: |-
         What's the latest news in AI?
   tags:
-    - example
-    - learning
+    - AI Agent Grounding
+    - AI Agent Hosting
+    - Azure AI AgentServer
+    - Bing Grounding
+    - Microsoft Agent Framework
   authors:
     - jeomhove
 template:


### PR DESCRIPTION
This PR:    
- Changes the msft-docs-agent and web-search-agent names to make them deployable. The deployment was failing with the error: _"agentName{Microsoft Learn MCP Agent}: Must start and end with alphanumeric characters, can contain hyphens in the middle, and must not exceed 63 characters."_
- Revises the agents' tags and descriptions to align with the agents' code.