### PR TITLE
Fix brand: Azure AI Foundry → Microsoft Foundry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Azure AI Foundry Documentation Samples
+# Microsoft Foundry Documentation Samples
 
-This repository acts as the top-level directory for official Azure AI Foundry documentation sample code and examples. It includes notebooks and sample code that contain end-to-end examples as well as smaller code snippets for common developer tasks.
+This repository acts as the top-level directory for official Microsoft Foundry documentation sample code and examples. It includes notebooks and sample code that contain end-to-end examples as well as smaller code snippets for common developer tasks.
 
 This repository is entirely open source, guidance on how to contribute and links to additional repositories are provided below.
 
-Use the samples in this repository to try out Azure AI Foundry scenarios on your local machine!
+Use the samples in this repository to try out Microsoft Foundry scenarios on your local machine!
 
 ## Contributing
 


### PR DESCRIPTION
Updates the repo-level README.md to use the correct brand name (Microsoft Foundry). The sample-level READMEs will be addressed in a separate scrub.