### PR TITLE
chore: re-restore workflows wiped by sync (post-#758 undo)

### DIFF
--- a/.github/workflows/ado-automation.yml
+++ b/.github/workflows/ado-automation.yml
@@ -1,0 +1,52 @@
+name: Create ADO user story from GitHub issue
+run-name: GitHub Issue #${{ github.event.issue.number }}
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  create-ado-story:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Build payload and call Azure DevOps
+        env:
+          ADO_ORG:            ${{ secrets.ADO_ORG }}
+          ADO_PROJECT:        ${{ secrets.ADO_PROJECT }}
+          ADO_PAT:            ${{ secrets.ADO_PAT }}
+          DRI_EMAIL:          ${{ secrets.DRI_EMAIL }}
+          ADO_AREA_PATH:      ${{ secrets.ADO_AREA_PATH }}
+          ADO_ITERATION_PATH: ${{ secrets.ADO_ITERATION_PATH }}
+          ADO_TAG:            ${{ secrets.ADO_TAG }}
+          ISSUE_TITLE:        ${{ github.event.issue.title }}
+          ISSUE_BODY:         ${{ github.event.issue.body }}
+          ISSUE_URL:          ${{ github.event.issue.html_url }}
+        run: |
+          DESCRIPTION="<div>${ISSUE_BODY//$'\n'/<br/>}<br/><br/><a href=\"$ISSUE_URL\">$ISSUE_URL</a></div>"
+
+          jq -n \
+            --arg title "$ISSUE_TITLE" \
+            --arg desc  "$DESCRIPTION" \
+            --arg area  "$ADO_AREA_PATH" \
+            --arg iter  "$ADO_ITERATION_PATH" \
+            --arg assn  "$DRI_EMAIL" \
+            --arg tags  "$ADO_TAG" \
+            '[
+               { "op":"add", "path":"/fields/System.Title",         "value":$title },
+               { "op":"add", "path":"/fields/System.Description",   "value":$desc  },
+               { "op":"add", "path":"/fields/System.AreaPath",      "value":$area  },
+               { "op":"add", "path":"/fields/System.IterationPath", "value":$iter  },
+               { "op":"add", "path":"/fields/System.AssignedTo",    "value":$assn  },
+               { "op":"add", "path":"/fields/System.Tags",          "value":$tags  }
+             ]' > /tmp/payload.json
+
+          AUTH=$(printf ":$ADO_PAT" | base64 | tr -d '\n')
+          WORK_ITEM_URL="https://dev.azure.com/${ADO_ORG}/${ADO_PROJECT}/_apis/wit/workitems/\$User%20Story?api-version=7.1-preview.3"
+
+          curl --fail-with-body -sS \
+               -H "Content-Type: application/json-patch+json" \
+               -H "Authorization: Basic $AUTH" \
+               -X POST \
+               --data-binary @/tmp/payload.json \
+               "$WORK_ITEM_URL"

--- a/.github/workflows/mirror-back.yml
+++ b/.github/workflows/mirror-back.yml
@@ -1,0 +1,97 @@
+name: Mirror Public Commits Back to Private
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Print the proposed private PR body without creating branches or PRs.'
+        required: false
+        type: boolean
+        default: true
+      public_sha:
+        description: 'Specific public commit SHA to replay or preview. Defaults to the workflow SHA.'
+        required: false
+        type: string
+        default: ''
+      private_repo:
+        description: 'Private repository that receives replay PRs.'
+        required: false
+        type: string
+        default: 'microsoft-foundry/foundry-samples-pr'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror-back-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve repositories
+        id: repos
+        env:
+          PRIVATE_REPO_INPUT: ${{ github.event.inputs.private_repo || 'microsoft-foundry/foundry-samples-pr' }}
+        run: |
+          set -euo pipefail
+          private_owner="${PRIVATE_REPO_INPUT%%/*}"
+          private_name="${PRIVATE_REPO_INPUT#*/}"
+          if [[ -z "$private_owner" || -z "$private_name" || "$private_owner" == "$private_name" ]]; then
+            echo "::error::private_repo must be owner/name; got '$PRIVATE_REPO_INPUT'"
+            exit 1
+          fi
+          echo "private_repo=$PRIVATE_REPO_INPUT" >> "$GITHUB_OUTPUT"
+          echo "private_owner=$private_owner" >> "$GITHUB_OUTPUT"
+          echo "private_name=$private_name" >> "$GITHUB_OUTPUT"
+
+      - name: Validate App secrets
+        env:
+          SYNC_APP_ID: ${{ secrets.SYNC_APP_ID }}
+          SYNC_APP_PRIVATE_KEY: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$SYNC_APP_ID" || -z "$SYNC_APP_PRIVATE_KEY" ]]; then
+            echo "::error::SYNC_APP_ID and SYNC_APP_PRIVATE_KEY must be configured on the public repository before mirror-back can mint a private-repo App token."
+            exit 1
+          fi
+
+      - name: Generate private repo App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SYNC_APP_ID }}
+          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
+          owner: ${{ steps.repos.outputs.private_owner }}
+          repositories: ${{ steps.repos.outputs.private_name }}
+
+      - name: Checkout public repo
+        uses: actions/checkout@v4
+        with:
+          path: public-repo
+          fetch-depth: 0
+
+      - name: Checkout private repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ steps.repos.outputs.private_repo }}
+          token: ${{ steps.app-token.outputs.token }}
+          path: private-repo
+          fetch-depth: 0
+          ref: main
+
+      - name: Mirror non-sync-App public commits
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PUBLIC_REPO_PATH: ${{ github.workspace }}/public-repo
+          PRIVATE_REPO_PATH: ${{ github.workspace }}/private-repo
+          PUBLIC_REPO: ${{ github.repository }}
+          PRIVATE_REPO: ${{ steps.repos.outputs.private_repo }}
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          AFTER_SHA: ${{ github.sha }}
+          PUBLIC_SHA: ${{ github.event.inputs.public_sha || '' }}
+          DRY_RUN: ${{ github.event.inputs.dry_run == 'true' && '1' || '0' }}
+        run: bash public-repo/.github/scripts/mirror-back.sh

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,23 @@
+name: Pre-Commit
+
+
+on:
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - run: pip install -r dev-requirements.txt
+      - name: Run Pre-Commit
+        run: pre-commit run --all-files

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,24 @@
+name: Pull Request Checks
+
+on:
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   branches:
+  #     - main
+  workflow_dispatch:
+
+jobs:
+  pull_request_size:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Check Pull Request Size
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }} --quiet # Need to manually fetch base branch in CI
+          python ./.github/scripts/commit-filesize-diff-summary.py --limit 1MB origin/${{ github.event.pull_request.base.ref }}..HEAD

--- a/.github/workflows/redirect-pull-requests.yml
+++ b/.github/workflows/redirect-pull-requests.yml
@@ -1,0 +1,165 @@
+name: Redirect Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  redirect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check org membership and redirect
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const author = pr.user.login;
+
+            // Allow PRs from trusted automation bots (e.g., repo sync)
+            const allowedBots = ['foundry-samples-repo-sync[bot]'];
+            if (allowedBots.includes(author)) {
+              console.log(`Skipping redirect for allowed bot: ${author}`);
+              return;
+            }
+
+            // Classify the PR author as internal (Microsoft) vs external using a
+            // cascade of signals. The GITHUB_TOKEN is an *installation* token, not
+            // a user identity in the 'microsoft' or 'microsoft-foundry' orgs, so
+            // the org-membership checks below can only confirm *public* members.
+            // Most Microsoft employees default to private membership, so we also
+            // fall back to a username pattern and a public-profile heuristic.
+            // Contributors with no public Microsoft signal anywhere will still be
+            // misclassified as external; the external-tier message below carries a
+            // universal caveat pointing self-aware internal contributors at the
+            // private staging repo, so that failure mode is self-correcting.
+            async function classifyAuthor(login) {
+              // Signal 1: microsoft-foundry org membership (public members only).
+              try {
+                const res = await github.rest.orgs.checkMembershipForUser({
+                  org: 'microsoft-foundry',
+                  username: login,
+                });
+                if (res.status === 204) return 'microsoft-foundry org member (public)';
+              } catch {}
+
+              // Signal 2: direct collaborator on this repo (team-based access is
+              // typically not visible to GITHUB_TOKEN here).
+              try {
+                const res = await github.rest.repos.checkCollaborator({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  username: login,
+                });
+                if (res.status === 204) return 'repo collaborator';
+              } catch {}
+
+              // Signal 3: microsoft org membership (public members only).
+              try {
+                const res = await github.rest.orgs.checkMembershipForUser({
+                  org: 'microsoft',
+                  username: login,
+                });
+                if (res.status === 204) return 'microsoft org member (public)';
+              } catch {}
+
+              // Signal 4: username pattern. Matches 'ms', 'msft', or 'microsoft'
+              // as a whole token bounded by start/end/'-'/'_'. Catches handles like
+              // 'aprilk-ms', 'mitsha-microsoft', 'brandom-msft' without false-
+              // positiving 'cosmos', 'awesome', etc.
+              if (/(^|[-_])(ms|msft|microsoft)([-_]|$)/i.test(login)) {
+                return 'username pattern';
+              }
+
+              // Signal 5: public profile heuristic. Strict regex on `email`, plus
+              // a normalized whole-string match on `company` against a small allow
+              // list. We deliberately do NOT scan `bio` — phrases like
+              // 'ex-Microsoft' or 'Microsoft MVP' would produce false positives.
+              try {
+                const { data: profile } = await github.rest.users.getByUsername({ username: login });
+                const email = (profile.email || '').trim();
+                if (/@([a-z0-9-]+\.)?microsoft\.com$/i.test(email)) {
+                  return 'profile email (@microsoft.com)';
+                }
+                const normalizedCompany = (profile.company || '')
+                  .trim()
+                  .toLowerCase()
+                  .replace(/^@/, '')
+                  .replace(/[.,]+$/, '');
+                const acceptedCompanies = new Set([
+                  'microsoft',
+                  'microsoft corporation',
+                  'microsoft corp',
+                  'msft',
+                ]);
+                if (acceptedCompanies.has(normalizedCompany)) {
+                  return 'profile company';
+                }
+              } catch {}
+
+              return null;
+            }
+
+            const matchedSignal = await classifyAuthor(author);
+            const isInternal = matchedSignal !== null;
+
+            console.log(`Author: ${author}, isInternal: ${isInternal}, signal: ${matchedSignal || 'none'}`);
+
+            let body;
+            if (isInternal) {
+              body = [
+                `👋 Thanks for your contribution, @${author}!`,
+                '',
+                'This repository is read-only. If you are contributing on behalf of Microsoft, please submit your PR to the private staging repository instead:',
+                '',
+                '👉 **[foundry-samples-pr](https://github.com/microsoft-foundry/foundry-samples-pr)**',
+                '',
+                'See [CONTRIBUTING.md](https://github.com/microsoft-foundry/foundry-samples/blob/main/CONTRIBUTING.md) for full instructions.',
+              ].join('\n');
+            } else {
+              body = [
+                `👋 Thanks for your interest in contributing, @${author}!`,
+                '',
+                'This repository does not accept pull requests directly. If you\'d like to report a bug, suggest an improvement, or propose a new sample, please **[open an issue](https://github.com/microsoft-foundry/foundry-samples/issues/new)** instead.',
+                '',
+                '_If you are a Microsoft-internal contributor, please submit your PR through **[foundry-samples-pr](https://github.com/microsoft-foundry/foundry-samples-pr)** instead._',
+                '',
+                'See [CONTRIBUTING.md](https://github.com/microsoft-foundry/foundry-samples/blob/main/CONTRIBUTING.md) for more details.',
+              ].join('\n');
+            }
+
+            // Skip if the bot already commented (idempotent on re-runs). We
+            // match on the staging-repo slug "microsoft-foundry/foundry-samples-pr",
+            // which both the internal- and external-tier messages above include
+            // and is structurally specific to this workflow — generic phrases
+            // like "This repository" can collide with unrelated bot comments
+            // and silently suppress the redirect.
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+            });
+            const alreadyCommented = comments.data.some(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.includes('microsoft-foundry/foundry-samples-pr')
+            );
+            if (alreadyCommented) {
+              console.log('Bot already commented on this PR, skipping.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed',
+            });

--- a/.github/workflows/run-setup.yml
+++ b/.github/workflows/run-setup.yml
@@ -1,0 +1,135 @@
+name: Run Setup
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - infrastructure/infrastructure-setup-bicep/**
+  pull_request:
+    branches: [main]
+    paths:
+      - infrastructure/infrastructure-setup-bicep/**
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  run-setup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source branch
+        uses: actions/checkout@v3
+        with:
+          # PR: checks out the PR branch, Push: checks out main, Dispatch: checks out default branch
+          ref: ${{ github.head_ref || github.ref_name }}
+          fetch-depth: 0
+
+      - name: Install Bicep
+        run: |
+          INSTALL_PATH="$RUNNER_TEMP/bicep"
+          BICEP_PATH="$RUNNER_TEMP/bicep/bicep"
+          mkdir -p "$INSTALL_PATH"
+          curl -sLo bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
+          chmod +x ./bicep
+          sudo mv ./bicep "$INSTALL_PATH"
+          echo "BICEP_PATH=$BICEP_PATH" >> $GITHUB_ENV
+          $BICEP_PATH --version
+
+      - name: Determine changed main.bicep files
+        id: changes
+        run: |
+          set -e
+          cd "$GITHUB_WORKSPACE"
+
+          EVENT="${{ github.event_name }}"
+          echo "Event: $EVENT"
+
+          if [ "$EVENT" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          elif [ "$EVENT" = "push" ]; then
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          else
+            # workflow_dispatch: use last commit as best-effort
+            BASE="$(git rev-parse HEAD~1 || echo '')"
+            HEAD="$(git rev-parse HEAD)"
+          fi
+
+          echo "Diff range: ${BASE}..${HEAD}"
+
+          # Only rebuild when main.bicep changes
+          if [ -n "$BASE" ]; then
+            MODIFIED=$(git diff --name-only "$BASE" "$HEAD" \
+              | grep -E "^infrastructure/infrastructure-setup-bicep/.*/main\.bicep$" || true)
+          else
+            MODIFIED=$(git show --name-only --pretty="" -1 \
+              | grep -E "^infrastructure/infrastructure-setup-bicep/.*/main\.bicep$" || true)
+          fi
+
+          if [ -z "$MODIFIED" ]; then
+            echo "No relevant Bicep changes detected."
+            echo "files=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Changed main.bicep files:"
+          echo "$MODIFIED"
+
+          # Output as newline-delimited list
+          {
+            echo "files<<EOF"
+            echo "$MODIFIED"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Build changed Bicep files -> azuredeploy.json
+        if: steps.changes.outputs.files != ''
+        run: |
+          set -e
+          cd "$GITHUB_WORKSPACE"
+
+          while IFS= read -r BICEP_FILE; do
+            OUTFILE="$(dirname "$BICEP_FILE")/azuredeploy.json"
+            echo "Building: $BICEP_FILE -> $OUTFILE"
+            $BICEP_PATH build "$BICEP_FILE" --outfile "$OUTFILE"
+          done <<< "${{ steps.changes.outputs.files }}"
+
+      - name: Commit + push changes back to branch (PR) or main (push)
+        if: always()
+        run: |
+          set -e
+          cd "$GITHUB_WORKSPACE"
+
+          git config --global user.email "foundry-samples@noreply.github.com"
+          git config --global user.name "foundry-samples automation"
+
+          git add -A
+
+          if git diff-index --quiet HEAD --; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git commit -m "Automatic fixes"
+
+          EVENT="${{ github.event_name }}"
+
+          # If PR is from a fork, pushing will be rejected. Detect and skip.
+          if [ "$EVENT" = "pull_request" ]; then
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+              echo "PR is from a fork; cannot push changes back to fork branch. Skipping push."
+              exit 0
+            fi
+            BRANCH="${{ github.head_ref }}"
+            echo "Pushing fixes to PR branch: $BRANCH"
+            git push origin "HEAD:refs/heads/$BRANCH"
+            exit 0
+          fi
+
+          # push / workflow_dispatch
+          BRANCH="${{ github.ref_name }}"
+          echo "Pushing fixes to branch: $BRANCH"
+          git push origin "HEAD:refs/heads/$BRANCH"


### PR DESCRIPTION
Same restore as #758, which was undone hours after merge by commit c0d740d (the sync of private PR #418, which had zero `.github/` changes itself).

**The 6 files restored** (byte-identical hashes to #758):
- `.github/workflows/ado-automation.yml`
- `.github/workflows/mirror-back.yml`
- `.github/workflows/pre-commit.yml`
- `.github/workflows/pull-request-checks.yml`
- `.github/workflows/redirect-pull-requests.yml` (the auto-close that redirects external contributor PRs to the internal repo)
- `.github/workflows/run-setup.yml`

## Why this is a re-restore

PR #707 also restored these previously after a similar sync wipe. Pattern: each time the sync runs, the import builds the sync branch from filtered private history whose parent ancestry doesn't include direct-public commits → public-only excluded paths drop out.

## Plan to stop the cycle

This PR is a stopgap. Durable fix (separate work, tracked):
1. Add a protected-path invariant guard to `sync-core.sh` that fails the sync before push if any of `.github/workflows/`, `README.md`, `CONTRIBUTING.md`, `docs/` differ from the public main captured at run start
2. Resolve the GitHub App `workflows: write` permission gap (currently the App's install on `microsoft-foundry` org has not accepted the upgraded permission, blocking the overlay-based restore from working post-sync)
3. Migrate from `public-overlay/` re-injection to post-import restore-from-public-head (cleaner mental model, no duplication in private)

## Verification

All 6 blob hashes verified byte-identical to source (the pre-deletion commits in private's history before PRs #448 and #451 emptied `public-overlay/.github/workflows/`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>