### PR TITLE
Fix EchoAgent echo_prefix initialization

### DIFF
--- a/samples-classic/python/getting-started-agents/hosted-agents/echo-agent/main.py
+++ b/samples-classic/python/getting-started-agents/hosted-agents/echo-agent/main.py
@@ -30,8 +30,6 @@ class EchoAgent(BaseAgent):
     and implementing the required run() and run_stream() methods.
     """
 
-    echo_prefix: str = "Echo: "
-
     def __init__(
         self,
         *,
@@ -48,10 +46,10 @@ class EchoAgent(BaseAgent):
             echo_prefix: The prefix to add to echoed messages.
             **kwargs: Additional keyword arguments passed to BaseAgent.
         """
+        self.echo_prefix = echo_prefix
         super().__init__(
             name=name,
             description=description,
-            echo_prefix=echo_prefix,  # type: ignore
             **kwargs,
         )
 

--- a/samples/python/hosted-agents/echo-agent/main.py
+++ b/samples/python/hosted-agents/echo-agent/main.py
@@ -31,8 +31,6 @@ class EchoAgent(BaseAgent):
     and implementing the required run() and run_stream() methods.
     """
 
-    echo_prefix: str = "Echo: "
-
     def __init__(
         self,
         *,
@@ -49,10 +47,10 @@ class EchoAgent(BaseAgent):
             echo_prefix: The prefix to add to echoed messages.
             **kwargs: Additional keyword arguments passed to BaseAgent.
         """
+        self.echo_prefix = echo_prefix
         super().__init__(
             name=name,
             description=description,
-            echo_prefix=echo_prefix,  # type: ignore
             **kwargs,
         )
 


### PR DESCRIPTION
### Problem
The Echo Agent samples were passing `echo_prefix` into `BaseAgent.__init__` (guarded by `# type: ignore`). In current `agent_framework` / `BaseAgent` implementations, this parameter is not part of the base constructor contract.

### What this fixes
- Stores `echo_prefix` on the agent instance (`self.echo_prefix`) and stops passing it to `BaseAgent.__init__`.
- Removes the redundant class-level `echo_prefix` attribute to avoid conflicting sources of truth.

Updated samples:
- `samples/python/hosted-agents/echo-agent/main.py`
- `samples-classic/python/getting-started-agents/hosted-agents/echo-agent/main.py`

### Why this matters / impact if not fixed
Without this change, the echo passed-in `echo_prefix` is not used, because its value does not set to anywhere.
As a result, `self.echo_prefix` always points to the class-level `echo_prefix`, which is unexpected.

### Verification

* When creating `EchoAgent`, `echo_prefix` is set to `"🔊 Echo: "` (Note that there's an emoji at the beginning):
<img width="833" height="86" alt="image" src="https://github.com/user-attachments/assets/1e8932dd-7fa2-45bd-9043-49ee70477a85" />

* On the other hand, the class-level `echo_prefix` is hard-coded to `"Echo: "`:
<img width="640" height="186" alt="image" src="https://github.com/user-attachments/assets/ae393a8f-0971-40f2-bc10-141fefe69805" />

#### Before this PR fix
The hard-coded class-level `echo_prefix` is used, which is unexpected.
<img width="609" height="95" alt="image" src="https://github.com/user-attachments/assets/992591b4-a760-47fd-aa51-39b6342fb42f" />

#### After this PR
The `echo_prefix` when creating `EchoAgent` is used. This is the expected behavior.
<img width="663" height="97" alt="image" src="https://github.com/user-attachments/assets/7924af54-d6f9-4063-916e-51ed058a37b3" />