### PR TITLE
fix: add graceful shutdown handler to github-copilot sample

### DIFF
--- a/samples/python/hosted-agents/bring-your-own/invocations/github-copilot/main.py
+++ b/samples/python/hosted-agents/bring-your-own/invocations/github-copilot/main.py
@@ -177,6 +177,34 @@ async def handle_invoke(request: Request) -> Response:
     )
 
 
+# ── Graceful shutdown ────────────────────────────────────────────────────────
+
+
+@app.shutdown_handler
+async def on_shutdown():
+    """Gracefully tear down the CopilotClient on SIGTERM.
+
+    Calls ``client.stop()`` which destroys all active sessions (persisting
+    their state so they can be resumed later via ``resume_session``), closes
+    the JSON-RPC connection, and terminates the CLI subprocess.  Falls back
+    to ``force_stop()`` if graceful cleanup fails.
+    """
+    global _client, _session
+    if _client is None:
+        return
+    try:
+        errors = await _client.stop()
+        for err in errors:
+            logger.warning("Shutdown cleanup error: %s", err.message)
+        logger.info("CopilotClient stopped gracefully")
+    except Exception:
+        logger.exception("Graceful stop failed, forcing shutdown")
+        await _client.force_stop()
+    finally:
+        _client = None
+        _session = None
+
+
 if __name__ == "__main__":
     has_token = bool(os.environ.get("GITHUB_TOKEN"))
     has_byok = bool(


### PR DESCRIPTION
Add @app.shutdown_handler to cleanly tear down the CopilotClient when the server receives SIGTERM.  Without this, the CLI subprocess is orphaned and session state is not persisted.

The handler calls client.stop() which:
- Destroys all active sessions (persists state for resume_session)
- Closes the JSON-RPC connection
- Terminates the CLI subprocess (5s graceful, then SIGKILL)

Falls back to force_stop() if graceful cleanup fails or times out.