### PR TITLE
URGENT: Restore public-only files deleted by broken sync run (PR #705)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,49 @@
+# See for instructions on this file https://help.github.com/articles/about-codeowners/
+
+#### Team-owned sample areas ############################################################################
+# Each contributing team owns their sample paths for review routing. See CONTRIBUTING.md for setup guide.
+/samples/python/hosted-agents/ @microsoft-foundry/hosted-agents
+/samples/csharp/hosted-agents/ @microsoft-foundry/hosted-agents
+
+#### files referenced in docs (DO NOT EDIT, except for Docs team!!!) ##########################################
+/infrastructure/infrastructure-setup-bicep/01-connections/connection-key-vault.bicep @microsoft-foundry/AI-Platform-Docs
+/infrastructure/infrastructure-setup-bicep/05-custom-policy-definitions/deny-disallowed-connections.json @microsoft-foundry/AI-Platform-Docs
+/infrastructure/infrastructure-setup-terraform/00-basic-azurerm/code/main.tf @microsoft-foundry/AI-Platform-Docs
+/infrastructure/infrastructure-setup-terraform/00-basic-azurerm/code/providers.tf @microsoft-foundry/AI-Platform-Docs
+/infrastructure/infrastructure-setup-terraform/00-basic-azurerm/code/variables.tf @microsoft-foundry/AI-Platform-Docs
+/infrastructure/infrastructure-setup-terraform/00-basic/code/main.tf @microsoft-foundry/AI-Platform-Docs
+/infrastructure/infrastructure-setup-terraform/00-basic/code/providers.tf @microsoft-foundry/AI-Platform-Docs
+/infrastructure/infrastructure-setup-terraform/00-basic/code/variables.tf @microsoft-foundry/AI-Platform-Docs
+/samples-classic/REST/quickstart/quickstart.sh @microsoft-foundry/AI-Platform-Docs
+/samples-classic/csharp/quickstart/Samples/.env.example @microsoft-foundry/AI-Platform-Docs
+/samples-classic/csharp/quickstart/Samples/AgentFileSearch.cs @microsoft-foundry/AI-Platform-Docs
+/samples-classic/csharp/quickstart/Samples/AgentService.cs @microsoft-foundry/AI-Platform-Docs
+/samples-classic/csharp/quickstart/Samples/SimpleInference.cs @microsoft-foundry/AI-Platform-Docs
+/samples-classic/java/quickstart/src/main/java/com/azure/ai/foundry/samples/AgentSample.java @microsoft-foundry/AI-Platform-Docs
+/samples-classic/java/quickstart/src/main/java/com/azure/ai/foundry/samples/ChatCompletionSample.java @microsoft-foundry/AI-Platform-Docs
+/samples-classic/java/quickstart/src/main/java/com/azure/ai/foundry/samples/FileSearchAgentSample.java @microsoft-foundry/AI-Platform-Docs
+/samples-classic/python/quickstart/create_project.py @microsoft-foundry/AI-Platform-Docs
+/samples-classic/python/quickstart/quickstart.py @microsoft-foundry/AI-Platform-Docs
+/samples-classic/typescript/quickstart/.env.template @microsoft-foundry/AI-Platform-Docs
+/samples-classic/typescript/quickstart/src/quickstart.ts @microsoft-foundry/AI-Platform-Docs
+/samples/REST/quickstart/quickstart-chat-with-agent.sh @microsoft-foundry/AI-Platform-Docs
+/samples/REST/quickstart/quickstart-create-agent.sh @microsoft-foundry/AI-Platform-Docs
+/samples/REST/quickstart/quickstart-responses.sh @microsoft-foundry/AI-Platform-Docs
+/samples/csharp/enterprise-agent-tutorial/1-idea-to-prototype/Evaluate/Program.cs @microsoft-foundry/AI-Platform-Docs
+/samples/csharp/enterprise-agent-tutorial/1-idea-to-prototype/ModernWorkplaceAssistant/Program.cs @microsoft-foundry/AI-Platform-Docs
+/samples/csharp/quickstart/chat-with-agent/quickstart-chat-with-agent.cs @microsoft-foundry/AI-Platform-Docs
+/samples/csharp/quickstart/create-agent/quickstart-create-agent.cs @microsoft-foundry/AI-Platform-Docs
+/samples/csharp/quickstart/responses/quickstart-responses.cs @microsoft-foundry/AI-Platform-Docs
+/samples/java/quickstart/chat-with-agent/src/main/java/com/azure/ai/agents/ChatWithAgent.java @microsoft-foundry/AI-Platform-Docs
+/samples/java/quickstart/create-agent/src/main/java/com/azure/ai/agents/CreateAgent.java @microsoft-foundry/AI-Platform-Docs
+/samples/python/enterprise-agent-tutorial/1-idea-to-prototype/evaluate.py @microsoft-foundry/AI-Platform-Docs
+/samples/python/enterprise-agent-tutorial/1-idea-to-prototype/main.py @microsoft-foundry/AI-Platform-Docs
+/samples/python/foundry-models/model-router/model-router-chat-completions.py @microsoft-foundry/AI-Platform-Docs
+/samples/python/foundry-models/model-router/model-router-foundry-responses.py @microsoft-foundry/AI-Platform-Docs
+/samples/python/quickstart/chat-with-agent/quickstart-chat-with-agent.py @microsoft-foundry/AI-Platform-Docs
+/samples/python/quickstart/create-agent/quickstart-create-agent.py @microsoft-foundry/AI-Platform-Docs
+/samples/python/quickstart/responses/quickstart-responses.py @microsoft-foundry/AI-Platform-Docs
+/samples/typescript/quickstart/chat-with-agent/src/quickstart-chat-with-agent.ts @microsoft-foundry/AI-Platform-Docs
+/samples/typescript/quickstart/create-agent/src/quickstart-create-agent.ts @microsoft-foundry/AI-Platform-Docs
+/samples/typescript/quickstart/responses/src/quickstart-responses.ts @microsoft-foundry/AI-Platform-Docs
+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,12 @@
+## Files owned by the AI Platform Docs team
+
+If a file is listed in the CODEOWNERS file with @azure-ai-foundry/ai-platform-docs as the owner, it is owned by the AI Platform Docs team.  For these files:
+
+- Do not change the filename or move the file.
+- Do not remove any comments which contain <some_text> or </some_text> (for any text in between the tags)
+- Do not remove any cell in a notebook if it contains metadata with "name:" in it.
+
+In a code review, if any of the above rules are broken, please add the following text to your review:
+🛑STOP! This PR contains changes that may break documentation.  Please post a message on [ai-platform-docs](https://teams.microsoft.com/l/team/19%3AHhf4F_YfPn3kYGdmWvePNwlbF5-RR8wciQEUwwrcggw1%40thread.tacv2/conversations?groupId=fdaf4412-8993-4ea6-a7d4-aeaded7fc854&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47) to request help.
+
+Only files owned by the AI Platform Docs team are subject to these rules. 

--- a/.github/scripts/commit-filesize-diff-summary.py
+++ b/.github/scripts/commit-filesize-diff-summary.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from itertools import chain
+from pathlib import Path
+from typing import Dict, Iterable, List, Literal, Optional, Tuple
+
+
+@dataclass
+class GitDiffTreeRecord:
+    """Represents a line of output from 'git diff-tree'"""
+
+    src_mode: str
+    src_hash: str
+    dst_mode: str
+    dst_hash: str
+    src_path: Path
+    dst_path: Optional[Path]
+    status: Literal["A", "C", "D", "M", "R", "T", "U", "X"]
+    score: Optional[int]
+
+
+@dataclass
+class GitChange:
+    diff_record: GitDiffTreeRecord
+    bytes_changed: int
+
+
+def parse_git_diff_tree_output(output: str) -> List[GitDiffTreeRecord]:
+    """Parses the output of `git diff-tree` as described in the "Raw Output" section
+    of the man page
+    """
+
+    def make_record(line: str) -> GitDiffTreeRecord:
+        src_mode, dst_mode, src_hash, dst_hash, rest = line[1:].split(" ", maxsplit=4)
+        status_score_and_paths = rest.split("\t")
+        return GitDiffTreeRecord(
+            src_mode=src_mode,
+            src_hash=src_hash,
+            dst_mode=dst_mode,
+            dst_hash=dst_hash,
+            status=status_score_and_paths[0][0],
+            score=int(status_score_and_paths[0][1:]) if len(status_score_and_paths[0]) > 1 else None,
+            src_path=Path(status_score_and_paths[1]),
+            dst_path=Path(status_score_and_paths[2]) if len(status_score_and_paths) >= 3 else None,
+        )
+
+    return [make_record(line) for line in output.splitlines(keepends=False)]
+
+
+def get_blob_sizes(hashes: Iterable[str]) -> Dict[str, Optional[int]]:
+    """Fetches the sizes, in bytes, of git blobs
+
+    :param hashes: A iterable of git blob hashes
+    :type hashes: Iterable[str]
+
+    :return: A dictionary that mapping blob hashes to their size if the blob exists,
+             or None otherwise
+    :rtype: Dict[str, Optional[int]]
+    """
+    input = "\n".join(set(hashes))
+    cat_file_output = subprocess.run(
+        ["git", "cat-file", "--batch-check"],
+        input=input,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+
+    def make_object_size_tuple(line: str) -> Tuple[str, Optional[int]]:
+        hash, *_, size = line.split()
+        return (hash, int(size) if size != "missing" else None)
+
+    return dict(make_object_size_tuple(line) for line in cat_file_output.splitlines(keepends=False))
+
+
+def get_file_size_differences(commit_range: str) -> Dict[Path, GitChange]:
+    """Computes the size difference, in bytes, of files changed between two commits
+
+    :param commit_range: A git commit range (e.g. HEAD~3..HEAD)
+    :type commit_range: str
+
+    :return: A dictionary mapping paths (relative to repository root) to size
+        differences.
+    :rtype: dict[Path, GitChange]
+    """
+    changed_records = parse_git_diff_tree_output(
+        subprocess.run(
+            ["git", "diff-tree", "-r", commit_range],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+
+    sizes = get_blob_sizes(chain.from_iterable((idx.src_hash, idx.dst_hash) for idx in changed_records))
+
+    assert {"A", "D", "M"}.issuperset(idx.status for idx in changed_records)
+
+    def as_int(maybe_num: Optional[int]) -> int:
+        return maybe_num or 0
+
+    return {
+        x.src_path: GitChange(
+            diff_record=x,
+            bytes_changed=as_int(sizes[x.dst_hash]) - as_int(sizes[x.src_hash]),
+        )
+        for x in changed_records
+    }
+
+
+def main(
+    commit_range: str,
+    quiet: bool = False,
+    limit: Optional[int] = None,
+    show_n_largest_files: int = 30,
+) -> Literal[0, 1]:
+    size_differences = get_file_size_differences(commit_range)
+    cumulative_size_difference = sum(x.bytes_changed for x in size_differences.values())
+    exceeds_limit = limit is not None and cumulative_size_difference > limit
+
+    def bytes_diff(num: int) -> str:
+        return ("+" if num >= 0 else "") + human_friendly_bytes(num)
+
+    if not quiet:
+        print(f"Total file size difference for commit range '{commit_range}': ")
+        print(f"\t{bytes_diff(cumulative_size_difference)}", end="")
+        print(f" (Exceeds set limit of {bytes_diff(limit)})" if exceeds_limit else "")
+
+        largest_n_sizes = sorted(size_differences.items(), key=lambda x: x[1].bytes_changed, reverse=True)[
+            :show_n_largest_files
+        ]
+
+        if largest_n_sizes:
+            print("")
+            print(f"Largest {len(largest_n_sizes)} filesize differences:")
+
+        for path, val in largest_n_sizes:
+            print(f"\t{bytes_diff(val.bytes_changed)}\t{path}")
+
+    return 1 if exceeds_limit else 0
+
+
+def num_bytes(arg: str) -> int:
+    """Converts a string to a number of bytes"""
+    error = argparse.ArgumentTypeError(f"'{arg}' cannot be parsed into a number of bytes")
+    try:
+        return int(arg)
+    except ValueError:
+        pass
+
+    if len(arg) < 3:
+        raise error
+
+    num, suffix = (arg[:-2], arg[-2:])
+    shift_values = {
+        "KB": 1,
+        "MB": 2,
+        "GB": 3,
+        "TB": 4,
+        "PB": 5,
+        "EB": 6,
+        "ZB": 7,
+        "YB": 8,
+    }
+
+    shift = shift_values.get(suffix)
+
+    if shift is None:
+        raise error
+    try:
+        return int(num) << (shift * 10)
+    except ValueError as e:
+        raise error from e
+
+
+def human_friendly_bytes(num: int) -> str:
+    """Prints a number of bytes as a human friendly string"""
+    for prefix in ["", "K", "M", "G", "T", "P", "E", "Z"]:
+        if abs(num) < 1024.0:
+            return f"{num:.1f}{prefix}B"
+        num /= 1024.0
+    return f"{num:.1f}YB"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="A program that summarizes the file size " + "differences between two git commits."
+    )
+    parser.add_argument(
+        "commit_range",
+        default="HEAD^..HEAD",
+        type=str,
+        help="Commit range to commit the diff for (e.g. HEAD~3..HEAD)",
+    )
+    parser.add_argument("--quiet", action="store_true", help="Silence all output")
+    parser.add_argument(
+        "--limit",
+        type=num_bytes,
+        help="Exit non-zero if total changes exceeds this value. "
+        + "Can be a raw number of bytes (e.g. 65536) or a suffixed value (e.g 2MB)",
+    )
+    parser.add_argument(
+        "--show-n-largest-files",
+        type=int,
+        help="Show this many of the largest files in diff",
+        default=30,
+    )
+    sys.exit(main(**vars(parser.parse_args())))

--- a/.github/workflows/ado-automation.yml
+++ b/.github/workflows/ado-automation.yml
@@ -1,0 +1,52 @@
+name: Create ADO user story from GitHub issue
+run-name: GitHub Issue #${{ github.event.issue.number }}
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-ado-story:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build payload and call Azure DevOps
+        env:
+          ADO_ORG:            ${{ secrets.ADO_ORG }}
+          ADO_PROJECT:        ${{ secrets.ADO_PROJECT }}
+          ADO_PAT:            ${{ secrets.ADO_PAT }}
+          DRI_EMAIL:          ${{ secrets.DRI_EMAIL }}
+          ADO_AREA_PATH:      ${{ secrets.ADO_AREA_PATH }}
+          ADO_ITERATION_PATH: ${{ secrets.ADO_ITERATION_PATH }}
+          ADO_TAG:            ${{ secrets.ADO_TAG }}
+          ISSUE_TITLE:        ${{ github.event.issue.title }}
+          ISSUE_BODY:         ${{ github.event.issue.body }}
+          ISSUE_URL:          ${{ github.event.issue.html_url }}
+        run: |
+          DESCRIPTION="<div>${ISSUE_BODY//$'\n'/<br/>}<br/><br/><a href=\"$ISSUE_URL\">$ISSUE_URL</a></div>"
+
+          jq -n \
+            --arg title "$ISSUE_TITLE" \
+            --arg desc  "$DESCRIPTION" \
+            --arg area  "$ADO_AREA_PATH" \
+            --arg iter  "$ADO_ITERATION_PATH" \
+            --arg assn  "$DRI_EMAIL" \
+            --arg tags  "$ADO_TAG" \
+            '[
+               { "op":"add", "path":"/fields/System.Title",         "value":$title },
+               { "op":"add", "path":"/fields/System.Description",   "value":$desc  },
+               { "op":"add", "path":"/fields/System.AreaPath",      "value":$area  },
+               { "op":"add", "path":"/fields/System.IterationPath", "value":$iter  },
+               { "op":"add", "path":"/fields/System.AssignedTo",    "value":$assn  },
+               { "op":"add", "path":"/fields/System.Tags",          "value":$tags  }
+             ]' > /tmp/payload.json
+
+          AUTH=$(printf ":$ADO_PAT" | base64 | tr -d '\n')
+          WORK_ITEM_URL="https://dev.azure.com/${ADO_ORG}/${ADO_PROJECT}/_apis/wit/workitems/\$User%20Story?api-version=7.1-preview.3"
+
+          curl --fail-with-body -sS \
+               -H "Content-Type: application/json-patch+json" \
+               -H "Authorization: Basic $AUTH" \
+               -X POST \
+               --data-binary @/tmp/payload.json \
+               "$WORK_ITEM_URL"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,23 @@
+name: Pre-Commit
+
+
+on:
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - run: pip install -r dev-requirements.txt
+      - name: Run Pre-Commit
+        run: pre-commit run --all-files

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,24 @@
+name: Pull Request Checks
+
+on:
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+jobs:
+  pull_request_size:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Check Pull Request Size
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }} --quiet # Need to manually fetch base branch in CI
+          python ./.github/scripts/commit-filesize-diff-summary.py --limit 1MB origin/${{ github.event.pull_request.base.ref }}..HEAD

--- a/.github/workflows/redirect-pull-requests.yml
+++ b/.github/workflows/redirect-pull-requests.yml
@@ -1,0 +1,132 @@
+name: Redirect Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  redirect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check org membership and redirect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            // Allow PRs from trusted automation bots (e.g., repo sync)
+            const allowedBots = ['foundry-samples-repo-sync[bot]'];
+            if (allowedBots.includes(author)) {
+              console.log(`Skipping redirect for allowed bot: ${author}`);
+              return;
+            }
+
+            // Check if author is a Microsoft contributor using multiple signals.
+            // The GITHUB_TOKEN can only see *public* members of the 'microsoft' org
+            // (since this repo is in the 'microsoft-foundry' org), so we cascade
+            // through several checks to catch contributors with private membership.
+            let isInternal = false;
+            let matchedSignal = null;
+
+            // Signal 1: Check microsoft-foundry org membership (full visibility via GITHUB_TOKEN)
+            try {
+              const res = await github.rest.orgs.checkMembershipForUser({
+                org: 'microsoft-foundry',
+                username: author,
+              });
+              if (res.status === 204) {
+                isInternal = true;
+                matchedSignal = 'microsoft-foundry org member';
+              }
+            } catch {
+              // 404 or 302 means not a member
+            }
+
+            // Signal 2: Check if author is a collaborator on this repo
+            if (!isInternal) {
+              try {
+                const res = await github.rest.repos.checkCollaborator({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: author,
+                });
+                if (res.status === 204) {
+                  isInternal = true;
+                  matchedSignal = 'repo collaborator';
+                }
+              } catch {
+                // 404 means not a collaborator
+              }
+            }
+
+            // Signal 3: Check microsoft org membership (catches public members only)
+            if (!isInternal) {
+              try {
+                const res = await github.rest.orgs.checkMembershipForUser({
+                  org: 'microsoft',
+                  username: author,
+                });
+                if (res.status === 204) {
+                  isInternal = true;
+                  matchedSignal = 'microsoft org member (public)';
+                }
+              } catch {
+                // 404 or 302 means not a member (or private membership not visible)
+              }
+            }
+
+            console.log(`Author: ${author}, isInternal: ${isInternal}, signal: ${matchedSignal || 'none'}`);
+
+            let body;
+            if (isInternal) {
+              body = [
+                `👋 Thanks for your contribution, @${author}!`,
+                '',
+                'This repository is read-only. As a Microsoft contributor, please submit your PR to the private staging repository instead:',
+                '',
+                '👉 **[foundry-samples-pr](https://github.com/microsoft-foundry/foundry-samples-pr)**',
+                '',
+                'See [CONTRIBUTING.md](https://github.com/microsoft-foundry/foundry-samples/blob/main/CONTRIBUTING.md) for full instructions.',
+              ].join('\n');
+            } else {
+              body = [
+                `👋 Thanks for your interest in contributing, @${author}!`,
+                '',
+                'This repository does not accept pull requests directly. If you\'d like to report a bug, suggest an improvement, or propose a new sample, please **[open an issue](https://github.com/microsoft-foundry/foundry-samples/issues/new)** instead.',
+                '',
+                'See [CONTRIBUTING.md](https://github.com/microsoft-foundry/foundry-samples/blob/main/CONTRIBUTING.md) for more details.',
+              ].join('\n');
+            }
+
+            // Skip if the bot already commented (idempotent on re-runs)
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            });
+            const alreadyCommented = comments.data.some(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('This repository')
+            );
+            if (alreadyCommented) {
+              console.log('Bot already commented on this PR, skipping.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });

--- a/.github/workflows/run-setup.yml
+++ b/.github/workflows/run-setup.yml
@@ -1,0 +1,135 @@
+name: Run Setup
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - infrastructure/infrastructure-setup-bicep/**
+  pull_request:
+    branches: [main]
+    paths:
+      - infrastructure/infrastructure-setup-bicep/**
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  run-setup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@v3
+        with:
+          # PR: checks out the PR branch, Push: checks out main, Dispatch: checks out default branch
+          ref: ${{ github.head_ref || github.ref_name }}
+          fetch-depth: 0
+
+      - name: Install Bicep
+        run: |
+          INSTALL_PATH="$RUNNER_TEMP/bicep"
+          BICEP_PATH="$RUNNER_TEMP/bicep/bicep"
+          mkdir -p "$INSTALL_PATH"
+          curl -sLo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
+          chmod +x ./bicep
+          sudo mv ./bicep "$INSTALL_PATH"
+          echo "BICEP_PATH=$BICEP_PATH" >> $GITHUB_ENV
+          $BICEP_PATH --version
+
+      - name: Determine changed main.bicep files
+        id: changes
+        run: |
+          set -e
+          cd "$GITHUB_WORKSPACE"
+
+          EVENT="${{ github.event_name }}"
+          echo "Event: $EVENT"
+
+          if [ "$EVENT" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          elif [ "$EVENT" = "push" ]; then
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          else
+            # workflow_dispatch: use last commit as best-effort
+            BASE="$(git rev-parse HEAD~1 || echo '')"
+            HEAD="$(git rev-parse HEAD)"
+          fi
+
+          echo "Diff range: ${BASE}..${HEAD}"
+
+          # Only rebuild when main.bicep changes
+          if [ -n "$BASE" ]; then
+            MODIFIED=$(git diff --name-only "$BASE" "$HEAD" \
+              | grep -E "^infrastructure/infrastructure-setup-bicep/.*/main\.bicep$" || true)
+          else
+            MODIFIED=$(git show --name-only --pretty="" -1 \
+              | grep -E "^infrastructure/infrastructure-setup-bicep/.*/main\.bicep$" || true)
+          fi
+
+          if [ -z "$MODIFIED" ]; then
+            echo "No relevant Bicep changes detected."
+            echo "files=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Changed main.bicep files:"
+          echo "$MODIFIED"
+
+          # Output as newline-delimited list
+          {
+            echo "files<<EOF"
+            echo "$MODIFIED"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Build changed Bicep files -> azuredeploy.json
+        if: steps.changes.outputs.files != ''
+        run: |
+          set -e
+          cd "$GITHUB_WORKSPACE"
+
+          while IFS= read -r BICEP_FILE; do
+            OUTFILE="$(dirname "$BICEP_FILE")/azuredeploy.json"
+            echo "Building: $BICEP_FILE -> $OUTFILE"
+            $BICEP_PATH build "$BICEP_FILE" --outfile "$OUTFILE"
+          done <<< "${{ steps.changes.outputs.files }}"
+
+      - name: Commit + push changes back to branch (PR) or main (push)
+        if: always()
+        run: |
+          set -e
+          cd "$GITHUB_WORKSPACE"
+
+          git config --global user.email "foundry-samples@noreply.github.com"
+          git config --global user.name "foundry-samples automation"
+
+          git add -A
+
+          if git diff-index --quiet HEAD --; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git commit -m "Automatic fixes"
+
+          EVENT="${{ github.event_name }}"
+
+          # If PR is from a fork, pushing will be rejected. Detect and skip.
+          if [ "$EVENT" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              echo "PR is from a fork; cannot push changes back to fork branch. Skipping push."
+              exit 0
+            fi
+            BRANCH="${{ github.head_ref }}"
+            echo "Pushing fixes to PR branch: $BRANCH"
+            git push origin "HEAD:refs/heads/$BRANCH"
+            exit 0
+          fi
+
+          # push / workflow_dispatch
+          BRANCH="${{ github.ref_name }}"
+          echo "Pushing fixes to branch: $BRANCH"
+          git push origin "HEAD:refs/heads/$BRANCH"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to Microsoft Foundry Samples
+
+This repository contains official Microsoft Foundry documentation samples. The contents are published automatically from a private staging repository and are not edited directly here.
+
+## Reporting Issues
+
+If you find a bug, have a question, or want to suggest an improvement to an existing sample, please [open an issue](https://github.com/microsoft-foundry/foundry-samples/issues/new) on this repository. We welcome feedback from everyone!
+
+## Contributing Changes (Microsoft Contributors)
+
+Sample contributions are currently limited to Microsoft Foundry teams.
+
+All changes — new samples, updates, and bug fixes — are submitted through the private staging repository [`foundry-samples-pr`](https://github.com/microsoft-foundry/foundry-samples-pr). Changes merged there are automatically synced to this public repository on a nightly basis.
+
+> [!NOTE]
+> The link above will return a **404** until you've completed step 1 below.
+
+### How to get started
+
+1. **Join the `microsoft-foundry` GitHub organization.** Navigate to the organization page on the Open Source Management Portal and click **Join**:
+
+   <https://repos.opensource.microsoft.com/orgs/microsoft-foundry>
+
+2. **Access the staging repository.** Once you've joined the org, you'll be able to view [`foundry-samples-pr`](https://github.com/microsoft-foundry/foundry-samples-pr).
+
+3. **Follow the contributing guide there.** The `foundry-samples-pr` repository has its own [`CONTRIBUTING.md`](https://github.com/microsoft-foundry/foundry-samples-pr/blob/main/CONTRIBUTING.md) with full instructions for setting up write access, creating a branch, and submitting a pull request.
+
+## Contributor License Agreement
+
+This project requires a Contributor License Agreement (CLA). When you submit a pull request, a CLA bot will check whether you need to sign one and guide you through the process. You only need to do this once across all Microsoft repos. For details, visit <https://cla.opensource.microsoft.com>.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com).
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Microsoft Foundry Documentation Samples
+
+This repository acts as the top-level directory for official Microsoft Foundry documentation sample code and examples. It includes notebooks and sample code that contain end-to-end examples as well as smaller code snippets for common developer tasks.
+
+This repository is entirely open source, guidance on how to contribute and links to additional repositories are provided below.
+
+Use the samples in this repository to try out Microsoft Foundry scenarios on your local machine!
+
+## Contributing
+
+Found a bug or have a suggestion? [Open an issue](https://github.com/microsoft-foundry/foundry-samples/issues/new) — we welcome feedback from everyone!
+
+Sample contributions are submitted through a private staging repository. If you're a Microsoft employee or contractor, see the [contributing guidelines](CONTRIBUTING.md) for how to get started.
+


### PR DESCRIPTION
**Production incident rollback.**

## What broke

Sync run [25763953361](https://github.com/microsoft-foundry/foundry-samples-pr/actions/runs/25763953361) (manually triggered with `seed_from_public_sha=701eb5f0` + `seed_from_private_sha=704b6e1a`) merged [PR #705](https://github.com/microsoft-foundry/foundry-samples/pull/705) at 21:47 UTC, which deleted every public-only file in this repo:

- `README.md`
- `CONTRIBUTING.md`
- `.github/CODEOWNERS`
- `.github/copilot-instructions.md`
- `.github/scripts/commit-filesize-diff-summary.py`
- `.github/workflows/` (5 workflow files)

## Why this happened

The sync workflow ran on commit `91d9617e` (the SHA at private main BEFORE the [sentinel fix PR #305](https://github.com/microsoft-foundry/foundry-samples-pr/pull/305) merged), so it executed pre-fix sync-core code. The sentinel fix isn't the issue, though — the failure is a latent logic gap in `apply_public_overlay` that has been present all along:

`
[sync-core] public-overlay/ unchanged          # \u2192 overlay_changed=0
[sync-core] CODEOWNERS unchanged                # \u2192 codeowners_changed=0
[sync-core] Running fast-import to refs/heads/sync/private-to-public-...
[sync-core] Sync complete.
``n
`sync_public_overlay` compares `private:public-overlay/<file>` against `public:<file>`. They matched (prior overlay applications were intact on public main), so `overlay_changed=0` and `apply_public_overlay` was skipped. **But the seed-from-public fast-import path itself deleted the overlay files** \u2014 the "unchanged" check is done BEFORE the import, so it can't see the import about to delete what it's checking. Same gap for CODEOWNERS.

The `seed-marks-from-public.sh` comments explicitly warn about parent-rewriting causing orphan-style imports (PR #702 / run 25584711501). Today's failure is the same family of bug.

## What this PR does

Restores the 10 public-only files from rollback point `701eb5f0` (the SHA in [PR #705's rollback hint](https://github.com/microsoft-foundry/foundry-samples/pull/705#issue-body)). **Legitimate synced sample changes are left in place** \u2014 only the overlay payload + CODEOWNERS are restored. CODEOWNERS at 701eb5f0 (blob `2e3730df`) is byte-identical to private's current `.github/CODEOWNERS`, so this matches what a clean sync would produce.

## Mitigation status

- \u2705 **Sync workflow disabled** (`gh workflow disable sync-to-public.yml` on foundry-samples-pr)
- \u2705 This PR opened to restore public state
- \u23f3 **Will not re-enable sync until the apply_public_overlay logic gap is fixed** \u2014 filing an ADO P1 follow-up

## Risk

Low. Pure restore of files that existed at `701eb5f0` and are byte-identical to what private's public-overlay/ + CODEOWNERS would produce. No content changes.