### PR TITLE
fix(t15): gate explicit account capability host behind opt-in flag

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/README.md
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/README.md
@@ -102,7 +102,7 @@ Use the table below to choose the right infrastructure template for your scenari
   
   > **Notes:** 
   - If you do not provide an existing virtual network, the template will create a new virtual network with the default address spaces and subnets described above. If you use an existing virtual network, make sure it already contains two subnets (Agent and Private Endpoint) before deploying the template.
-  - The account-level capability host is now provisioned declaratively by `modules-network-secured/add-account-capability-host.bicep` as part of `main.bicep`. The standalone `createCapHost.sh` script is no longer required for first-time deployments; it remains in the folder only to support the cleanup-then-recreate flow described in the [Account Deletion Prerequisites and Cleanup Guidance](#account-deletion-prerequisites-and-cleanup-guidance).
+  - The account-level capability host is created implicitly by the platform via `networkInjections.scenario='agent'` on the Foundry account (see `modules-network-secured/ai-account-identity.bicep`). Only one capability host per account is allowed, so `main.bicep` does not declare a second one for fresh deployments. Set `createAccountCapabilityHost=true` only when the account has no capability host — BYO accounts without one, or after running `deleteCapHost.sh` (see [Account Deletion Prerequisites and Cleanup Guidance](#account-deletion-prerequisites-and-cleanup-guidance)).
   - You must ensure the subnet is exclusively delegated to __Microsoft.App/environments__ and cannot be used by any other Azure resources.
 
 
@@ -126,9 +126,9 @@ Before deleting an **Account** resource, it is essential to first delete the ass
 
 **1. Full Account Removal**: To completely remove an account, you must delete and purge the account. Simply deleting the account is not sufficient, you must purge so that deletion of the associated capability host is triggered. The service will automatically handle the removal of the capability host and any linked resources in the background. To purge the account, use the following [link](https://learn.microsoft.com/en-us/azure/ai-services/recover-purge-resources?tabs=azure-portal#purge-a-deleted-resource). Please allow approximately max of 20 minutes for all resources to be fully unlinked from the account.
  
-**2. Retain Account, Remove Capability Host**: If you intend to retain the account but remove the capability host, execute the script `deleteCaphost.sh` located in this folder. After deletion, allow approximately max of 20 minutes for all resources to be fully unlinked from the account. To recreate the capability host for the account, use the script `createCaphost.sh` located in the same folder.
+**2. Retain Account, Remove Capability Host**: If you intend to retain the account but remove the capability host, execute the script `deleteCapHost.sh` located in this folder. After deletion, allow approximately max of 20 minutes for all resources to be fully unlinked from the account. To recreate the capability host, redeploy `main.bicep` with `createAccountCapabilityHost=true`.
 
-> **Note**: The account-level capability host is created declaratively by `main.bicep` (via `modules-network-secured/add-account-capability-host.bicep`) on first deployment. The `createCapHost.sh` script is intended for this cleanup-then-recreate scenario only; it is not required for an initial deployment.
+> **Note**: The capability host name to enter when prompted by `deleteCapHost.sh` follows the platform convention `<accountName>@aml_aiagentservice` for implicitly-created hosts. When `createAccountCapabilityHost=true` was used previously, the same conventional name applies (it is the module's default).
 
 
 > **Important**: Before deleting the account capability host, ensure that the **project capability host** is deleted.
@@ -166,6 +166,7 @@ Note: If not provided, the following resources will be created automatically for
 | `azureStorageAccountResourceId` | ARM Resource ID of existing Storage account | `''` (creates new) | No |
 | `azureCosmosDBAccountResourceId` | ARM Resource ID of existing Cosmos DB | `''` (creates new) | No |
 | `existingAiFoundryAccountResourceId` | Full ARM Resource ID of an existing Microsoft Foundry (Cognitive Services / AIServices) account to reuse. When set, the template will not create a new account. | `''` (creates new) | No |
+| `createAccountCapabilityHost` | When `true`, the template explicitly creates the account-level capability host. Leave `false` for fresh deployments — the platform auto-creates it via `networkInjections.scenario='agent'`. Set `true` only for a BYO account with no capability host, or to recreate after running `deleteCapHost.sh`. Only one capability host per account is allowed. | `false` | No |
 | `dnsZonesSubscriptionId` | Subscription ID for existing DNS zones. Accepts either a bare GUID (`<subscription-id>`) or a full ARM subscription path (`/subscriptions/<subscription-id>`); the template normalizes the value internally. | `''` (current sub) | No |
 | `existingDnsZones` | Map of DNS zone names to resource groups | All empty (creates new) | No |
 
@@ -228,14 +229,17 @@ To use an existing Azure Storage account, set aiStorageAccountResourceId paramet
 
 5. **Use an existing Microsoft Foundry account**
 
-To reuse an existing Microsoft Foundry (Cognitive Services / AIServices kind) account instead of creating a new one, set `existingAiFoundryAccountResourceId` to the full Azure Resource ID of the target account. The template will reference the existing account, scope the account-level capability host to its resource group and subscription, and skip the deterministic-suffix account creation path (which would otherwise create a new account on every redeploy).
+To reuse an existing Microsoft Foundry (Cognitive Services / AIServices kind) account instead of creating a new one, set `existingAiFoundryAccountResourceId` to the full Azure Resource ID of the target account. The template will reference the existing account (cross-RG / cross-subscription aware) and skip the deterministic-suffix account creation path (which would otherwise create a new account on every redeploy).
 
 - param existingAiFoundryAccountResourceId string = '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}'
 - param skipModelDeployment bool = true  // recommended when the BYO account already has the required model deployment(s)
+- param createAccountCapabilityHost bool = false  // set true ONLY if the BYO account has no capability host yet
 
 💡 **When to use this**: bring-your-own-account is intended for scenarios where the Foundry account is provisioned ahead of time by a platform team or landing zone, and the workload deployment must reuse it (for compliance, naming standards, or to avoid orphaned accounts on retry).
 
 ⚠️ **Important**: When `existingAiFoundryAccountResourceId` is set, the required model deployment(s) must already exist on the BYO account if `skipModelDeployment = true`. The agent service depends on at least one model deployment matching `modelName` / `modelVersion` to function.
+
+⚠️ **Capability host on BYO accounts**: If your BYO account already has a capability host (one created via `networkInjections.scenario='agent'` at account creation, or a previous explicit creation), leave `createAccountCapabilityHost=false`. Set it to `true` only when the account has no capability host — only one capability host per account is allowed and a second create will fail.
 
 ---
 
@@ -465,8 +469,8 @@ Private endpoints ensure secure, internal-only connectivity. Private endpoints a
 
 ```text
 modules-network-secured/
-├── add-account-capability-host.bicep               # Declarative account-level capability host (replaces createCapHost.sh for first-time deployments)
-├── add-project-capability-host.bicep               # Configuring the project's capability host
+├── add-account-capability-host.bicep                # Opt-in (createAccountCapabilityHost=true): creates the account caphost when the account has none
+├── add-project-capability-host.bicep                # Configuring the project's capability host
 ├── ai-account-identity.bicep                       # Microsoft Foundry deployment and configuration (supports BYO existing account)
 ├── ai-project-identity.bicep                       # Foundry project deployment and connection configuration           
 ├── ai-search-role-assignments.bicep                # AI Search RBAC configuration

--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "14993641389519398529"
+      "templateHash": "3697601458917982261"
     }
   },
   "parameters": {
@@ -178,6 +178,13 @@
         "description": "Optional. When true, skip the model deployment. Recommended when reusing an existing account that already has the required model deployments."
       }
     },
+    "createAccountCapabilityHost": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Optional. Create the account-level capability host explicitly. Leave false for fresh deployments (platform auto-creates it via networkInjections). Set true only for a BYO account with no capability host, or to recreate after running deleteCapHost.sh."
+      }
+    },
     "aiSearchResourceId": {
       "type": "string",
       "defaultValue": "",
@@ -245,10 +252,6 @@
   "variables": {
     "uniqueSuffix": "[substring(uniqueString(format('{0}-{1}', resourceGroup().id, parameters('deploymentTimestamp'))), 0, 4)]",
     "accountName": "[toLower(format('{0}{1}', parameters('aiServices'), variables('uniqueSuffix')))]",
-    "useExistingAccount": "[not(empty(parameters('existingAiFoundryAccountResourceId')))]",
-    "existingAccountIdParts": "[split(parameters('existingAiFoundryAccountResourceId'), '/')]",
-    "existingAccountSubscriptionId": "[if(variables('useExistingAccount'), variables('existingAccountIdParts')[2], subscription().subscriptionId)]",
-    "existingAccountResourceGroupName": "[if(variables('useExistingAccount'), variables('existingAccountIdParts')[4], resourceGroup().name)]",
     "projectName": "[toLower(format('{0}{1}', parameters('firstProjectName'), variables('uniqueSuffix')))]",
     "aiServicesSanitized": "[toLower(replace(parameters('aiServices'), '-', ''))]",
     "storagePrefixMax": 18,
@@ -2595,11 +2598,10 @@
       ]
     },
     {
+      "condition": "[parameters('createAccountCapabilityHost')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2025-04-01",
-      "name": "[format('account-caphost-{0}-deployment', variables('uniqueSuffix'))]",
-      "subscriptionId": "[variables('existingAccountSubscriptionId')]",
-      "resourceGroup": "[variables('existingAccountResourceGroupName')]",
+      "name": "[format('account-capability-host-{0}-deployment', variables('uniqueSuffix'))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -2620,7 +2622,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.43.8.12551",
-              "templateHash": "18033747207003499362"
+              "templateHash": "7220206622113249406"
             }
           },
           "parameters": {
@@ -2632,15 +2634,15 @@
             },
             "accountCapHost": {
               "type": "string",
-              "defaultValue": "caphostacct",
+              "defaultValue": "[format('{0}@aml_aiagentservice', parameters('accountName'))]",
               "metadata": {
-                "description": "Name of the account-level capabilityHost"
+                "description": "Name of the account-level capability host. Defaults to the platform convention `<account>@aml_aiagentservice`."
               }
             },
             "agentSubnetResourceId": {
               "type": "string",
               "metadata": {
-                "description": "ARM resource ID of the customer agent subnet (delegated to Microsoft.App/environments)"
+                "description": "ARM resource ID of the customer agent subnet"
               }
             }
           },
@@ -2665,7 +2667,6 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', format('{0}-{1}-deployment', variables('accountName'), variables('uniqueSuffix')))]",
-        "[resourceId('Microsoft.Resources/deployments', format('{0}-private-endpoint', variables('uniqueSuffix')))]",
         "[resourceId('Microsoft.Resources/deployments', format('vnet-{0}-{1}-deployment', variables('trimVnetName'), variables('uniqueSuffix')))]"
       ]
     },
@@ -2761,7 +2762,7 @@
         }
       },
       "dependsOn": [
-        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('existingAccountSubscriptionId'), variables('existingAccountResourceGroupName')), 'Microsoft.Resources/deployments', format('account-caphost-{0}-deployment', variables('uniqueSuffix')))]",
+        "[resourceId('Microsoft.Resources/deployments', format('account-capability-host-{0}-deployment', variables('uniqueSuffix')))]",
         "[resourceId('Microsoft.Resources/deployments', format('{0}-{1}-deployment', variables('accountName'), variables('uniqueSuffix')))]",
         "[resourceId('Microsoft.Resources/deployments', format('dependencies-{0}-deployment', variables('uniqueSuffix')))]",
         "[resourceId('Microsoft.Resources/deployments', format('{0}-{1}-deployment', variables('projectName'), variables('uniqueSuffix')))]",

--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/main.bicep
@@ -106,12 +106,13 @@ param existingAiFoundryAccountResourceId string = ''
 @description('Optional. When true, skip the model deployment. Recommended when reusing an existing account that already has the required model deployments.')
 param skipModelDeployment bool = false
 
-// Re-derive BYO account context at main.bicep level so we can scope the
-// account-level capabilityHost module to the right RG/subscription.
-var useExistingAccount = !empty(existingAiFoundryAccountResourceId)
-var existingAccountIdParts = split(existingAiFoundryAccountResourceId, '/')
-var existingAccountSubscriptionId = useExistingAccount ? existingAccountIdParts[2] : subscription().subscriptionId
-var existingAccountResourceGroupName = useExistingAccount ? existingAccountIdParts[4] : resourceGroup().name
+// Account-level capability host is auto-created by the platform when
+// `networkInjections.scenario='agent'` is set on a NEW account. Only one
+// capability host per account is allowed, so this flag must stay false in that
+// case. Set true only when the account has NO capability host: a BYO account
+// without one, or after `deleteCapHost.sh` for a redeploy.
+@description('Optional. Create the account-level capability host explicitly. Leave false for fresh deployments (platform auto-creates it via networkInjections). Set true only for a BYO account with no capability host, or to recreate after running deleteCapHost.sh.')
+param createAccountCapabilityHost bool = false
 
 @description('The AI Search Service full ARM Resource ID. This is an optional field, and if not provided, the resource will be created.')
 param aiSearchResourceId string = ''
@@ -431,22 +432,18 @@ module aiSearchRoleAssignments 'modules-network-secured/ai-search-role-assignmen
   ]
 }
 
-// Account-level capabilityHost (bootstraps before project caphost).
-// The current sample relies on createCapHost.sh being run manually; making it
-// declarative keeps the flow idempotent and works for both new and BYO accounts.
-module addAccountCapabilityHost 'modules-network-secured/add-account-capability-host.bicep' = {
-  name: 'account-caphost-${uniqueSuffix}-deployment'
-  scope: resourceGroup(existingAccountSubscriptionId, existingAccountResourceGroupName)
+// Account-level capability host (opt-in). See `createAccountCapabilityHost`
+// param notes — disabled by default because the platform creates it implicitly
+// for fresh accounts. Project caphost depends on this so ordering is correct
+// when the flag is true; when false, the dependsOn entry is a no-op in ARM.
+module addAccountCapabilityHost 'modules-network-secured/add-account-capability-host.bicep' = if (createAccountCapabilityHost) {
+  name: 'account-capability-host-${uniqueSuffix}-deployment'
   params: {
     accountName: aiAccount.outputs.accountName
     agentSubnetResourceId: vnet.outputs.agentSubnetId
   }
-  dependsOn: [
-    privateEndpointAndDNS
-  ]
 }
 
-// This module creates the capability host for the project and account
 module addProjectCapabilityHost 'modules-network-secured/add-project-capability-host.bicep' = {
   name: 'capabilityHost-configuration-${uniqueSuffix}-deployment'
   params: {
@@ -458,7 +455,7 @@ module addProjectCapabilityHost 'modules-network-secured/add-project-capability-
     projectCapHost: projectCapHost
   }
   dependsOn: [
-     addAccountCapabilityHost  // account caphost must exist first
+     addAccountCapabilityHost  // no-op when createAccountCapabilityHost=false
      aiSearch      // Ensure AI Search exists
      storage       // Ensure Storage exists
      cosmosDB

--- a/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/modules-network-secured/add-account-capability-host.bicep
+++ b/infrastructure/infrastructure-setup-bicep/15-private-network-standard-agent-setup/modules-network-secured/add-account-capability-host.bicep
@@ -1,24 +1,23 @@
-// Account-level capabilityHost.
+// Account-level capability host.
 //
-// The current template ONLY creates the project-level capabilityHost in Bicep
-// and relies on the `createCapHost.sh` script being run manually before
-// deployment to bootstrap the account-level capabilityHost. When the account
-// is BYO (already-existing Foundry account that never had the script run),
-// the project capability host creation fails with:
-//   "Foundry Account capabilityHost Not Found, please retry again after
-//    creating capabilityHost for the Foundry Account."
+// Only one capability host per Foundry account is allowed. For a fresh account
+// with `networkInjections.scenario='agent'`, the platform auto-creates one
+// named `<account>@aml_aiagentservice` — this module is NOT needed.
 //
-// This module bootstraps the account-level capabilityHost in Bicep so the
-// flow is fully declarative and idempotent regardless of whether the account
-// is freshly created or pre-existing.
+// Use this module only when the account has NO capability host:
+//   - BYO account that never had one created, or
+//   - After running `deleteCapHost.sh` for a redeploy.
+//
+// Default `accountCapHost` matches the platform convention so the resulting
+// caphost is named the same as the implicit one would have been.
 
 @description('Name of the AI Foundry (Cognitive Services) account')
 param accountName string
 
-@description('Name of the account-level capabilityHost')
-param accountCapHost string = 'caphostacct'
+@description('Name of the account-level capability host. Defaults to the platform convention `<account>@aml_aiagentservice`.')
+param accountCapHost string = '${accountName}@aml_aiagentservice'
 
-@description('ARM resource ID of the customer agent subnet (delegated to Microsoft.App/environments)')
+@description('ARM resource ID of the customer agent subnet')
 param agentSubnetResourceId string
 
 resource account 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' existing = {


### PR DESCRIPTION
Template 15 (private-network-standard-agent-setup) was unconditionally provisioning the account-level capability host twice:

1. Implicitly, server-side: when the account is created with networkInjections.scenario='agent', the platform auto-provisions a capability host named '<account>@aml_aiagentservice'.
2. Explicitly: add-account-capability-host.bicep then PUT a second caphost ('caphostacct') against the same account.

Only one capability host per account is allowed. The second PUT is rejected by agent-management, ARM keeps polling, and the deployment fails after the 1h resource-provisioning timeout.

This change makes the explicit caphost opt-in via a new boolean parameter 'createAccountCapabilityHost' (default false). The module is preserved for two legitimate scenarios:

- BYO existing account that has no capability host yet (original use case of the module added in #261).
- Recovery: after running deleteCapHost.sh, redeploy with the flag set to recreate the capability host declaratively.

When the flag is true, the module defaults the resource name to '<accountName>@aml_aiagentservice' so the caphost matches the platform convention regardless of how it was created.

createCapHost.sh is removed: a user-named curl script that PUTs an account caphost competes with the implicit one in the default path and is fully superseded by the new flag.

Changes:
- main.bicep: add 'createAccountCapabilityHost' bool (default false); conditionally invoke add-account-capability-host; keep it in the project caphost's dependsOn (no-op when condition is false).
- modules-network-secured/add-account-capability-host.bicep: restored; default 'accountCapHost' is now '${accountName}@aml_aiagentservice'.
- createCapHost.sh: deleted (replaced by the flag).
- README.md: document the flag, the BYO/recovery scenarios, the platform convention for the implicit caphost name; fix deleteCaphost.sh casing; update module-structure listing.
- azuredeploy.json: regenerated via 'az bicep build'.

Model: Claude Opus 4.7
Authored-by: vtrika
(cherry picked from commit 9f40464f68b4f47bc60a64fe44c67808d09ebf14)