### PR TITLE
fix: remove invalid permission breaking redirect workflow

### DIFF
--- a/.github/workflows/redirect-pull-requests.yml
+++ b/.github/workflows/redirect-pull-requests.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   pull-requests: write
-  members: read
 
 jobs:
   redirect:


### PR DESCRIPTION
## Problem
PR #586 added `members: read` to the workflow permissions block, but this is **not a valid GitHub Actions permission key**. This causes the workflow YAML to fail validation, completely breaking the redirect automation. PRs #587 and #588 were not auto-closed as a result.

## Fix
Remove the invalid `members: read` permission. The `repos.checkCollaborator` API (Signal 2 in the cascading check) works with the default `GITHUB_TOKEN` repo access — no extra permission key is needed.

**This is urgent — merge ASAP to restore PR redirect automation.**