### PR TITLE
update Docs/cosmosdb connection requirements

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/README.md
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/README.md
@@ -136,6 +136,25 @@ To use an existing VNet and subnets, set the existingVnetResourceId parameter to
 To use an existing Cosmos DB for NoSQL resource, set cosmosDBResourceId parameter to the full Azure Resource ID of the target Cosmos DB.
 - param azureCosmosDBAccountResourceId string =  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}
 
+> **⚠️ Important: Cosmos DB Connection Requirements**
+>
+> When creating the Cosmos DB connection (e.g., via REST API or ARM), ensure the following:
+> - The `authType` **must** be set to `AAD`. This is the only supported authentication type for the Cosmos DB connection used by the Agent Service.
+> - The `metadata` section **must** include the `ResourceId` property, set to the full Azure Resource ID of your Cosmos DB account. The Agent Service relies on this property to correctly identify and connect to your Cosmos DB resource. Omitting `ResourceId` from the metadata will cause the connection to fail.
+>
+> Example connection properties:
+> ```json
+> {
+>   "category": "CosmosDB",
+>   "authType": "AAD",
+>   "metadata": {
+>     "ApiType": "Azure",
+>     "ResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}",
+>     "location": "{region}"
+>   }
+> }
+> ```
+
 
 3. **Use an existing Azure AI Search resource**
 

--- a/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup-preview/README.md
+++ b/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup-preview/README.md
@@ -143,6 +143,25 @@ To use an existing VNet and subnets, set the existingVnetResourceId parameter to
 To use an existing Cosmos DB for NoSQL resource, set cosmosDBResourceId parameter to the full Azure Resource ID of the target Cosmos DB.
 - param azureCosmosDBAccountResourceId string =  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}
 
+> **⚠️ Important: Cosmos DB Connection Requirements**
+>
+> When creating the Cosmos DB connection (e.g., via REST API or ARM), ensure the following:
+> - The `authType` **must** be set to `AAD`. This is the only supported authentication type for the Cosmos DB connection used by the Agent Service.
+> - The `metadata` section **must** include the `ResourceId` property, set to the full Azure Resource ID of your Cosmos DB account. The Agent Service relies on this property to correctly identify and connect to your Cosmos DB resource. Omitting `ResourceId` from the metadata will cause the connection to fail.
+>
+> Example connection properties:
+> ```json
+> {
+>   "category": "CosmosDB",
+>   "authType": "AAD",
+>   "metadata": {
+>     "ApiType": "Azure",
+>     "ResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}",
+>     "location": "{region}"
+>   }
+> }
+> ```
+
 
 3. **Use an existing Azure AI Search resource**
 

--- a/infrastructure/infrastructure-setup-bicep/17-private-network-standard-user-assigned-identity-agent-setup/README.md
+++ b/infrastructure/infrastructure-setup-bicep/17-private-network-standard-user-assigned-identity-agent-setup/README.md
@@ -138,6 +138,25 @@ To use an existing VNet and subnets, set the existingVnetResourceId parameter to
 To use an existing Cosmos DB for NoSQL resource, set cosmosDBResourceId parameter to the full Azure Resource ID of the target Cosmos DB.
 - param azureCosmosDBAccountResourceId string =  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}
 
+> **⚠️ Important: Cosmos DB Connection Requirements**
+>
+> When creating the Cosmos DB connection (e.g., via REST API or ARM), ensure the following:
+> - The `authType` **must** be set to `AAD`. This is the only supported authentication type for the Cosmos DB connection used by the Agent Service.
+> - The `metadata` section **must** include the `ResourceId` property, set to the full Azure Resource ID of your Cosmos DB account. The Agent Service relies on this property to correctly identify and connect to your Cosmos DB resource. Omitting `ResourceId` from the metadata will cause the connection to fail.
+>
+> Example connection properties:
+> ```json
+> {
+>   "category": "CosmosDB",
+>   "authType": "AAD",
+>   "metadata": {
+>     "ApiType": "Azure",
+>     "ResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}",
+>     "location": "{region}"
+>   }
+> }
+> ```
+
 
 3. **Use an existing Azure AI Search resource**
 

--- a/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network-preview/README.md
+++ b/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network-preview/README.md
@@ -103,6 +103,25 @@ To use an existing VNet and subnet, set the existingVnetResourceId parameter to 
 To use an existing Cosmos DB for NoSQL resource, set cosmosDBResourceId parameter to the full Azure Resource ID of the target Cosmos DB.
 - param azureCosmosDBAccountResourceId string =  /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}
 
+> **⚠️ Important: Cosmos DB Connection Requirements**
+>
+> When creating the Cosmos DB connection (e.g., via REST API or ARM), ensure the following:
+> - The `authType` **must** be set to `AAD`. This is the only supported authentication type for the Cosmos DB connection used by the Agent Service.
+> - The `metadata` section **must** include the `ResourceId` property, set to the full Azure Resource ID of your Cosmos DB account. The Agent Service relies on this property to correctly identify and connect to your Cosmos DB resource. Omitting `ResourceId` from the metadata will cause the connection to fail.
+>
+> Example connection properties:
+> ```json
+> {
+>   "category": "CosmosDB",
+>   "authType": "AAD",
+>   "metadata": {
+>     "ApiType": "Azure",
+>     "ResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}",
+>     "location": "{region}"
+>   }
+> }
+> ```
+
 
 3. **Use an existing Azure AI Search resource**
 

--- a/infrastructure/infrastructure-setup-bicep/19-hybrid-private-resources-agent-setup/README.md
+++ b/infrastructure/infrastructure-setup-bicep/19-hybrid-private-resources-agent-setup/README.md
@@ -178,6 +178,25 @@ Then configure private DNS zone for Container Apps (see TESTING-GUIDE.md Step 6.
 
 ## Parameters
 
+> **⚠️ Important: Cosmos DB Connection Requirements**
+>
+> If you are creating the Cosmos DB connection manually (e.g., via REST API or ARM), ensure the following:
+> - The `authType` **must** be set to `AAD`. This is the only supported authentication type for the Cosmos DB connection used by the Agent Service.
+> - The `metadata` section **must** include the `ResourceId` property, set to the full Azure Resource ID of your Cosmos DB account. The Agent Service relies on this property to correctly identify and connect to your Cosmos DB resource. Omitting `ResourceId` from the metadata will cause the connection to fail.
+>
+> Example connection properties:
+> ```json
+> {
+>   "category": "CosmosDB",
+>   "authType": "AAD",
+>   "metadata": {
+>     "ApiType": "Azure",
+>     "ResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}",
+>     "location": "{region}"
+>   }
+> }
+> ```
+
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `location` | Azure region | `eastus2` |

--- a/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/README.md
+++ b/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/README.md
@@ -30,3 +30,22 @@ For more details on the standard agent setup, see the [standard agent setup conc
 **Azure Cosmos DB for NoSQL**
 - Your existing Azure Cosmos DB for NoSQL Account used in standard setup must have at least a total throughput limit of at least 3000 RU/s. Both Provisioned Thoughtput and Serverless are supported.
     - 3 containers will be provisioned in your existing Cosmos DB account and each need 1000 RU/s
+
+> **⚠️ Important: Cosmos DB Connection Requirements**
+>
+> When creating the Cosmos DB connection (e.g., via REST API or ARM), ensure the following:
+> - The `authType` **must** be set to `AAD`. This is the only supported authentication type for the Cosmos DB connection used by the Agent Service.
+> - The `metadata` section **must** include the `ResourceId` property, set to the full Azure Resource ID of your Cosmos DB account. The Agent Service relies on this property to correctly identify and connect to your Cosmos DB resource. Omitting `ResourceId` from the metadata will cause the connection to fail.
+>
+> Example connection properties:
+> ```json
+> {
+>   "category": "CosmosDB",
+>   "authType": "AAD",
+>   "metadata": {
+>     "ApiType": "Azure",
+>     "ResourceId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.DocumentDB/databaseAccounts/{cosmosDbAccountName}",
+>     "location": "{region}"
+>   }
+> }
+> ```


### PR DESCRIPTION
…D authType

Add important notes to 6 infrastructure setup READMEs clarifying that:
- The authType must be set to AAD (only supported type for CosmosDB)
- The ResourceId property must be included in the connection metadata

This addresses issues where customers creating CosmosDB connections via REST API were omitting the ResourceId property, causing connection failures.

Affected setups:
- 15-private-network-standard-agent-setup
- 16-private-network-standard-agent-apim-setup-preview
- 17-private-network-standard-user-assigned-identity-agent-setup
- 18-managed-virtual-network-preview
- 19-hybrid-private-resources-agent-setup
- 41-standard-agent-setup