### PR TITLE
Use template location when creating private endpoints instead of resource group location

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/main.bicep
@@ -272,6 +272,7 @@ module privateEndpointAndDNS 'modules-network-secured/private-endpoint-and-dns.b
       storageAccountSubscriptionId: azureStorageSubscriptionId // Subscription ID for Storage Account
       existingDnsZones: existingDnsZones
       dnsZonesSubscriptionId: resolvedDnsZonesSubscriptionId
+      location: location
     }
     dependsOn: [
     aiSearch      // Ensure AI Search exists

--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/modules-network-secured/private-endpoint-and-dns.bicep
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/modules-network-secured/private-endpoint-and-dns.bicep
@@ -75,6 +75,9 @@ param existingDnsZones object = {
 @description('Subscription ID where existing private DNS zones are located. Should be resolved to current subscription if empty.')
 param dnsZonesSubscriptionId string
 
+@description('Location where resources will be deployed')
+param location string = resourceGroup().location
+
 // ---- Resource references ----
 resource aiAccount 'Microsoft.CognitiveServices/accounts@2023-05-01' existing = {
   name: aiAccountName
@@ -113,7 +116,7 @@ resource peSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' existin
 // - Establishes private connection to AI Services account
 resource aiAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
   name: '${aiAccountName}-private-endpoint'
-  location: resourceGroup().location
+  location: location
   properties: {
     subnet: { id: peSubnet.id } // Deploy in customer hub subnet
     privateLinkServiceConnections: [
@@ -135,7 +138,7 @@ resource aiAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01
 // - Establishes private connection to AI Search service
 resource aiSearchPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
   name: '${aiSearchName}-private-endpoint'
-  location: resourceGroup().location
+  location: location
   properties: {
     subnet: { id: peSubnet.id } // Deploy in customer hub subnet
     privateLinkServiceConnections: [
@@ -157,7 +160,7 @@ resource aiSearchPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01'
 // - Establishes private connection to blob storage
 resource storagePrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
   name: '${storageName}-private-endpoint'
-  location: resourceGroup().location
+  location: location
   properties: {
     subnet: { id: peSubnet.id } // Deploy in customer hub subnet
     privateLinkServiceConnections: [
@@ -176,7 +179,7 @@ resource storagePrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' 
 
 resource cosmosDBPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
   name: '${cosmosDBName}-private-endpoint'
-  location: resourceGroup().location
+  location: location
   properties: {
     subnet: { id: peSubnet.id } // Deploy in customer hub subnet
     privateLinkServiceConnections: [


### PR DESCRIPTION
Resolves https://github.com/microsoft-foundry/foundry-samples/issues/657.

I'm creating a PR with the fix because I read the contributing doc, but am unable to join the staging repo with a personal Microsoft account (can't log in), and my Github account associated with my enterprise Microsoft account does not allow for collaboration on outside repos.

Hopefully the fix makes sense to merge in or have someone else fix in the staging repo.

Thanks!