### PR TITLE
Sync: Remaining commits from foundry-samples-pr#62 (linting, .gitignore, prefix removal)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -461,14 +461,3 @@ terraform.rc
 samples/microsoft/nul
 samples/microsoft/microsoft.sln
 samples/microsoft/developer-journey-stage-1-idea-to-prototype.md
-# Doc-Kit workspace files
-.github/AGENTS.md
-.github/agents/
-.github/instructions/
-.github/prompts/
-.github/skills/
-.vscode/settings.json
-.dockit/
-.env
-.env.example
-requirements.txt

--- a/samples/csharp/quickstart/chat-with-agent/quickstart-chat-with-agent.cs
+++ b/samples/csharp/quickstart/chat-with-agent/quickstart-chat-with-agent.cs
@@ -6,12 +6,12 @@ using OpenAI.Responses;
 #pragma warning disable OPENAI001
 
 // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-var foundryProjectEndpoint = "your_project_endpoint";
-var foundryAgentName = "your_agent_name";
+var ProjectEndpoint = "your_project_endpoint";
+var AgentName = "your_agent_name";
 
 // Create project client to call Foundry API
 AIProjectClient projectClient = new(
-    endpoint: new Uri(foundryProjectEndpoint),
+    endpoint: new Uri(ProjectEndpoint),
     tokenProvider: new DefaultAzureCredential());
 
 // Create a conversation for multi-turn chat
@@ -19,7 +19,7 @@ ProjectConversation conversation = projectClient.OpenAI.Conversations.CreateProj
 
 // Chat with the agent to answer questions
 ProjectResponsesClient responsesClient = projectClient.OpenAI.GetProjectResponsesClientForAgent(
-    defaultAgent: foundryAgentName,
+    defaultAgent: AgentName,
     defaultConversationId: conversation.Id);
 ResponseResult response = responsesClient.CreateResponse("What is the size of France in square miles?");
 Console.WriteLine(response.GetOutputText());

--- a/samples/csharp/quickstart/create-agent/quickstart-create-agent.cs
+++ b/samples/csharp/quickstart/create-agent/quickstart-create-agent.cs
@@ -4,7 +4,6 @@ using Azure.AI.Projects.OpenAI;
 
 // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
 var foundryProjectEndpoint = "your_project_endpoint";
-var foundryModelName = "gpt-5-mini";  // supports all Foundry direct models
 var foundryAgentName = "your_agent_name";
 
 // Create project client to call Foundry API
@@ -13,7 +12,7 @@ AIProjectClient projectClient = new(
     tokenProvider: new DefaultAzureCredential());
 
 // Create an agent with a model and instructions
-AgentDefinition agentDefinition = new PromptAgentDefinition(foundryModelName)
+AgentDefinition agentDefinition = new PromptAgentDefinition("gpt-5-mini") // supports all Foundry direct models
 {
     Instructions = "You are a helpful assistant that answers general questions",
 };

--- a/samples/csharp/quickstart/create-agent/quickstart-create-agent.cs
+++ b/samples/csharp/quickstart/create-agent/quickstart-create-agent.cs
@@ -3,12 +3,12 @@ using Azure.AI.Projects;
 using Azure.AI.Projects.OpenAI;
 
 // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-var foundryProjectEndpoint = "your_project_endpoint";
-var foundryAgentName = "your_agent_name";
+var ProjectEndpoint = "your_project_endpoint";
+var AgentName = "your_agent_name";
 
 // Create project client to call Foundry API
 AIProjectClient projectClient = new(
-    endpoint: new Uri(foundryProjectEndpoint),
+    endpoint: new Uri(ProjectEndpoint),
     tokenProvider: new DefaultAzureCredential());
 
 // Create an agent with a model and instructions
@@ -18,6 +18,6 @@ AgentDefinition agentDefinition = new PromptAgentDefinition("gpt-5-mini") // sup
 };
 
 AgentVersion agent = projectClient.Agents.CreateAgentVersion(
-    foundryAgentName,
+    AgentName,
     options: new(agentDefinition));
 Console.WriteLine($"Agent created (id: {agent.Id}, name: {agent.Name}, version: {agent.Version})");

--- a/samples/csharp/quickstart/responses/quickstart-responses.cs
+++ b/samples/csharp/quickstart/responses/quickstart-responses.cs
@@ -6,16 +6,15 @@ using OpenAI.Responses;
 #pragma warning disable OPENAI001
 
 // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-var foundryProjectEndpoint = "your_project_endpoint";
-var foundryModelName = "gpt-5-mini";  // supports all Foundry direct models
+var ProjectEndpoint = "your_project_endpoint";
 
 // Create project client to call Foundry API
 AIProjectClient projectClient = new(
-    endpoint: new Uri(foundryProjectEndpoint),
+    endpoint: new Uri(ProjectEndpoint),
     tokenProvider: new DefaultAzureCredential());
 
 // Run a responses API call
-ProjectResponsesClient responseClient = projectClient.OpenAI.GetProjectResponsesClientForModel(foundryModelName);
+ProjectResponsesClient responseClient = projectClient.OpenAI.GetProjectResponsesClientForModel("gpt-5-mini"); // supports all Foundry direct models
 ResponseResult response = await responseClient.CreateResponseAsync(
     "What is the size of France in square miles?");
 Console.WriteLine(response.GetOutputText());

--- a/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/ChatWithAgent.java
+++ b/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/ChatWithAgent.java
@@ -58,7 +58,7 @@ public class ChatWithAgent {
 
         ResponseCreateParams responseRequest = new ResponseCreateParams.Builder()
             .input("Hello, how can you help me?")
-            .model("gpt-5-mini")
+            .model("gpt-5-mini") //supports all Foundry direct models
             .build();
 
         Response result = client.responses().create(responseRequest);

--- a/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/ChatWithAgent.java
+++ b/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/ChatWithAgent.java
@@ -20,15 +20,15 @@ import com.openai.models.responses.ResponseCreateParams;
 public class ChatWithAgent {
     public static void main(String[] args) {
         // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-        String foundryProjectEndpoint = "your_project_endpoint";
-        String foundryAgentName = "your_agent_name";
+        String ProjectEndpoint = "your_project_endpoint";
+        String AgentName = "your_agent_name";
         
         AgentsClient agentsClient = new AgentsClientBuilder()
                 .credential(new DefaultAzureCredentialBuilder().build())
-                .endpoint(foundryProjectEndpoint)
+                .endpoint(ProjectEndpoint)
                 .buildAgentsClient();
 
-        AgentDetails agent = agentsClient.getAgent(foundryAgentName);
+        AgentDetails agent = agentsClient.getAgent(AgentName);
 
         Conversation conversation = conversationsClient.getConversationService().create();
         conversationsClient.getConversationService().items().create(
@@ -49,7 +49,7 @@ public class ChatWithAgent {
         Response response = responsesClient.createWithAgentConversation(agentReference, conversation.id());
 
         OpenAIClient client = OpenAIOkHttpClient.builder()
-            .baseUrl(foundryProjectEndpoint.endsWith("/") ? foundryProjectEndpoint + "openai" : foundryProjectEndpoint + "/openai")
+            .baseUrl(ProjectEndpoint.endsWith("/") ? ProjectEndpoint + "openai" : ProjectEndpoint + "/openai")
             .azureUrlPathMode(AzureUrlPathMode.UNIFIED)
             .credential(BearerTokenCredential.create(AuthenticationUtil.getBearerTokenSupplier(
                     new DefaultAzureCredentialBuilder().build(), "https://ai.azure.com/.default")))

--- a/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/CreateAgent.java
+++ b/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/CreateAgent.java
@@ -8,7 +8,6 @@ public class CreateAgent {
     public static void main(String[] args) {
         // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
         String foundryProjectEndpoint = "your_project_endpoint";
-        String foundryModelName = "gpt-5-mini";  // supports all Foundry direct models
         String foundryAgentName = "your_agent_name";
 
         // Create agents client to call Foundry API
@@ -18,7 +17,8 @@ public class CreateAgent {
                 .buildAgentsClient();
 
         // Create an agent with a model and instructions
-        PromptAgentDefinition request = new PromptAgentDefinition(foundryModelName);
+        PromptAgentDefinition request = new PromptAgentDefinition("gpt-5-mini") // supports all Foundry direct models
+                .setInstructions("You are a helpful assistant that answers general questions");
         AgentVersionDetails agent = agentsClient.createAgentVersion(foundryAgentName, request);
 
         System.out.println("Agent ID: " + agent.getId());

--- a/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/CreateAgent.java
+++ b/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/CreateAgent.java
@@ -7,19 +7,19 @@ import com.azure.identity.DefaultAzureCredentialBuilder;
 public class CreateAgent {
     public static void main(String[] args) {
         // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-        String foundryProjectEndpoint = "your_project_endpoint";
-        String foundryAgentName = "your_agent_name";
+        String ProjectEndpoint = "your_project_endpoint";
+        String AgentName = "your_agent_name";
 
         // Create agents client to call Foundry API
         AgentsClient agentsClient = new AgentsClientBuilder()
                 .credential(new DefaultAzureCredentialBuilder().build())
-                .endpoint(foundryProjectEndpoint)
+                .endpoint(ProjectEndpoint)
                 .buildAgentsClient();
 
         // Create an agent with a model and instructions
         PromptAgentDefinition request = new PromptAgentDefinition("gpt-5-mini") // supports all Foundry direct models
                 .setInstructions("You are a helpful assistant that answers general questions");
-        AgentVersionDetails agent = agentsClient.createAgentVersion(foundryAgentName, request);
+        AgentVersionDetails agent = agentsClient.createAgentVersion(AgentName, request);
 
         System.out.println("Agent ID: " + agent.getId());
         System.out.println("Agent Name: " + agent.getName());

--- a/samples/java/quickstart/responses/src/main/java/com/azure/ai/agents/CreateResponse.java
+++ b/samples/java/quickstart/responses/src/main/java/com/azure/ai/agents/CreateResponse.java
@@ -7,19 +7,18 @@ import com.openai.models.responses.ResponseCreateParams;
 public class CreateResponse {
     public static void main(String[] args) {
         // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-        String foundryProjectEndpoint = "your_project_endpoint";
-        String foundryModelName = "gpt-5-mini";  // supports all Foundry direct models
+        String ProjectEndpoint = "your_project_endpoint";
 
         // Create responses client to call Foundry API
         ResponsesClient responsesClient = new AgentsClientBuilder()
                 .credential(new DefaultAzureCredentialBuilder().build())
-                .endpoint(foundryProjectEndpoint)
+                .endpoint(ProjectEndpoint)
                 .buildResponsesClient();
 
         // Run a responses API call
         ResponseCreateParams responseRequest = new ResponseCreateParams.Builder()
                 .input("What is the size of France in square miles?")
-                .model(foundryModelName)
+                .model("gpt-5-mini")  // supports all Foundry direct models
                 .build();
         Response response = responsesClient.getResponseService().create(responseRequest);
         System.out.println(response.output());

--- a/samples/python/quickstart/chat-with-agent/quickstart-chat-with-agent.py
+++ b/samples/python/quickstart/chat-with-agent/quickstart-chat-with-agent.py
@@ -2,8 +2,8 @@ from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
 
 # Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint"
-FOUNDRY_AGENT_NAME = "your_agent_name"
+PROJECT_ENDPOINT = "your_project_endpoint"
+AGENT_NAME = "your_agent_name"
 
 # Create project and openai clients to call Foundry API
 project = AIProjectClient(

--- a/samples/python/quickstart/create-agent/quickstart-create-agent.py
+++ b/samples/python/quickstart/create-agent/quickstart-create-agent.py
@@ -3,21 +3,20 @@ from azure.ai.projects import AIProjectClient
 from azure.ai.projects.models import PromptAgentDefinition
 
 # Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint"
-FOUNDRY_MODEL_NAME = "gpt-5-mini"  # supports all Foundry direct models
-FOUNDRY_AGENT_NAME = "your_agent_name"
+PROJECT_ENDPOINT = "your_project_endpoint"
+AGENT_NAME = "your_agent_name"
 
 # Create project client to call Foundry API
 project = AIProjectClient(
-    endpoint=FOUNDRY_PROJECT_ENDPOINT,
+    endpoint=PROJECT_ENDPOINT,
     credential=DefaultAzureCredential(),
 )
 
 # Create an agent with a model and instructions
 agent = project.agents.create_version(
-    agent_name=FOUNDRY_AGENT_NAME,
+    agent_name=AGENT_NAME,
     definition=PromptAgentDefinition(
-        model=FOUNDRY_MODEL_NAME,
+        model="gpt-5-mini",  # supports all Foundry direct models"
         instructions="You are a helpful assistant that answers general questions",
     ),
 )

--- a/samples/python/quickstart/responses/quickstart-responses.py
+++ b/samples/python/quickstart/responses/quickstart-responses.py
@@ -2,19 +2,18 @@ from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
 
 # Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint"
-FOUNDRY_MODEL_NAME = "gpt-5-mini"  # supports all Foundry direct models
+PROJECT_ENDPOINT = "your_project_endpoint"
 
 # Create project and openai clients to call Foundry API
 project = AIProjectClient(
-    endpoint=FOUNDRY_PROJECT_ENDPOINT,
+    endpoint=PROJECT_ENDPOINT,
     credential=DefaultAzureCredential(),
 )
 openai = project.get_openai_client()
 
 # Run a responses API call
 response = openai.responses.create(
-    model=FOUNDRY_MODEL_NAME,
+    model="gpt-5-mini",  # supports all Foundry direct models
     input="What is the size of France in square miles?",
 )
 print(f"Response output: {response.output_text}")

--- a/samples/typescript/quickstart/chat-with-agent/src/quickstart-chat-with-agent.ts
+++ b/samples/typescript/quickstart/chat-with-agent/src/quickstart-chat-with-agent.ts
@@ -2,12 +2,12 @@ import { DefaultAzureCredential } from "@azure/identity";
 import { AIProjectClient } from "@azure/ai-projects";
 
 // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-const FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint";
-const FOUNDRY_AGENT_NAME = "your_agent_name";
+const PROJECT_ENDPOINT = "your_project_endpoint";
+const AGENT_NAME = "your_agent_name";
 
 async function main(): Promise<void> {
     // Create project and openai clients to call Foundry API
-    const project = new AIProjectClient(FOUNDRY_PROJECT_ENDPOINT, new DefaultAzureCredential());
+    const project = new AIProjectClient(PROJECT_ENDPOINT, new DefaultAzureCredential());
     const openai = await project.getOpenAIClient();
 
     // Create a conversation for multi-turn chat
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
             input: "What is the size of France in square miles?",
         },
         {
-            body: { agent: { name: FOUNDRY_AGENT_NAME, type: "agent_reference" } },
+            body: { agent: { name: AGENT_NAME, type: "agent_reference" } },
         },
     );
     console.log(response.output_text);

--- a/samples/typescript/quickstart/create-agent/src/quickstart-create-agent.ts
+++ b/samples/typescript/quickstart/create-agent/src/quickstart-create-agent.ts
@@ -2,15 +2,15 @@ import { DefaultAzureCredential } from "@azure/identity";
 import { AIProjectClient } from "@azure/ai-projects";
 
 // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-const FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint";
-const FOUNDRY_AGENT_NAME = "your_agent_name";
+const PROJECT_ENDPOINT = "your_project_endpoint";
+const AGENT_NAME = "your_agent_name";
 
 async function main(): Promise<void> {
     // Create project client to call Foundry API
-    const project = new AIProjectClient(FOUNDRY_PROJECT_ENDPOINT, new DefaultAzureCredential());
+    const project = new AIProjectClient(PROJECT_ENDPOINT, new DefaultAzureCredential());
 
     // Create an agent with a model and instructions
-    const agent = await project.agents.createVersion(FOUNDRY_AGENT_NAME, {
+    const agent = await project.agents.createVersion(AGENT_NAME, {
         kind: "prompt",
         model: "gpt-5-mini", //supports all Foundry direct models
         instructions: "You are a helpful assistant that answers general questions",

--- a/samples/typescript/quickstart/create-agent/src/quickstart-create-agent.ts
+++ b/samples/typescript/quickstart/create-agent/src/quickstart-create-agent.ts
@@ -3,7 +3,6 @@ import { AIProjectClient } from "@azure/ai-projects";
 
 // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
 const FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint";
-const FOUNDRY_MODEL_NAME = "gpt-5-mini"; 
 const FOUNDRY_AGENT_NAME = "your_agent_name";
 
 async function main(): Promise<void> {
@@ -13,7 +12,7 @@ async function main(): Promise<void> {
     // Create an agent with a model and instructions
     const agent = await project.agents.createVersion(FOUNDRY_AGENT_NAME, {
         kind: "prompt",
-        model: FOUNDRY_MODEL_NAME,
+        model: "gpt-5-mini", //supports all Foundry direct models
         instructions: "You are a helpful assistant that answers general questions",
     });
     console.log(`Agent created (id: ${agent.id}, name: ${agent.name}, version: ${agent.version})`);

--- a/samples/typescript/quickstart/responses/src/quickstart-responses.ts
+++ b/samples/typescript/quickstart/responses/src/quickstart-responses.ts
@@ -2,17 +2,16 @@ import { DefaultAzureCredential } from "@azure/identity";
 import { AIProjectClient } from "@azure/ai-projects";
 
 // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-const FOUNDRY_PROJECT_ENDPOINT = "your_project_endpoint";
-const FOUNDRY_MODEL_NAME = "gpt-5-mini";  // supports all Foundry direct models
+const PROJECT_ENDPOINT = "your_project_endpoint";
 
 async function main(): Promise<void> {
     // Create project and openai clients to call Foundry API
-    const project = new AIProjectClient(FOUNDRY_PROJECT_ENDPOINT, new DefaultAzureCredential());
+    const project = new AIProjectClient(PROJECT_ENDPOINT, new DefaultAzureCredential());
     const openai = await project.getOpenAIClient();
 
     // Run a responses API call
     const response = await openai.responses.create({
-        model: FOUNDRY_MODEL_NAME,
+        model: "gpt-5-mini", // supports all Foundry direct models
         input: "What is the size of France in square miles?",
     });
     console.log(`Response output: ${response.output_text}`);


### PR DESCRIPTION
## Syncing remaining changes from foundry-samples-pr#62

PR #579 missed 3 commits that were on the fork side of a merge in the original PR. This brings over the remaining changes:

- **linting** — C#, Java, TypeScript quickstart fixes
- **Update .gitignore** — Remove unnecessary entries
- **removing prefix** — Cleanup across all 12 quickstart sample files (Python, C#, Java, TypeScript)

Source: [foundry-samples-pr#62](https://github.com/microsoft-foundry/foundry-samples-pr/pull/62) by @aahill

Original commits cherry-picked with author attribution preserved.