### PR TITLE
Enable OpenTelemetry instrumentation for MAF agent-framework samples

### DIFF
--- a/samples/csharp/hosted-agents/agent-framework/agent-skills/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/agent-skills/Program.cs
@@ -59,6 +59,8 @@ var projectEndpoint = new Uri(Environment.GetEnvironmentVariable("FOUNDRY_PROJEC
 string deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME")
     ?? throw new InvalidOperationException("AZURE_AI_MODEL_DEPLOYMENT_NAME environment variable is not set.");
 
+const string SourceName = "AgentSkills.AgentFramework";
+
 // SKILL_NAMES is optional. CI environments that don't pass sample-specific manifest
 // parameters will leave it unset (or as the literal "{{SKILL_NAMES}}" placeholder).
 // In that case the agent still starts up and responds, just without any skills wired
@@ -135,8 +137,14 @@ ChatClientAgent agent = projectClient.AsAIAgent(new ChatClientAgentOptions
     AIContextProviders = skillsProvider is null ? [] : [skillsProvider],
 });
 
+// Wrap agent for end-to-end OpenTelemetry tracing.
+var instrumentedAgent = agent
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
+
 var builder = AgentHost.CreateBuilder(args);
-builder.Services.AddFoundryResponses(agent);
+builder.Services.AddFoundryResponses(instrumentedAgent);
 builder.RegisterProtocol("responses", endpoints => endpoints.MapFoundryResponses());
 
 var app = builder.Build();

--- a/samples/csharp/hosted-agents/agent-framework/azure-search-rag/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/azure-search-rag/Program.cs
@@ -20,6 +20,8 @@ var searchEndpoint = new Uri(Environment.GetEnvironmentVariable("AZURE_SEARCH_EN
     ?? throw new InvalidOperationException("AZURE_SEARCH_ENDPOINT environment variable is not set."));
 var indexName = Environment.GetEnvironmentVariable("AZURE_SEARCH_INDEX_NAME") ?? "contoso-outdoors";
 
+const string SourceName = "AzureSearchRag.AgentFramework";
+
 var credential = new DefaultAzureCredential();
 
 // The index is expected to exist and be populated before the agent runs. See README.md for the
@@ -45,7 +47,10 @@ AIAgent agent = new AIProjectClient(projectEndpoint, credential)
                            "If you cannot find relevant information in the provided context, let the customer know.",
         },
         AIContextProviders = [new TextSearchProvider(CreateSearchAdapter(searchClient), textSearchOptions)]
-    });
+    })
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 var builder = AgentHost.CreateBuilder(args);
 builder.Services.AddFoundryResponses(agent);

--- a/samples/csharp/hosted-agents/agent-framework/file-tools/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/file-tools/Program.cs
@@ -16,6 +16,8 @@ var projectEndpoint = new Uri(Environment.GetEnvironmentVariable("FOUNDRY_PROJEC
 
 var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME") ?? "gpt-4.1-mini";
 
+const string SourceName = "FileTools.AgentFramework";
+
 // Bundled root: files copied into the published output via csproj <Content Include="resources\**">.
 // In the container this resolves to /app/resources/.
 string bundledRoot = Path.GetFullPath(
@@ -48,13 +50,20 @@ AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential(
             """,
         name: "file-tools",
         description: "Hosted agent that answers questions over bundled (image-baked) and session-uploaded files via two scoped tool pairs.",
+        clientFactory: inner => inner
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+            .Build(),
         tools:
         [
             AIFunctionFactory.Create(ListBundledFiles),
             AIFunctionFactory.Create(ReadBundledFile),
             AIFunctionFactory.Create(ListSessionFiles),
             AIFunctionFactory.Create(ReadSessionFile),
-        ]);
+        ])
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 var builder = AgentHost.CreateBuilder(args);
 builder.Services.AddFoundryResponses(agent);

--- a/samples/csharp/hosted-agents/agent-framework/foundry-memory-rag/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/foundry-memory-rag/Program.cs
@@ -27,6 +27,8 @@ var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_N
 var embeddingDeployment = Environment.GetEnvironmentVariable("AZURE_AI_EMBEDDING_DEPLOYMENT_NAME") ?? "text-embedding-3-small";
 var memoryStoreName = Environment.GetEnvironmentVariable("AZURE_AI_MEMORY_STORE_ID") ?? "foundry-memory-rag-store";
 
+const string SourceName = "FoundryMemoryRag.AgentFramework";
+
 var projectClient = new AIProjectClient(projectEndpoint, new DefaultAzureCredential());
 
 // Per-user memory scoping is the production pattern. This sample uses a single shared scope
@@ -61,8 +63,13 @@ var agent = projectClient.AsAIAgent(new ChatClientAgentOptions
     AIContextProviders = [memoryProvider]
 });
 
+var instrumentedAgent = agent
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
+
 var builder = AgentHost.CreateBuilder(args);
-builder.Services.AddFoundryResponses(agent);
+builder.Services.AddFoundryResponses(instrumentedAgent);
 builder.RegisterProtocol("responses", endpoints => endpoints.MapFoundryResponses());
 
 var app = builder.Build();

--- a/samples/csharp/hosted-agents/agent-framework/foundry-toolbox-server-side/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/foundry-toolbox-server-side/Program.cs
@@ -22,6 +22,7 @@ using Azure.Identity;
 using DotNetEnv;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Foundry.Hosting;
+using Microsoft.Extensions.AI;
 
 // Load .env file if present (for local development)
 Env.TraversePath().Load();
@@ -34,6 +35,8 @@ var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_N
 
 var toolboxName = Environment.GetEnvironmentVariable("TOOLBOX_NAME")
     ?? throw new InvalidOperationException("TOOLBOX_NAME environment variable is not set.");
+
+const string SourceName = "FoundryToolboxServerSide.AgentFramework";
 
 // Fetch the toolbox's tools from Foundry. Omitting the version resolves the toolbox's
 // current default version. The returned AITools are passed directly to the agent as
@@ -48,7 +51,14 @@ AIAgent agent = projectClient
                     + "Use the available tools to help answer user questions. Be concise.",
         name: "foundry-toolbox-server-side",
         description: "Agent with Foundry Toolbox integration using server-side tools.",
-        tools: [.. tools]);
+        clientFactory: inner => inner
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+            .Build(),
+        tools: [.. tools])
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 var builder = AgentHost.CreateBuilder(args);
 builder.Services.AddFoundryResponses(agent);

--- a/samples/csharp/hosted-agents/agent-framework/hello-world/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/hello-world/Program.cs
@@ -41,6 +41,7 @@ using Azure.AI.Projects;
 using Azure.Identity;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Foundry.Hosting;
+using Microsoft.Extensions.AI;
 
 if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
 {
@@ -56,6 +57,8 @@ var projectEndpoint = new Uri(Environment.GetEnvironmentVariable("FOUNDRY_PROJEC
 var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME")
     ?? throw new InvalidOperationException("AZURE_AI_MODEL_DEPLOYMENT_NAME environment variable is not set.");
 
+const string SourceName = "HelloWorld.AgentFramework";
+
 // Create an AIAgent backed by a Foundry model.
 // The agent framework manages the LLM call, conversation sessions, and response lifecycle.
 AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential())
@@ -63,7 +66,14 @@ AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential(
         model: deployment,
         instructions: "You are a helpful AI assistant. Be concise and informative.",
         name: "hello-world",
-        description: "A minimal Hello World agent using the Agent Framework");
+        description: "A minimal Hello World agent using the Agent Framework",
+        clientFactory: inner => inner
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+            .Build())
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 // AgentHost.CreateBuilder() auto-configures:
 //   - Kestrel on port 8088 (or the PORT environment variable)

--- a/samples/csharp/hosted-agents/agent-framework/local-tools/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/local-tools/Program.cs
@@ -14,6 +14,8 @@ var projectEndpoint = new Uri(Environment.GetEnvironmentVariable("FOUNDRY_PROJEC
     ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT environment variable is not set."));
 var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME") ?? "gpt-4o";
 
+const string SourceName = "LocalTools.AgentFramework";
+
 AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential())
     .AsAIAgent(
         model: deployment,
@@ -24,11 +26,18 @@ AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential(
             """,
         name: "local-tools",
         description: "A hotel concierge assistant with local function tools",
+        clientFactory: inner => inner
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+            .Build(),
         tools:
         [
             AIFunctionFactory.Create(GetAvailableHotels, "GetAvailableHotels",
                 "Gets a list of available hotels in Seattle with details about amenities and pricing.")
-        ]);
+        ])
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 var builder = AgentHost.CreateBuilder(args);
 builder.Services.AddFoundryResponses(agent);

--- a/samples/csharp/hosted-agents/agent-framework/mcp-tools/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/mcp-tools/Program.cs
@@ -31,6 +31,8 @@ var projectEndpoint = new Uri(Environment.GetEnvironmentVariable("FOUNDRY_PROJEC
     ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT environment variable is not set."));
 var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME") ?? "gpt-4o";
 
+const string SourceName = "McpTools.AgentFramework";
+
 // ── Client-side MCP: Microsoft Learn (local resolution) ──────────────────────
 // Connect directly to the MCP server. The agent discovers and invokes tools locally.
 Console.WriteLine("Connecting to Microsoft Learn MCP server (client-side)...");
@@ -70,7 +72,14 @@ AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential(
             """,
         name: "mcp-tools",
         description: "Developer assistant with dual-layer MCP tools (client-side and server-side)",
-        tools: allTools);
+        clientFactory: inner => inner
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+            .Build(),
+        tools: allTools)
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 var builder = AgentHost.CreateBuilder(args);
 builder.Services.AddFoundryResponses(agent);

--- a/samples/csharp/hosted-agents/agent-framework/simple-agent/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/simple-agent/Program.cs
@@ -6,12 +6,15 @@ using Azure.Identity;
 using DotNetEnv;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Foundry.Hosting;
+using Microsoft.Extensions.AI;
 
 Env.TraversePath().Load();
 
 var projectEndpoint = new Uri(Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT")
     ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT environment variable is not set."));
 var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME") ?? "gpt-4o";
+
+const string SourceName = "SimpleAgent.AgentFramework";
 
 AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential())
     .AsAIAgent(
@@ -23,7 +26,14 @@ AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential(
             Be concise, clear, and helpful in your responses.
             """,
         name: "simple-agent",
-        description: "A simple general-purpose AI assistant");
+        description: "A simple general-purpose AI assistant",
+        clientFactory: inner => inner
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+            .Build())
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 var builder = AgentHost.CreateBuilder(args);
 builder.Services.AddFoundryResponses(agent);

--- a/samples/csharp/hosted-agents/agent-framework/teams-activity/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/teams-activity/Program.cs
@@ -20,6 +20,7 @@ using Azure.Identity;
 using DotNetEnv;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Foundry.Hosting;
+using Microsoft.Extensions.AI;
 
 // Load .env file if present (for local development)
 Env.TraversePath().Load();
@@ -33,6 +34,8 @@ var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_N
 var toolboxName = Environment.GetEnvironmentVariable("TOOLBOX_NAME")
     ?? throw new InvalidOperationException("TOOLBOX_NAME environment variable is not set.");
 
+const string SourceName = "TeamsActivity.AgentFramework";
+
 // Fetch the toolbox's tools from Foundry. Omitting the version resolves the toolbox's
 // current default version. The returned AITools are passed directly to the agent as
 // server-side tools — Foundry will execute them on the agent's behalf.
@@ -44,7 +47,14 @@ AIAgent agent = projectClient
         instructions: "You are a helpful assistant with access to Azure AI Foundry toolbox tools. "
                     + "Use the available tools to help answer user questions. Be concise.",
         name: "teams-activity-dotnet-agent-framework",
-        description: "Agent with Foundry Toolbox integration using Work IQ tools.");
+        description: "Agent with Foundry Toolbox integration using Work IQ tools.",
+        clientFactory: inner => inner
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+            .Build())
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 var builder = AgentHost.CreateBuilder(args);
 builder.Services.AddFoundryResponses(agent);

--- a/samples/csharp/hosted-agents/agent-framework/text-search-rag/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/text-search-rag/Program.cs
@@ -14,6 +14,8 @@ var projectEndpoint = new Uri(Environment.GetEnvironmentVariable("FOUNDRY_PROJEC
     ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT environment variable is not set."));
 var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME") ?? "gpt-4o";
 
+const string SourceName = "TextSearchRag.AgentFramework";
+
 AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential())
     .AsAIAgent(
         model: deployment,
@@ -25,11 +27,18 @@ AIAgent agent = new AIProjectClient(projectEndpoint, new DefaultAzureCredential(
             """,
         name: "text-search-rag",
         description: "A RAG-powered customer support assistant with text search capabilities",
+        clientFactory: inner => inner
+            .AsBuilder()
+            .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+            .Build(),
         tools:
         [
             AIFunctionFactory.Create(SearchKnowledgeBase, "SearchKnowledgeBase",
                 "Searches the company knowledge base for relevant information about products, policies, and procedures.")
-        ]);
+        ])
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 var builder = AgentHost.CreateBuilder(args);
 builder.Services.AddFoundryResponses(agent);

--- a/samples/csharp/hosted-agents/agent-framework/workflows/Program.cs
+++ b/samples/csharp/hosted-agents/agent-framework/workflows/Program.cs
@@ -7,12 +7,15 @@ using DotNetEnv;
 using Microsoft.Agents.AI;
 using Microsoft.Agents.AI.Foundry.Hosting;
 using Microsoft.Agents.AI.Workflows;
+using Microsoft.Extensions.AI;
 
 Env.TraversePath().Load();
 
 var projectEndpoint = new Uri(Environment.GetEnvironmentVariable("FOUNDRY_PROJECT_ENDPOINT")
     ?? throw new InvalidOperationException("FOUNDRY_PROJECT_ENDPOINT environment variable is not set."));
 var deployment = Environment.GetEnvironmentVariable("AZURE_AI_MODEL_DEPLOYMENT_NAME") ?? "gpt-4o";
+
+const string SourceName = "Workflows.AgentFramework";
 
 var projectClient = new AIProjectClient(projectEndpoint, new DefaultAzureCredential());
 
@@ -24,7 +27,14 @@ AIAgent englishToFrench = projectClient.AsAIAgent(
         Only output the translated text, nothing else. Do not add explanations or notes.
         """,
     name: "english-to-french",
-    description: "Translates English text to French");
+    description: "Translates English text to French",
+    clientFactory: inner => inner
+        .AsBuilder()
+        .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+        .Build())
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 AIAgent frenchToSpanish = projectClient.AsAIAgent(
     model: deployment,
@@ -33,7 +43,14 @@ AIAgent frenchToSpanish = projectClient.AsAIAgent(
         Only output the translated text, nothing else. Do not add explanations or notes.
         """,
     name: "french-to-spanish",
-    description: "Translates French text to Spanish");
+    description: "Translates French text to Spanish",
+    clientFactory: inner => inner
+        .AsBuilder()
+        .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+        .Build())
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 AIAgent spanishToEnglish = projectClient.AsAIAgent(
     model: deployment,
@@ -42,14 +59,24 @@ AIAgent spanishToEnglish = projectClient.AsAIAgent(
         Only output the translated text, nothing else. Do not add explanations or notes.
         """,
     name: "spanish-to-english",
-    description: "Translates Spanish text to English");
+    description: "Translates Spanish text to English",
+    clientFactory: inner => inner
+        .AsBuilder()
+        .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+        .Build())
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 // Build a sequential translation chain: English → French → Spanish → English
 AIAgent agent = AgentWorkflowBuilder
     .BuildSequential("translation-chain", englishToFrench, frenchToSpanish, spanishToEnglish)
     .AsAIAgent(
         name: "translation-chain",
-        description: "A translation workflow that chains English → French → Spanish → English");
+        description: "A translation workflow that chains English → French → Spanish → English")
+    .AsBuilder()
+    .UseOpenTelemetry(sourceName: SourceName, configure: c => c.EnableSensitiveData = true)
+    .Build();
 
 var builder = AgentHost.CreateBuilder(args);
 builder.Services.AddFoundryResponses(agent);


### PR DESCRIPTION
Add UseOpenTelemetry tracing to all C# hosted agent samples under samples/csharp/hosted-agents/agent-framework. Each sample now instruments both the inner IChatClient (via clientFactory) and the outer AIAgent (via .AsBuilder().UseOpenTelemetry()) using a sample-specific source name.

Samples updated:
- simple-agent
- local-tools
- file-tools
- azure-search-rag
- mcp-tools
- workflows (all three sub-agents + the combined workflow agent)
- agent-skills
- foundry-toolbox-server-side
- teams-activity
- text-search-rag
- foundry-memory-rag

Note: ChatClientAgentOptions-based samples (azure-search-rag, agent-skills, foundry-memory-rag) use only the outer agent-level OTel wrapping since ChatClientAgentOptions does not expose a ClientFactory property.