### PR TITLE
Gate account capability host creation

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "14993641389519398529"
+      "templateHash": "13138450198117259390"
     }
   },
   "parameters": {
@@ -2595,6 +2595,7 @@
       ]
     },
     {
+      "condition": "[variables('useExistingAccount')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
       "name": "[format('account-caphost-{0}-deployment', variables('uniqueSuffix'))]",

--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/main.bicep
@@ -106,8 +106,8 @@ param existingAiFoundryAccountResourceId string = ''
 @description('Optional. When true, skip the model deployment. Recommended when reusing an existing account that already has the required model deployments.')
 param skipModelDeployment bool = false
 
-// Re-derive BYO account context at main.bicep level so we can scope the
-// account-level capabilityHost module to the right RG/subscription.
+// Re-derive BYO account context at main.bicep level so account-scoped modules
+// can target the right RG/subscription.
 var useExistingAccount = !empty(existingAiFoundryAccountResourceId)
 var existingAccountIdParts = split(existingAiFoundryAccountResourceId, '/')
 var existingAccountSubscriptionId = useExistingAccount ? existingAccountIdParts[2] : subscription().subscriptionId
@@ -431,10 +431,9 @@ module aiSearchRoleAssignments 'modules-network-secured/ai-search-role-assignmen
   ]
 }
 
-// Account-level capabilityHost (bootstraps before project caphost).
-// The current sample relies on createCapHost.sh being run manually; making it
-// declarative keeps the flow idempotent and works for both new and BYO accounts.
-module addAccountCapabilityHost 'modules-network-secured/add-account-capability-host.bicep' = {
+// Existing Foundry accounts might not have the account-level capabilityHost yet.
+// New accounts get it automatically, so only bootstrap it for BYO accounts.
+module addAccountCapabilityHost 'modules-network-secured/add-account-capability-host.bicep' = if (useExistingAccount) {
   name: 'account-caphost-${uniqueSuffix}-deployment'
   scope: resourceGroup(existingAccountSubscriptionId, existingAccountResourceGroupName)
   params: {
@@ -446,7 +445,7 @@ module addAccountCapabilityHost 'modules-network-secured/add-account-capability-
   ]
 }
 
-// This module creates the capability host for the project and account
+// This module creates the capability host for the project
 module addProjectCapabilityHost 'modules-network-secured/add-project-capability-host.bicep' = {
   name: 'capabilityHost-configuration-${uniqueSuffix}-deployment'
   params: {
@@ -458,7 +457,7 @@ module addProjectCapabilityHost 'modules-network-secured/add-project-capability-
     projectCapHost: projectCapHost
   }
   dependsOn: [
-     addAccountCapabilityHost  // account caphost must exist first
+     addAccountCapabilityHost  // only created for BYO accounts; new accounts create it automatically
      aiSearch      // Ensure AI Search exists
      storage       // Ensure Storage exists
      cosmosDB


### PR DESCRIPTION
## Summary
- only bootstrap the account-level capability host when using an existing Foundry account
- let new Foundry accounts use the automatically-created account capability host
- regenerate azuredeploy.json from main.bicep

## Validation
- az bicep build --file main.bicep --outfile azuredeploy.json