### PR TITLE
Restore post-PR-#463 sample delta (manual cherry-pick from private)

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network/modules-network-secured/managed-network.bicep
+++ b/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network/modules-network-secured/managed-network.bicep
@@ -39,6 +39,22 @@ resource managedNetwork 'Microsoft.CognitiveServices/accounts/managednetworks@20
 
 // Outbound PE rules allow the managed VNet (where hosted agents run) to reach dependent resources
 // Rules must be created sequentially to avoid conflicting state errors on the managed network
+
+// The agent needs a PE back to the Foundry/AI Services endpoint itself (public access is disabled)
+#disable-next-line BCP081
+resource aiServicesOutboundRule 'Microsoft.CognitiveServices/accounts/managedNetworks/outboundRules@2025-10-01-preview' = {
+  parent: managedNetwork
+  name: 'aiservices-account-rule'
+  properties: {
+    type: 'PrivateEndpoint'
+    destination: {
+      serviceResourceId: aiAccount.id
+      subresourceTarget: 'account'
+    }
+    category: 'UserDefined'
+  }
+}
+
 #disable-next-line BCP081
 resource storageOutboundRule 'Microsoft.CognitiveServices/accounts/managedNetworks/outboundRules@2025-10-01-preview' = {
   parent: managedNetwork
@@ -51,6 +67,7 @@ resource storageOutboundRule 'Microsoft.CognitiveServices/accounts/managedNetwor
     }
     category: 'UserDefined'
   }
+  dependsOn: [aiServicesOutboundRule]
 }
 
 #disable-next-line BCP081

--- a/infrastructure/infrastructure-setup-terraform/18-managed-virtual-network/ai-foundry.tf
+++ b/infrastructure/infrastructure-setup-terraform/18-managed-virtual-network/ai-foundry.tf
@@ -154,6 +154,39 @@ resource "azapi_resource" "managed_network" {
   }
 }
 
+# Outbound PE rules allow the managed VNet (where hosted agents run) to reach
+# dependent resources. The managed network API does not support concurrent
+# outbound rule creation, so rules are serialized via depends_on to avoid
+# "Resource is in conflicting state" errors. Chain order:
+# aiservices -> storage -> cosmos -> search
+
+# Managed Network Outbound Rule for the AI Services account itself
+# The agent needs a PE back to the Foundry/AI Services endpoint because
+# publicNetworkAccess is disabled on the account.
+resource "azapi_resource" "aiservices_outbound_rule" {
+  type      = "Microsoft.CognitiveServices/accounts/managedNetworks/outboundRules@2025-10-01-preview"
+  name      = "aiservices-account-rule"
+  parent_id = azapi_resource.managed_network.id
+
+  schema_validation_enabled = false
+
+  body = {
+    properties = {
+      type = "PrivateEndpoint"
+      destination = {
+        serviceResourceId = azapi_resource.cognitive_account.id
+        subresourceTarget = "account"
+      }
+      category = "UserDefined"
+    }
+  }
+
+  depends_on = [
+    azapi_resource.managed_network,
+    azurerm_role_assignment.foundry_network_connection_approver
+  ]
+}
+
 # Wait for Storage Account to be fully created before creating outbound rule
 resource "time_sleep" "wait_storage" {
   count           = var.enable_storage ? 1 : 0
@@ -187,6 +220,7 @@ resource "azapi_resource" "storage_outbound_rule" {
 
   depends_on = [
     time_sleep.wait_storage,
+    azapi_resource.aiservices_outbound_rule,
     azurerm_role_assignment.foundry_network_connection_approver,
     azurerm_role_assignment.foundry_storage_blob,
     azurerm_role_assignment.foundry_storage_contributor
@@ -288,6 +322,7 @@ resource "time_sleep" "wait_outbound_rules" {
   create_duration = "600s"
 
   depends_on = [
+    azapi_resource.aiservices_outbound_rule,
     azapi_resource.storage_outbound_rule,
     azapi_resource.cosmos_outbound_rule,
     azapi_resource.aisearch_outbound_rule
@@ -330,6 +365,7 @@ resource "azapi_resource" "project_capability_host" {
     time_sleep.wait_project_rbac,
     # CRITICAL: All outbound rules must be created AND provisioned before capability host
     # The capability host validates that outbound rules exist and are in Succeeded state
+    azapi_resource.aiservices_outbound_rule,
     azapi_resource.storage_outbound_rule,
     azapi_resource.cosmos_outbound_rule,
     azapi_resource.aisearch_outbound_rule,

--- a/infrastructure/infrastructure-setup-terraform/18-managed-virtual-network/aisearch.tf
+++ b/infrastructure/infrastructure-setup-terraform/18-managed-virtual-network/aisearch.tf
@@ -85,6 +85,7 @@ resource "azapi_resource" "aisearch_outbound_rule" {
 
   depends_on = [
     time_sleep.wait_aisearch,
+    azapi_resource.cosmos_outbound_rule,
     azurerm_role_assignment.foundry_network_connection_approver,
     azurerm_role_assignment.project_search_index,
     azurerm_role_assignment.project_search_contributor

--- a/infrastructure/infrastructure-setup-terraform/18-managed-virtual-network/cosmos.tf
+++ b/infrastructure/infrastructure-setup-terraform/18-managed-virtual-network/cosmos.tf
@@ -99,6 +99,7 @@ resource "azapi_resource" "cosmos_outbound_rule" {
 
   depends_on = [
     time_sleep.wait_cosmos,
+    azapi_resource.storage_outbound_rule,
     azurerm_role_assignment.foundry_network_connection_approver,
     azurerm_role_assignment.foundry_cosmos_contributor,
     azurerm_role_assignment.project_cosmos_reader,

--- a/samples/python/hosted-agents/bring-your-own/voicelive/client/voicelive_client.py
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/client/voicelive_client.py
@@ -45,7 +45,7 @@ except ImportError:
     sys.exit(1)
 
 # Azure VoiceLive SDK imports
-from azure.ai.voicelive.aio import VoiceLiveConnection, connect, AgentSessionConfig
+from azure.ai.voicelive.aio import VoiceLiveConnection, connect
 from azure.ai.voicelive.models import (
     AudioEchoCancellation,
     AudioNoiseReduction,
@@ -245,7 +245,7 @@ class AudioProcessor:
 
 class AgentV2VoiceAssistant:
     """
-    Voice assistant using Azure AI Foundry agent with AgentSessionConfig.
+    Voice assistant using Azure AI Foundry agent.
 
     This demonstrates the new pattern where the agent is configured at
     connection time using AgentSessionConfig, rather than as a tool in the session.
@@ -255,11 +255,13 @@ class AgentV2VoiceAssistant:
         self,
         endpoint: str,
         credential: AsyncTokenCredential,
-        agent_config: AgentSessionConfig,
+        agent_name: str,
+        project_name: str,
     ) -> None:
         self.endpoint = endpoint
         self.credential = credential
-        self.agent_config = agent_config
+        self.agent_name = agent_name
+        self.project_name = project_name
         self.connection: Optional[VoiceLiveConnection] = None
         self.audio_processor: Optional[AudioProcessor] = None
         self.session_ready = False
@@ -269,15 +271,16 @@ class AgentV2VoiceAssistant:
         try:
             logger.info(
                 "Connecting to VoiceLive API with agent %s for project %s",
-                self.agent_config.get("agent_name"),
-                self.agent_config.get("project_name"),
+                self.agent_name,
+                self.project_name,
             )
 
             # Connect using AgentSessionConfig
             async with connect(
                 endpoint=self.endpoint,
                 credential=self.credential,
-                agent_config=self.agent_config,  # Agent configured at connection time
+                agent_name=self.agent_name,
+                project_name=self.project_name,
             ) as connection:
                 conn = connection
                 self.connection = conn
@@ -295,8 +298,8 @@ class AgentV2VoiceAssistant:
                 logger.info("Voice assistant ready! Start speaking...")
                 print("\n" + "=" * 60)
                 print("🎤 AGENT V2 VOICE ASSISTANT READY")
-                print(f"Agent: {self.agent_config.get('agent_name')}")
-                print(f"Project: {self.agent_config.get('project_name')}")
+                print(f"Agent: {self.agent_name}")
+                print(f"Project: {self.project_name}")
                 print("Start speaking to begin conversation")
                 print("Press Ctrl+C to exit")
                 print("=" * 60 + "\n")
@@ -424,10 +427,6 @@ class AgentV2VoiceAssistant:
 
 async def run_assistant(endpoint: str, agent_name: str, agent_project_name: str):
     """Run the voice assistant."""
-    agent_config: AgentSessionConfig = {
-        "agent_name": agent_name,
-        "project_name": agent_project_name,
-    }
 
     credential: AsyncTokenCredential = DefaultAzureCredential()
     logger.info("Using DefaultAzureCredential")
@@ -435,7 +434,8 @@ async def run_assistant(endpoint: str, agent_name: str, agent_project_name: str)
     assistant = AgentV2VoiceAssistant(
         endpoint=endpoint,
         credential=credential,
-        agent_config=agent_config,
+        agent_name=agent_name,
+        project_name=agent_project_name,
     )
 
     await assistant.start()

--- a/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/README.md
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/README.md
@@ -226,7 +226,7 @@ Once the agent is deployed to Microsoft Foundry, you can interact with it using 
 - **Python 3.10+** with the following packages:
 
 ```bash
-pip install azure-ai-voicelive[aiohttp]==1.2.0b5 azure-identity pyaudio
+pip install azure-ai-voicelive[aiohttp]==1.3.0b1 azure-identity pyaudio
 ```
 
 > [!NOTE]


### PR DESCRIPTION
## Summary

Manual cherry-pick of the 6 customer-facing files from private commits `7215e588..0e67b24d` that have not flowed to public via the normal sync pipeline. Sync was paused tonight pending a fix for an architectural bug in the protected-paths guard from PR microsoft-foundry/foundry-samples-pr#463; see microsoft-foundry/foundry-samples-pr#484 for the full diagnosis.

## What's included

| Source PR (private) | What it changes |
|---|---|
| [microsoft-foundry/foundry-samples-pr#470](https://github.com/microsoft-foundry/foundry-samples-pr/pull/470) — Voice Live testing: update to use latest SDK | `samples/python/hosted-agents/bring-your-own/voicelive/client/voicelive_client.py`, `samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/README.md` |
| [microsoft-foundry/foundry-samples-pr#465](https://github.com/microsoft-foundry/foundry-samples-pr/pull/465) — fix: add outbound PE rule for AI Services account (managed VNet) | `infrastructure/infrastructure-setup-bicep/18-managed-virtual-network/modules-network-secured/managed-network.bicep` |
| [microsoft-foundry/foundry-samples-pr#474](https://github.com/microsoft-foundry/foundry-samples-pr/pull/474) — fix(tf-18): add AI Services account outbound PE rule for managed VNet | `infrastructure/infrastructure-setup-terraform/18-managed-virtual-network/{ai-foundry,aisearch,cosmos}.tf` |
| [microsoft-foundry/foundry-samples-pr#250](https://github.com/microsoft-foundry/foundry-samples-pr/pull/250) — Hosted Agents: post per-sample validation commit statuses (single-sample canary) | (no sample-tree changes; entirely within `.azure-pipelines/`, which is sync-excluded — no rows here) |

Diff stat: **6 files changed, 70 insertions(+), 15 deletions(-)**.

## What's excluded (and why)

The private delta also includes changes to `.github/`, `docs/`, `public-overlay/`, and `.azure-pipelines/`. These paths are sync-excluded by `.github/sync-config.json` on the private repo and do not belong on public:

- PR microsoft-foundry/foundry-samples-pr#463 (Implement protected-paths guard + drop workflows from overlay) — entirely under `.github/` and `public-overlay/`.
- PR microsoft-foundry/foundry-samples-pr#481 (Add `seed_blocked_paths` workflow_dispatch input) — entirely under `.github/` and `docs/`.

## Why a manual PR

Investigation tonight revealed that `git fast-export`, when given both `--import-marks` and pathspec filters, forces `--full-tree` mode. The sync branch tip's tree is therefore built from `M` records covering only the include-set; files under `.github/` are absent from the sync-branch-tip tree even when they're on public main. The protected-paths guard from PR microsoft-foundry/foundry-samples-pr#463 reads sync-branch-tip blobs for protected workflows and hard-fails when they're absent — so once workflow files exist on public main, every sync trips the guard.

Three runs failed tonight with this signature:
- [run 27173996152](https://github.com/microsoft-foundry/foundry-samples-pr/actions/runs/27173996152) — first real sync after PR microsoft-foundry/foundry-samples-pr#463.
- [run 27176407548](https://github.com/microsoft-foundry/foundry-samples-pr/actions/runs/27176407548) — recovery dry-run anchored to morning's sync output (80c39cbd).
- [run 27176571437](https://github.com/microsoft-foundry/foundry-samples-pr/actions/runs/27176571437) — recovery dry-run anchored to current public main (550a9148).

This PR bypasses the sync pipeline entirely so customer-facing changes don't wait on the guard fix.

## Verification

- Applied private's `git diff 7215e588..0e67b24d` over the 6 include-set paths to clean public main (550a9148) — patch applied with no conflicts.
- Spot-checked against the morning's 46-path historical validation block-list — none of the 6 files are blocklisted.
- `git diff --stat` matches private's reported delta.

## Follow-ups

- microsoft-foundry/foundry-samples-pr#484 — pauses scheduled cron and documents the bug.
- (Pending) Fix the guard by replacing the blob comparison with a `git merge-tree --write-tree` simulation against current public main; check protected paths on the result tree instead of the sync-branch-tip tree. Add integration tests covering the real fast-export/fast-import + pathspec + marks combination.

## Authorship note

The author of each upstream PR is preserved in the table above. The commit author on this PR is the operator performing the manual cherry-pick (no upstream attribution rewrite possible since this is a single squashed delta).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>