### PR TITLE
fix(template-15): deploy fails with HTTP 409 because we PUT a second account-level capability host that the Cognitive Services resource provider already auto-created (closes #312)

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/README.md
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/README.md
@@ -102,7 +102,7 @@ Use the table below to choose the right infrastructure template for your scenari
   
   > **Notes:** 
   - If you do not provide an existing virtual network, the template will create a new virtual network with the default address spaces and subnets described above. If you use an existing virtual network, make sure it already contains two subnets (Agent and Private Endpoint) before deploying the template.
-  - The account-level capability host is now provisioned declaratively by `modules-network-secured/add-account-capability-host.bicep` as part of `main.bicep`. The standalone `createCapHost.sh` script is no longer required for first-time deployments; it remains in the folder only to support the cleanup-then-recreate flow described in the [Account Deletion Prerequisites and Cleanup Guidance](#account-deletion-prerequisites-and-cleanup-guidance).
+  - For network-secured deployments, the account-level capability host (`{accountName}@aml_aiagentservice`) is auto-created by the Cognitive Services resource provider (`Microsoft.CognitiveServices`) when the account is created with `properties.networkInjections[].scenario = 'agent'` (set in `modules-network-secured/ai-account-identity.bicep`). Neither `createCapHost.sh` nor the `add-account-capability-host.bicep` module is invoked for first-time deployments; both remain in the folder only to support the cleanup-then-recreate flow described in the [Account Deletion Prerequisites and Cleanup Guidance](#account-deletion-prerequisites-and-cleanup-guidance).
   - You must ensure the subnet is exclusively delegated to __Microsoft.App/environments__ and cannot be used by any other Azure resources.
 
 
@@ -128,7 +128,7 @@ Before deleting an **Account** resource, it is essential to first delete the ass
  
 **2. Retain Account, Remove Capability Host**: If you intend to retain the account but remove the capability host, execute the script `deleteCaphost.sh` located in this folder. After deletion, allow approximately max of 20 minutes for all resources to be fully unlinked from the account. To recreate the capability host for the account, use the script `createCaphost.sh` located in the same folder.
 
-> **Note**: The account-level capability host is created declaratively by `main.bicep` (via `modules-network-secured/add-account-capability-host.bicep`) on first deployment. The `createCapHost.sh` script is intended for this cleanup-then-recreate scenario only; it is not required for an initial deployment.
+> **Note**: For network-secured deployments, the account-level capability host is auto-created by the Cognitive Services resource provider on first deployment (triggered by the `networkInjections.scenario = 'agent'` property set in `modules-network-secured/ai-account-identity.bicep`). The `createCapHost.sh` script and the `add-account-capability-host.bicep` module are intended for this cleanup-then-recreate scenario only; neither is required for an initial deployment.
 
 
 > **Important**: Before deleting the account capability host, ensure that the **project capability host** is deleted.
@@ -465,7 +465,7 @@ Private endpoints ensure secure, internal-only connectivity. Private endpoints a
 
 ```text
 modules-network-secured/
-├── add-account-capability-host.bicep               # Declarative account-level capability host (replaces createCapHost.sh for first-time deployments)
+├── add-account-capability-host.bicep               # (Not invoked by main.bicep in network-secured deployments — the account-level capability host is auto-created by the Cognitive Services resource provider via networkInjections.scenario='agent'. Retained for the cleanup-then-recreate flow.)
 ├── add-project-capability-host.bicep               # Configuring the project's capability host
 ├── ai-account-identity.bicep                       # Microsoft Foundry deployment and configuration (supports BYO existing account)
 ├── ai-project-identity.bicep                       # Foundry project deployment and connection configuration           

--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/main.bicep
@@ -106,13 +106,6 @@ param existingAiFoundryAccountResourceId string = ''
 @description('Optional. When true, skip the model deployment. Recommended when reusing an existing account that already has the required model deployments.')
 param skipModelDeployment bool = false
 
-// Re-derive BYO account context at main.bicep level so we can scope the
-// account-level capabilityHost module to the right RG/subscription.
-var useExistingAccount = !empty(existingAiFoundryAccountResourceId)
-var existingAccountIdParts = split(existingAiFoundryAccountResourceId, '/')
-var existingAccountSubscriptionId = useExistingAccount ? existingAccountIdParts[2] : subscription().subscriptionId
-var existingAccountResourceGroupName = useExistingAccount ? existingAccountIdParts[4] : resourceGroup().name
-
 @description('The AI Search Service full ARM Resource ID. This is an optional field, and if not provided, the resource will be created.')
 param aiSearchResourceId string = ''
 @description('The AI Storage Account full ARM Resource ID. This is an optional field, and if not provided, the resource will be created.')
@@ -431,20 +424,36 @@ module aiSearchRoleAssignments 'modules-network-secured/ai-search-role-assignmen
   ]
 }
 
-// Account-level capabilityHost (bootstraps before project caphost).
-// The current sample relies on createCapHost.sh being run manually; making it
-// declarative keeps the flow idempotent and works for both new and BYO accounts.
-module addAccountCapabilityHost 'modules-network-secured/add-account-capability-host.bicep' = {
-  name: 'account-caphost-${uniqueSuffix}-deployment'
-  scope: resourceGroup(existingAccountSubscriptionId, existingAccountResourceGroupName)
-  params: {
-    accountName: aiAccount.outputs.accountName
-    agentSubnetResourceId: vnet.outputs.agentSubnetId
-  }
-  dependsOn: [
-    privateEndpointAndDNS
-  ]
-}
+// Account-level capabilityHost.
+//
+// PR #261 added this module to bootstrap the account-level capabilityHost so
+// the flow becomes fully declarative (no createCapHost.sh) and works for BYO
+// Foundry accounts that never had the script run.
+//
+// HOWEVER, this network-secured Standard Setup template creates the AI Foundry
+// account with `properties.networkInjections=[{scenario:'agent', subnetArmId:.., useMicrosoftManagedNetwork:false}]`
+// (see modules-network-secured/ai-account-identity.bicep). The Cognitive Services
+// resource provider (`Microsoft.CognitiveServices`) reacts to that property by
+// auto-creating an account-level capabilityHost named `{accountName}@aml_aiagentservice`
+// ~5 seconds after the account PUT. Any subsequent PUT of a second account-level
+// capabilityHost with a different name (here `caphostacct`) for the same account
+// then fails with HTTP 409:
+//
+//   "There is an existing Capability Host with name: {account}@aml_aiagentservice,
+//    provisioning state: Succeeded for workspace: ...
+//    cannot create a new Capability Host with name: caphostacct for the same ClientId."
+//
+// Account-level capability hosts are 1-per-account, keyed on ClientId, and
+// cannot be updated. The auto-created `@aml_aiagentservice` is what the
+// project-level capabilityHost (addProjectCapabilityHost) binds to, so we must
+// NOT create our own here.
+//
+// Because this template is network-secured-only (every deploy passes
+// networkInjections), the auto-create path is always taken. We therefore do
+// NOT call modules-network-secured/add-account-capability-host.bicep here.
+// The module file is intentionally kept in the directory because it may still
+// be useful for other (non-network-secured) BYO bootstrap scenarios.
+// See foundry-samples issues #312 / #254 / #255 / #265.
 
 // This module creates the capability host for the project and account
 module addProjectCapabilityHost 'modules-network-secured/add-project-capability-host.bicep' = {
@@ -458,7 +467,6 @@ module addProjectCapabilityHost 'modules-network-secured/add-project-capability-
     projectCapHost: projectCapHost
   }
   dependsOn: [
-     addAccountCapabilityHost  // account caphost must exist first
      aiSearch      // Ensure AI Search exists
      storage       // Ensure Storage exists
      cosmosDB


### PR DESCRIPTION
## TL;DR

- **Bug**: Deploying the `15-private-network-standard-agent-setup` template fails with **HTTP 409** on the `caphostacct` step.
- **Why**: The Cognitive Services resource provider (`Microsoft.CognitiveServices`) **silently auto-creates** an account-level capability host named `{account}@aml_aiagentservice` whenever the account is created with `networkInjections.scenario='agent'` (which this template always does). Our explicit `addAccountCapabilityHost` module then tries to PUT a *second* one called `caphostacct` — but only one capability host per account is allowed, so the resource provider rejects it.
- **Fix**: Delete the `addAccountCapabilityHost` call from this template's `main.bicep`. The auto-created `@aml_aiagentservice` capability host is sufficient — the project capability host binds to it cleanly and the whole deploy succeeds.

---

## The bug you'll hit

Deploy this template against a clean subscription today, and the `caphostacct` sub-deployment fails with this exact error from the Cognitive Services API:

```
There is an existing Capability Host with name: <accountName>@aml_aiagentservice,
provisioning state: Succeeded for workspace: ...
cannot create a new Capability Host with name: caphostacct for the same ClientId.
```

This is the symptom reported in #312 and several other open issues (#254, #255, #265 all show the same `for the same ClientId` text).

---

## Why it happens

The resource provider has a hidden behavior:

```
account PUT with networkInjections.scenario='agent'
     ↓  (~5 seconds later, no extra API call required)
account-level capability host named "{accountName}@aml_aiagentservice"
auto-appears under GET /capabilityHosts
```

Once that auto-created capability host exists, **any other** account-level capability host PUT — even with a different name like `caphostacct` — returns 409, because each account can hold only one capability host ([documented constraint](https://learn.microsoft.com/azure/ai-foundry/agents/concepts/capability-hosts): *"Each account can have only one active capability host. If you try to create a second capability host with a different name at the same scope, you'll receive a 409 error"*).

I verified the auto-create trigger on a clean subscription:

| Test account | Created with `networkInjections.scenario='agent'`? | Account capability host ~5s after create |
|---|---|---|
| Control #1 | x No | (empty list) |
| Control #2 | x No | (empty list) |
| Control #3 | x No | (empty list) |
| Control #4 | x No | (empty list) |
| **This template** | o Yes (via `ai-account-identity.bicep`) | **`{name}@aml_aiagentservice` appears** |

So the moment this template's `ai-account-identity.bicep` finishes, we already have an account capability host — and the `addAccountCapabilityHost` step is guaranteed to collide.

---

## Why the existing code looked correct

`addAccountCapabilityHost` was added in [#261](https://github.com/microsoft-foundry/foundry-samples/pull/261) to support **BYO / basic-setup** scenarios where the account does not auto-create a capability host. That intent is still valid for sibling templates. The author had no way to know that *this* template — because of its `networkInjections.scenario='agent'` flag — already gets one for free, because:

- `networkInjections` schema (`scenario`, `subnetArmId`, `useMicrosoftManagedNetwork`) **is** documented in the [Bicep / ARM reference](https://learn.microsoft.com/en-us/azure/templates/microsoft.cognitiveservices/accounts) and in the [REST API spec](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2025-04-01-preview/cognitiveservices.json) (`2025-04-01-preview`, [PR #32877](https://github.com/Azure/azure-rest-api-specs/pull/32877) Mar 2025, [PR #36395](https://github.com/Azure/azure-rest-api-specs/pull/36395) Aug 2025).
- The **side effect** of `scenario='agent'` (auto-creating `@aml_aiagentservice`) is **not documented anywhere public** — not in [virtual-networks](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/how-to/virtual-networks), not in [use-your-own-resources](https://learn.microsoft.com/en-us/azure/ai-foundry/agents/how-to/use-your-own-resources).

Two unrelated edits — adding `networkInjections` here, and adding `addAccountCapabilityHost` in #261 — therefore silently collide. This PR also adds an inline block comment in `main.bicep` so the next maintainer doesn't re-introduce the same conflict.

---

## The fix (concrete changes)

In `infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/`:

**`main.bicep`** (33 ins / 25 del):

- Delete the `addAccountCapabilityHost` module block (the one that PUTs `caphostacct`).
- Delete the 4 helper vars that *only* existed to compute that module's `scope`:
  `useExistingAccount`, `existingAccountIdParts`, `existingAccountSubscriptionId`, `existingAccountResourceGroupName`.
- Remove the `addAccountCapabilityHost` entry from `addProjectCapabilityHost.dependsOn`.
- Add a block comment explaining: *"This template does not create an account-level capability host. The resource provider auto-creates `{account}@aml_aiagentservice` because we set `networkInjections.scenario='agent'`. The project capability host below binds to that auto-created one."*

**`README.md`** (6 lines changed):

- Notes / Cleanup / Module table sections updated from *"declaratively created by `add-account-capability-host.bicep`"* to *"auto-created by the resource provider via `networkInjections.scenario='agent'`"*.

**After this PR**, `addProjectCapabilityHost` still depends on `aiProjectModule`, which depends on `aiAccount` (which is when the auto-create fires). So the ordering is preserved without `addAccountCapabilityHost` in the chain.

---

## What I intentionally did NOT delete

`modules-network-secured/add-account-capability-host.bicep` is **kept** even though this template no longer calls it. Reason: PR #261 added it for BYO / basic-setup templates that do not pass `networkInjections.scenario='agent'` and therefore really do need to declare their own account capability host. Removing the file would regress those templates. `grep -r add-account-capability-host` confirms no other current external callers, but the file is preserved for the documented BYO scenario.

---

## Validation

| Check | Result |
|---|---|
| Reproduce the original 409 on a freshly created account with `networkInjections.scenario='agent'` (no Portal, no SDK, no prior deploy) | o 409 `for the same ClientId` reproduced |
| Confirm an account *without* `networkInjections` does NOT auto-create any capability host (4 control accounts) | o All 4 show empty capability host list |
| Trace the internal resource provider chain via service logs | o `account PUT` → `VirtualWorkspace/CreateOrUpdateWorkspace` 202 → `NotifyCapabilityHost` 202 (same `operation_Id`) → `{name}@aml_aiagentservice` visible via `GET /capabilityHosts` |
| Fresh end-to-end deploy of the patched template in a clean RG (`japaneast`, 2026-06-04) — variant A: `if (false)` guard | o 15/15 sub-deployments Succeeded |
| Fresh end-to-end deploy — variant B: this PR's clean removal | o **20/20 sub-deployments Succeeded, PT19M0.87S** |
| After deploy: `{account}@aml_aiagentservice` exists, project capability host bound to vectorStore/storage/threadStorage connections, `caphostacct` GET returns 404 (because we never PUT it) | o All confirmed |
| `az bicep build main.bicep` | o 0 warnings related to this change |
| Compiled `main.json` contains no `caphostacct` / `addAccountCapabilityHost` / `add-account-capability-host` references | o Confirmed |

---

## Related issues

- **Closes #312** (primary symptom)
- **Likely fixes #254 / #255 / #265** — all three show the same `for the same ClientId` 409 error string
- **Builds on #261** — does not remove the `add-account-capability-host.bicep` module file, preserving #261's BYO / basic-setup intent for sibling templates