### PR TITLE
Add APIM Developer SKU deployment with VNet injection and peering

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup-preview/README.md
+++ b/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup-preview/README.md
@@ -188,6 +188,101 @@ Click the deploy to Azure button above to open the Azure portal and deploy the t
 
 ---
 
+## Deploy APIM with VNet Injection (Optional)
+
+If you need to create a new Azure API Management (APIM) instance with VNet injection and integrate it with your agent environment, use the `deploy-apim.bicep` template provided in this folder. This template creates:
+
+- A **separate VNet** (`10.0.0.0/16` by default) for APIM
+- An **NSG** with required APIM management rules
+- An **APIM Developer SKU** instance with **internal VNet injection**
+- **Bidirectional VNet peering** between the APIM VNet and the Agent VNet
+
+### APIM Template Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `location` | Azure region for all resources | Resource group location |
+| `apimName` | Name prefix for the APIM instance | `apim-agent` |
+| `publisherEmail` | Publisher email (required by APIM) | `admin@contoso.com` |
+| `publisherName` | Publisher organization name | `Contoso` |
+| `apimVnetName` | Name of the APIM VNet | `apim-vnet` |
+| `apimVnetAddressPrefix` | Address space for the APIM VNet | `10.0.0.0/16` |
+| `apimSubnetName` | Name of the APIM subnet | `apim-subnet` |
+| `apimSubnetAddressPrefix` | Address prefix for the APIM subnet | `10.0.0.0/24` |
+| `agentVnetResourceGroup` | Resource group of the existing Agent VNet | Same as deployment RG |
+| `agentVnetName` | Name of the existing Agent VNet to peer with | `agent-vnet-test` |
+
+### APIM Deployment Steps
+
+> **Note:** The Agent environment (main.bicep) must be deployed first before deploying APIM, as the APIM template peers with the existing Agent VNet.
+
+> **Note:** APIM Developer SKU with VNet injection typically takes **30-45 minutes** to provision.
+
+**Step 1: Deploy the APIM template**
+
+```bash
+az deployment group create \
+  --resource-group <your-resource-group> \
+  --template-file deploy-apim.bicep \
+  --parameters location=<your-region> \
+               agentVnetResourceGroup=<agent-vnet-resource-group> \
+               agentVnetName=<agent-vnet-name> \
+               publisherEmail=<your-email> \
+               publisherName=<your-org-name>
+```
+
+**Step 2: Retrieve the APIM Resource ID**
+
+After the APIM deployment completes, retrieve the APIM resource ID from the deployment outputs:
+
+```bash
+az deployment group show \
+  --resource-group <your-resource-group> \
+  --name deploy-apim \
+  --query "properties.outputs.apimResourceId.value" -o tsv
+```
+
+**Step 3: Redeploy the main template with the APIM Resource ID**
+
+Update the `main.bicepparam` file to include the APIM resource ID:
+
+```
+param apiManagementResourceId = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/{apimServiceName}'
+```
+
+Then redeploy:
+
+```bash
+az deployment group create \
+  --resource-group <your-resource-group> \
+  --template-file main.bicep \
+  --parameters main.bicepparam
+```
+
+This will create a private endpoint for APIM in the Agent VNet's private endpoint subnet and configure the necessary DNS zones.
+
+### APIM Module Structure
+
+```text
+deploy-apim.bicep                                      # Main APIM deployment template
+modules-network-secured/
+└── agent-to-apim-peering.bicep                        # VNet peering from Agent VNet to APIM VNet
+```
+
+### Network Architecture with APIM
+
+When APIM is deployed, the network topology includes:
+
+- **Agent VNet** (`192.168.0.0/16`): Contains the agent subnet and private endpoint subnet
+- **APIM VNet** (`10.0.0.0/16`): Contains the APIM subnet with VNet injection
+- **Bidirectional VNet Peering**: Enables connectivity between the two VNets
+- **Private Endpoint**: Created in the Agent VNet's PE subnet for APIM Gateway access
+- **Private DNS Zone**: `privatelink.azure-api.net` for APIM name resolution
+
+> **Important:** Ensure that the APIM VNet address space (`10.0.0.0/16` by default) does not overlap with the Agent VNet address space (`192.168.0.0/16` by default) or any other networks in your environment.
+
+---
+
 ## Network Secured Agent Project Architecture Deep Dive
 
 ### Core Components

--- a/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup-preview/deploy-apim.bicep
+++ b/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup-preview/deploy-apim.bicep
@@ -1,0 +1,220 @@
+/*
+  Deploy APIM Developer SKU with VNet Injection in a separate VNet
+  and peer it to the existing Agent VNet.
+*/
+
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+@description('Name for the APIM instance')
+param apimName string = 'apim-agent'
+
+@description('Publisher email for APIM (required)')
+param publisherEmail string = 'admin@contoso.com'
+
+@description('Publisher name for APIM (required)')
+param publisherName string = 'Contoso'
+
+@description('Name of the APIM VNet')
+param apimVnetName string = 'apim-vnet'
+
+@description('Address prefix for the APIM VNet')
+param apimVnetAddressPrefix string = '10.0.0.0/16'
+
+@description('Name of the APIM subnet')
+param apimSubnetName string = 'apim-subnet'
+
+@description('Address prefix for the APIM subnet')
+param apimSubnetAddressPrefix string = '10.0.0.0/24'
+
+@description('Resource group containing the existing Agent VNet')
+param agentVnetResourceGroup string = resourceGroup().name
+
+@description('Name of the existing Agent VNet to peer with')
+param agentVnetName string = 'agent-vnet-test'
+
+// Unique suffix
+var uniqueSuffix = substring(uniqueString(resourceGroup().id), 0, 4)
+var apimServiceName = toLower('${apimName}-${uniqueSuffix}')
+
+// NSG for APIM subnet - required for VNet injection
+resource apimNsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+  name: '${apimVnetName}-apim-nsg'
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowAPIMManagement'
+        properties: {
+          priority: 100
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '3443'
+          sourceAddressPrefix: 'ApiManagement'
+          destinationAddressPrefix: 'VirtualNetwork'
+        }
+      }
+      {
+        name: 'AllowAzureLoadBalancer'
+        properties: {
+          priority: 110
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '6390'
+          sourceAddressPrefix: 'AzureLoadBalancer'
+          destinationAddressPrefix: 'VirtualNetwork'
+        }
+      }
+      {
+        name: 'AllowHTTPS'
+        properties: {
+          priority: 120
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'VirtualNetwork'
+        }
+      }
+      {
+        name: 'AllowStorageOutbound'
+        properties: {
+          priority: 100
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'Storage'
+        }
+      }
+      {
+        name: 'AllowAADOutbound'
+        properties: {
+          priority: 110
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'AzureActiveDirectory'
+        }
+      }
+      {
+        name: 'AllowSQLOutbound'
+        properties: {
+          priority: 120
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '1433'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'Sql'
+        }
+      }
+      {
+        name: 'AllowAzureMonitorOutbound'
+        properties: {
+          priority: 130
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRanges: ['443', '1886', '12000']
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'AzureMonitor'
+        }
+      }
+    ]
+  }
+}
+
+// APIM VNet
+resource apimVnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+  name: apimVnetName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [apimVnetAddressPrefix]
+    }
+    subnets: [
+      {
+        name: apimSubnetName
+        properties: {
+          addressPrefix: apimSubnetAddressPrefix
+          networkSecurityGroup: {
+            id: apimNsg.id
+          }
+        }
+      }
+    ]
+  }
+}
+
+// Reference existing Agent VNet
+resource agentVnet 'Microsoft.Network/virtualNetworks@2024-05-01' existing = {
+  name: agentVnetName
+  scope: resourceGroup(agentVnetResourceGroup)
+}
+
+// Peering: APIM VNet -> Agent VNet
+resource apimToAgentPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-05-01' = {
+  parent: apimVnet
+  name: 'apim-to-agent-peering'
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: true
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: agentVnet.id
+    }
+  }
+}
+
+// Peering: Agent VNet -> APIM VNet
+module agentToApimPeering 'modules-network-secured/agent-to-apim-peering.bicep' = {
+  name: 'agent-to-apim-peering-deployment'
+  scope: resourceGroup(agentVnetResourceGroup)
+  params: {
+    agentVnetName: agentVnetName
+    apimVnetId: apimVnet.id
+  }
+}
+
+// APIM Developer SKU with VNet injection (internal mode)
+resource apimService 'Microsoft.ApiManagement/service@2023-05-01-preview' = {
+  name: apimServiceName
+  location: location
+  sku: {
+    name: 'Developer'
+    capacity: 1
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    publisherEmail: publisherEmail
+    publisherName: publisherName
+    virtualNetworkType: 'Internal'
+    virtualNetworkConfiguration: {
+      subnetResourceId: apimVnet.properties.subnets[0].id
+    }
+  }
+  dependsOn: [
+    apimToAgentPeering
+    agentToApimPeering
+  ]
+}
+
+output apimResourceId string = apimService.id
+output apimName string = apimService.name

--- a/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup-preview/modules-network-secured/agent-to-apim-peering.bicep
+++ b/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup-preview/modules-network-secured/agent-to-apim-peering.bicep
@@ -1,0 +1,28 @@
+/*
+  Module to create VNet peering from Agent VNet to APIM VNet.
+  Deployed as a separate module to support cross-resource-group scope.
+*/
+
+@description('Name of the existing Agent VNet')
+param agentVnetName string
+
+@description('Resource ID of the APIM VNet to peer with')
+param apimVnetId string
+
+resource agentVnet 'Microsoft.Network/virtualNetworks@2024-05-01' existing = {
+  name: agentVnetName
+}
+
+resource agentToApimPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-05-01' = {
+  parent: agentVnet
+  name: 'agent-to-apim-peering'
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: true
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: apimVnetId
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new Bicep template (deploy-apim.bicep) for deploying Azure API Management (Developer SKU) with internal VNet injection in a separate VNet, with bidirectional peering to the existing Agent VNet.

Closes #606

## Changes

- **deploy-apim.bicep** - New template that creates:
  - A separate VNet (10.0.0.0/16) with NSG for APIM
  - APIM Developer SKU with internal VNet injection
  - Bidirectional VNet peering between APIM VNet and Agent VNet
- **modules-network-secured/agent-to-apim-peering.bicep** - New module for cross-scope VNet peering from Agent VNet to APIM VNet
- **README.md** - Added Deploy APIM with VNet Injection section with parameter table, deployment guide, and architecture docs

## How to use

1. Deploy the agent environment first using main.bicep
2. Deploy APIM using deploy-apim.bicep
3. Retrieve the APIM resource ID from deployment outputs
4. Redeploy main.bicep with the apiManagementResourceId parameter set
