### PR TITLE
docs(01-basic): warn against running `azd ai agent init` in-place

### DIFF
--- a/samples/python/hosted-agents/agent-framework/responses/01-basic/README.md
+++ b/samples/python/hosted-agents/agent-framework/responses/01-basic/README.md
@@ -30,6 +30,17 @@ mkdir my-basic-agent && cd my-basic-agent
 azd ai agent init -m https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/01-basic/agent.manifest.yaml
 ```
 
+> [!IMPORTANT]
+> Run `azd ai agent init` from a **new, empty folder** as shown above. Do **not** run it from inside a cloned copy of this sample directory. Because this folder already contains `agent.manifest.yaml`, initializing in place fails with:
+>
+> ```
+> ERROR: downloading agent.yaml: cannot copy agent files: target '...' is inside the
+> manifest directory '...'. Move the manifest to a separate directory containing only the
+> agent files.
+> ```
+>
+> Using a fresh folder with the remote manifest URL (as shown above) avoids this. If you prefer a local manifest, keep it in its own directory and run `azd ai agent init` from a separate working directory.
+
 Follow the prompts to configure your Foundry project and model deployment. If you don't have an existing Foundry project, `azd ai agent init` will guide you through creating one.
 
 ### Provision Azure resources (if needed)


### PR DESCRIPTION
## What & why

Running `azd ai agent init` from **inside** this sample folder (e.g. after `git clone` + `cd ...\responses\01-basic`) fails, because the folder already contains `agent.manifest.yaml` and the generated `src/<name>` tree would be nested inside the manifest directory:

```
ERROR: downloading agent.yaml: cannot copy agent files: target '...\01-basic\<name>\src\<name>'
is inside the manifest directory '...\01-basic'.
Move the manifest to a separate directory containing only the agent files.
```

The README already recommends the correct `mkdir new-folder` + remote-manifest-URL flow, but nothing warns users away from the natural `cd into the sample && init` path. This adds an explicit callout.

## Change
- Adds an `[!IMPORTANT]` note under **Initialize the agent project** telling users to run `azd ai agent init` from a new empty folder and not in-place, with the exact error they'd otherwise hit and how to avoid it.

Docs-only change.

## Repro (for maintainers)
- `azure.ai.agents` extension **0.1.37-preview** (latest), azd 1.25.4, Windows.
- `cd` into a folder containing `agent.manifest.yaml` and run `azd ai agent init` -> error above.
- Note: `--force` does **not** bypass it despite its help text ("overwrite an input manifest that already lives inside the generated src tree"). The underlying CLI behavior is likely worth a separate fix; this PR is the docs mitigation.
