### PR TITLE
fix: remove invalid comment properties from ARM template

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network-preview/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network-preview/azuredeploy.json
@@ -2079,7 +2079,6 @@
               ]
             },
             {
-              "comment": "dependsOn to serialize connection creation and avoid 409 conflicts",
               "type": "Microsoft.CognitiveServices/accounts/projects/connections",
               "apiVersion": "2025-04-01-preview",
               "name": "[format('{0}/{1}/{2}', parameters('accountName'), parameters('projectName'), parameters('azureStorageName'))]",
@@ -2099,7 +2098,6 @@
               ]
             },
             {
-              "comment": "dependsOn to serialize connection creation and avoid 409 conflicts",
               "type": "Microsoft.CognitiveServices/accounts/projects/connections",
               "apiVersion": "2025-04-01-preview",
               "name": "[format('{0}/{1}/{2}', parameters('accountName'), parameters('projectName'), parameters('aiSearchName'))]",


### PR DESCRIPTION
PR #560 introduced comment properties in ARM template JSON causing InvalidRequestContent errors during deployment. This removes those invalid properties while preserving the dependsOn fixes that serialize connection creation to avoid 409 conflicts.