### PR TITLE
fix: support consent url in agent framework toolbox sample

### DIFF
--- a/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/main.py
+++ b/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/main.py
@@ -3,7 +3,16 @@
 import os
 
 import httpx
-from agent_framework import Agent, MCPStreamableHTTPTool
+from agent_framework import (
+    Agent,
+    AgentResponse,
+    AgentResponseUpdate,
+    Content,
+    MCPStreamableHTTPTool,
+    Message,
+    ResponseStream,
+    agent_middleware,
+)
 from agent_framework.foundry import FoundryChatClient
 from agent_framework_foundry_hosting import ResponsesHostServer
 from azure.identity import DefaultAzureCredential
@@ -11,6 +20,18 @@ from dotenv import load_dotenv
 
 # Load environment variables from .env file
 load_dotenv()
+
+# Workaround: MCP tool names from Foundry toolbox may contain dots (e.g.
+# "Vercel4.search_vercel_documentation"), but the Responses API rejects dots
+# in input[].name (pattern ^[a-zA-Z0-9_-]+$).  This matters whenever the SDK
+# replays function_call items as input — both within a single agent.run()
+# turn (store=False) and across turns (hosting server sends conversation
+# history).  Replacing dots with underscores in the normaliser avoids the
+# 400 error.
+import agent_framework._mcp as _mcp_module  # noqa: E402
+
+_orig_normalize = _mcp_module._normalize_mcp_name
+_mcp_module._normalize_mcp_name = lambda name: _orig_normalize(name).replace(".", "_")
 
 
 class ToolboxAuth(httpx.Auth):
@@ -21,6 +42,44 @@ class ToolboxAuth(httpx.Auth):
         token = credential.get_token("https://ai.azure.com/.default").token
         request.headers["Authorization"] = f"Bearer {token}"
         yield request
+
+
+def _extract_consent_url(exc: BaseException) -> str | None:
+    """Walk the exception chain for a Foundry MCP consent error (code -32006)."""
+    if hasattr(exc, "error") and getattr(exc.error, "code", None) == -32006:
+        return exc.error.message
+    for chained in (exc.__cause__, exc.__context__):
+        if chained is not None:
+            url = _extract_consent_url(chained)
+            if url:
+                return url
+    return None
+
+
+@agent_middleware
+async def consent_middleware(context, call_next):
+    """Catch MCP consent errors and return the consent URL as a message."""
+    try:
+        await call_next()
+    except Exception as e:
+        consent_url = _extract_consent_url(e)
+        if consent_url:
+            text = (
+                f"OAuth consent is required. Please open the following URL "
+                f"in a browser to authorize access, then try again:\n\n{consent_url}"
+            )
+            msg = Message("assistant", [text])
+            response = AgentResponse(messages=[msg])
+            if context.stream:
+                async def _updates():
+                    yield AgentResponseUpdate(
+                        contents=[Content("text", text=text)], role="assistant"
+                    )
+                context.result = ResponseStream(_updates(), finalizer=lambda _: response)
+            else:
+                context.result = response
+        else:
+            raise
 
 
 def main():
@@ -46,6 +105,7 @@ def main():
         client=client,
         instructions="You are a friendly assistant. Keep your answers brief.",
         tools=[foundry_mcp_tool],
+        middleware=[consent_middleware],
         # History will be managed by the hosting infrastructure, thus there
         # is no need to store history by the service. Learn more at:
         # https://developers.openai.com/api/reference/resources/responses/methods/create


### PR DESCRIPTION
Sync the changes from private sample repo: https://github.com/microsoft/hosted-agents-vnext-private-preview/pull/211

This sample has two issues:

The sample does not handle the toolbox consent URL errors. Because of this, it fails to display the consent URL to users, which causes all OAuth MCP not working.
To fix this issue, the sample code needs to include proper handling for the toolbox consent URL error, similar to how it is done in [this sample](https://github.com/microsoft/hosted-agents-vnext-private-preview/blob/ec8fed012b12af207ccd45f4ab1dcf56928240ff/samples/python/toolbox/maf/main.py#L205).

Tool calls fail due to invalid tool names with dots:
Workaround: MCP tool names from Foundry toolbox may contain dots (e.g. "Vercel4.search_vercel_documentation"), but the Responses API rejects dots in input[].name (pattern ^[a-zA-Z0-9_-]+$). This matters whenever the SDK replays function_call items as input — both within a single agent.run() turn (store=False) and across turns (hosting server sends conversation history). Replacing dots with underscores in the normaliser avoids the 400 error.