### PR TITLE
Fix snippet tag to exclude return statement from code excerpt

### DIFF
--- a/samples/python/enterprise-agent-tutorial/1-idea-to-prototype/main.py
+++ b/samples/python/enterprise-agent-tutorial/1-idea-to-prototype/main.py
@@ -179,8 +179,8 @@ CAPABILITIES:
     )
 
     print(f"✅ Agent created successfully (name: {agent.name}, version: {agent.version})")
-    return agent
     # </create_agent_with_tools>
+    return agent
 
 
 def demonstrate_business_scenarios(agent, openai_client):


### PR DESCRIPTION
## Fix: Snippet tag excludes `return` outside function body

### Problem
The `create_agent_with_tools` snippet tag in `main.py` includes the `return agent` line. When rendered as a documentation code excerpt on Microsoft Learn, this `return` statement appears outside any function definition, triggering a code validation error:

> 'return' outside function. In Python, return statements must be inside a function or method body.

**Source issue**: OPS-E2E-PPE/azure-ai-docs-pr#4968

### Fix
Move the closing `# </create_agent_with_tools>` tag to **before** the `return agent` line. The `return` statement is part of the enclosing function but adds no educational value to the snippet; removing it from the excerpt makes the snippet syntactically self-contained.

### Affected article
- [Tutorial: Idea to prototype - Build and evaluate an enterprise agent](https://learn.microsoft.com/en-us/azure/foundry/tutorials/developer-journey-idea-to-prototype)
