### PR TITLE
fix: allow sync bot PRs through redirect workflow

### DIFF
--- a/.github/workflows/redirect-pull-requests.yml
+++ b/.github/workflows/redirect-pull-requests.yml
@@ -18,6 +18,13 @@ jobs:
             const pr = context.payload.pull_request;
             const author = pr.user.login;
 
+            // Allow PRs from trusted automation bots (e.g., repo sync)
+            const allowedBots = ['foundry-samples-repo-sync[bot]'];
+            if (allowedBots.includes(author)) {
+              console.log(`Skipping redirect for allowed bot: ${author}`);
+              return;
+            }
+
             // Check if author is a member of the microsoft org
             let isOrgMember = false;
             try {


### PR DESCRIPTION
## Problem
The nightly sync automation from `foundry-samples-pr` creates PRs using `foundry-samples-repo-sync[bot]`, but the redirect workflow (added in #552) auto-closes **all** opened PRs. This breaks the sync pipeline — e.g., PR #576 was closed 10 seconds after creation.

## Fix
Add a named bot allowlist to `redirect-pull-requests.yml`. PRs authored by `foundry-samples-repo-sync[bot]` are now skipped by the redirect workflow. The list is easily extensible for future bots.

## Changes
- `.github/workflows/redirect-pull-requests.yml`: Added `allowedBots` array check before the org membership/redirect logic.

## Testing
After merge, trigger the sync workflow via `workflow_dispatch` on `foundry-samples-pr` and verify the resulting PR stays open.

**⚠️ NOTE**: This PR itself will be auto-closed by the redirect workflow (the very bug it fixes). An admin will need to re-open it for review/merge.

Fixes [ADO#5063962](https://msdata.visualstudio.com/Vienna/_workitems/edit/5063962)