### PR TITLE
Fix Storage Blob Data Owner role assignment name collision (template 16)

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/azuredeploy.json
@@ -2722,7 +2722,7 @@
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
               "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageName'))]",
-              "name": "[guid(resourceId('Microsoft.Authorization/roleDefinitions', 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'), resourceId('Microsoft.Storage/storageAccounts', parameters('storageName')))]",
+              "name": "[guid(parameters('aiProjectPrincipalId'), parameters('workspaceId'), resourceId('Microsoft.Authorization/roleDefinitions', 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'), resourceId('Microsoft.Storage/storageAccounts', parameters('storageName')))]",
               "properties": {
                 "principalId": "[parameters('aiProjectPrincipalId')]",
                 "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b')]",

--- a/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/modules-network-secured/blob-storage-container-role-assignments.bicep
+++ b/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/modules-network-secured/blob-storage-container-role-assignments.bicep
@@ -25,7 +25,7 @@ var conditionStr= '((!(ActionMatches{\'Microsoft.Storage/storageAccounts/blobSer
 // Assign Storage Blob Data Owner role
 resource storageBlobDataOwnerAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: storage
-  name: name: guid(aiProjectPrincipalId, workspaceId, storageBlobDataOwner.id, storage.id)
+  name: guid(aiProjectPrincipalId, workspaceId, storageBlobDataOwner.id, storage.id)
   properties: {
     principalId: aiProjectPrincipalId
     roleDefinitionId: storageBlobDataOwner.id

--- a/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/modules-network-secured/blob-storage-container-role-assignments.bicep
+++ b/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/modules-network-secured/blob-storage-container-role-assignments.bicep
@@ -25,7 +25,7 @@ var conditionStr= '((!(ActionMatches{\'Microsoft.Storage/storageAccounts/blobSer
 // Assign Storage Blob Data Owner role
 resource storageBlobDataOwnerAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   scope: storage
-  name: guid(storageBlobDataOwner.id, storage.id)
+  name: name: guid(aiProjectPrincipalId, workspaceId, storageBlobDataOwner.id, storage.id)
   properties: {
     principalId: aiProjectPrincipalId
     roleDefinitionId: storageBlobDataOwner.id


### PR DESCRIPTION
## Problem
In `16-private-network-standard-agent-apim-setup`, the Storage Blob Data Owner role
assignment name was computed as:

    guid(storageBlobDataOwner.id, storage.id)

This makes the assignment name a **singleton per storage account** — it only depends
on the role ID and the storage account ID. As a result, when more than one Foundry
project is deployed against the **same** BYO storage account (or the same project is
re-deployed with a different principal), the deterministic role-assignment name
collides:

- The second deployment either fails with a 409 Conflict, or
- Silently overwrites the first project's ABAC condition, breaking the first project's
  access to its containers.

## Fix
Include `aiProjectPrincipalId` and `workspaceId` in the GUID inputs so each
(project, workspace, storage) tuple gets its own assignment:

    guid(aiProjectPrincipalId, workspaceId, storageBlobDataOwner.id, storage.id)

- `aiProjectPrincipalId` ensures uniqueness across multiple projects sharing a storage account.
- `workspaceId` ensures the assignment name tracks the workspace-scoped ABAC condition
  embedded in `conditionStr`, so any workspaceId change produces a fresh assignment
  instead of silently keeping a stale condition.

## Files changed
- `modules-network-secured/blob-storage-container-role-assignments.bicep` — fix GUID inputs.
- `azuredeploy.json` — apply the same fix to the generated ARM template so the
  Deploy-to-Azure path stays in sync with the Bicep.

## Validation
- Re-tested deployment in a BYO-VNet environment after applying the fix; role
  assignment is created successfully and the ABAC condition resolves to the correct
  workspace-scoped container prefix.
- No change required to `azure-storage-account-role-assignment.bicep` (Storage Blob
  Data Contributor) — its GUID already includes `projectPrincipalId` and `storageAccount.id`.