### PR TITLE
fix: serialize project connection creation to avoid 409 conflicts

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network-preview/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network-preview/azuredeploy.json
@@ -2079,6 +2079,7 @@
               ]
             },
             {
+              "comment": "dependsOn to serialize connection creation and avoid 409 conflicts",
               "type": "Microsoft.CognitiveServices/accounts/projects/connections",
               "apiVersion": "2025-04-01-preview",
               "name": "[format('{0}/{1}/{2}', parameters('accountName'), parameters('projectName'), parameters('azureStorageName'))]",
@@ -2093,10 +2094,12 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.CognitiveServices/accounts/projects', parameters('accountName'), parameters('projectName'))]"
+                "[resourceId('Microsoft.CognitiveServices/accounts/projects', parameters('accountName'), parameters('projectName'))]",
+                "[resourceId('Microsoft.CognitiveServices/accounts/projects/connections', parameters('accountName'), parameters('projectName'), parameters('cosmosDBName'))]"
               ]
             },
             {
+              "comment": "dependsOn to serialize connection creation and avoid 409 conflicts",
               "type": "Microsoft.CognitiveServices/accounts/projects/connections",
               "apiVersion": "2025-04-01-preview",
               "name": "[format('{0}/{1}/{2}', parameters('accountName'), parameters('projectName'), parameters('aiSearchName'))]",
@@ -2111,7 +2114,8 @@
                 }
               },
               "dependsOn": [
-                "[resourceId('Microsoft.CognitiveServices/accounts/projects', parameters('accountName'), parameters('projectName'))]"
+                "[resourceId('Microsoft.CognitiveServices/accounts/projects', parameters('accountName'), parameters('projectName'))]",
+                "[resourceId('Microsoft.CognitiveServices/accounts/projects/connections', parameters('accountName'), parameters('projectName'), parameters('azureStorageName'))]"
               ]
             },
             {

--- a/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network-preview/modules-network-secured/ai-project-identity.bicep
+++ b/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network-preview/modules-network-secured/ai-project-identity.bicep
@@ -60,6 +60,7 @@ resource project 'Microsoft.CognitiveServices/accounts/projects@2025-04-01-previ
     }
   }
 
+  // dependsOn to serialize connection creation and avoid 409 conflicts
   resource project_connection_azure_storage 'connections@2025-04-01-preview' = {
     name: azureStorageName
     properties: {
@@ -72,8 +73,12 @@ resource project 'Microsoft.CognitiveServices/accounts/projects@2025-04-01-previ
         location: storageAccount.location
       }
     }
+    dependsOn: [
+      project_connection_cosmosdb_account
+    ]
   }
 
+  // dependsOn to serialize connection creation and avoid 409 conflicts
   resource project_connection_azureai_search 'connections@2025-04-01-preview' = {
     name: aiSearchName
     properties: {
@@ -86,6 +91,9 @@ resource project 'Microsoft.CognitiveServices/accounts/projects@2025-04-01-previ
         location: searchService.location
       }
     }
+    dependsOn: [
+      project_connection_azure_storage
+    ]
   }
 
 }


### PR DESCRIPTION
## Summary

When deploying AI projects with connections (CosmosDB, Azure Storage, AI Search), the deployment was failing with a **409 Conflict error**. This happened because all 3 connection resources were being created in parallel by default, and the backend service doesn't support concurrent connection creation on the same project.

## Solution

Serialize the connection creation so they deploy one after another instead of all at once:

1. **CosmosDB connection** deploys first (no dependencies)
2. **Azure Storage connection** waits for CosmosDB connection to complete
3. **AI Search connection** waits for Azure Storage connection to complete

## Changes

### Bicep (i-project-identity.bicep)
- Added `dependsOn: [project_connection_cosmosdb_account]` to the `project_connection_azure_storage` resource
- Added `dependsOn: [project_connection_azure_storage]` to the `project_connection_azureai_search` resource

### ARM Template (zuredeploy.json)
- Added CosmosDB connection dependency to Storage connection's `dependsOn` array
- Added Storage connection dependency to AI Search connection's `dependsOn` array

## Result

Connections now deploy sequentially: CosmosDB → Storage → AI Search, avoiding the 409 conflict caused by parallel PUT requests to the same project.