### PR TITLE
fix: use cascading org checks for PR redirect workflow

### DIFF
--- a/.github/workflows/redirect-pull-requests.yml
+++ b/.github/workflows/redirect-pull-requests.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write
+  members: read
 
 jobs:
   redirect:
@@ -25,21 +26,64 @@ jobs:
               return;
             }
 
-            // Check if author is a member of the microsoft org
-            let isOrgMember = false;
+            // Check if author is a Microsoft contributor using multiple signals.
+            // The GITHUB_TOKEN can only see *public* members of the 'microsoft' org
+            // (since this repo is in the 'microsoft-foundry' org), so we cascade
+            // through several checks to catch contributors with private membership.
+            let isInternal = false;
+            let matchedSignal = null;
+
+            // Signal 1: Check microsoft-foundry org membership (full visibility via GITHUB_TOKEN)
             try {
               const res = await github.rest.orgs.checkMembershipForUser({
-                org: 'microsoft',
+                org: 'microsoft-foundry',
                 username: author,
               });
-              isOrgMember = res.status === 204;
+              if (res.status === 204) {
+                isInternal = true;
+                matchedSignal = 'microsoft-foundry org member';
+              }
             } catch {
               // 404 or 302 means not a member
-              isOrgMember = false;
             }
 
+            // Signal 2: Check if author is a collaborator on this repo
+            if (!isInternal) {
+              try {
+                const res = await github.rest.repos.checkCollaborator({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: author,
+                });
+                if (res.status === 204) {
+                  isInternal = true;
+                  matchedSignal = 'repo collaborator';
+                }
+              } catch {
+                // 404 means not a collaborator
+              }
+            }
+
+            // Signal 3: Check microsoft org membership (catches public members only)
+            if (!isInternal) {
+              try {
+                const res = await github.rest.orgs.checkMembershipForUser({
+                  org: 'microsoft',
+                  username: author,
+                });
+                if (res.status === 204) {
+                  isInternal = true;
+                  matchedSignal = 'microsoft org member (public)';
+                }
+              } catch {
+                // 404 or 302 means not a member (or private membership not visible)
+              }
+            }
+
+            console.log(`Author: ${author}, isInternal: ${isInternal}, signal: ${matchedSignal || 'none'}`);
+
             let body;
-            if (isOrgMember) {
+            if (isInternal) {
               body = [
                 `👋 Thanks for your contribution, @${author}!`,
                 '',


### PR DESCRIPTION
## Problem
The redirect workflow uses `orgs.checkMembershipForUser` against the `microsoft` org, but the `GITHUB_TOKEN` (scoped to `microsoft-foundry`) can only see **public** members. Contributors with private `microsoft` org membership (e.g., [#574](https://github.com/microsoft-foundry/foundry-samples/pull/574)) are incorrectly treated as external.

## Fix
Replace the single org check with a cascading multi-signal approach:

1. **`microsoft-foundry` org membership** — full visibility via GITHUB_TOKEN
2. **Repo collaborator status** — catches invited collaborators
3. **`microsoft` org membership** — catches public members as fallback

Any positive signal → internal contributor.

Also adds `members: read` permission (for the collaborator check) and debug logging that shows which signal matched in the workflow run logs.

## Testing
- `brandom-msft` (microsoft-foundry member) → should match Signal 1 ✅
- `aahill` (microsoft member, likely not in microsoft-foundry) → should match Signal 2 or 3
- External contributors → no signal matches → external message
- `foundry-samples-repo-sync[bot]` → skipped by bot allowlist