### PR TITLE
Fix P0 local-auth and ACR DNS defaults

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/main.bicepparam
+++ b/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/main.bicepparam
@@ -33,6 +33,7 @@ param existingDnsZones = {
   'privatelink.search.windows.net': ''           
   'privatelink.blob.core.windows.net': ''                            
   'privatelink.documents.azure.com': ''
+  'privatelink.azurecr.io': ''
   'privatelink.azure-api.net': ''                       
 }
 
@@ -44,6 +45,7 @@ param dnsZoneNames = [
   'privatelink.search.windows.net'
   'privatelink.blob.core.windows.net'
   'privatelink.documents.azure.com'
+  'privatelink.azurecr.io'
   'privatelink.azure-api.net'
 ]
 
@@ -54,4 +56,3 @@ param dnsZoneNames = [
 param vnetAddressPrefix = ''
 param agentSubnetPrefix = ''
 param peSubnetPrefix = ''
-

--- a/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/modules-network-secured/ai-account-identity.bicep
+++ b/infrastructure/infrastructure-setup-bicep/16-private-network-standard-agent-apim-setup/modules-network-secured/ai-account-identity.bicep
@@ -37,7 +37,7 @@ resource account 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
       }
       ] : null )
     // Set disable local auth to true or false. Agent service does not support API key based authentication
-    disableLocalAuth: false
+    disableLocalAuth: true
   }
 }
 

--- a/infrastructure/infrastructure-setup-bicep/17-private-network-standard-user-assigned-identity-agent-setup/main.bicepparam
+++ b/infrastructure/infrastructure-setup-bicep/17-private-network-standard-user-assigned-identity-agent-setup/main.bicepparam
@@ -30,7 +30,8 @@ param existingDnsZones = {
   'privatelink.cognitiveservices.azure.com': ''               
   'privatelink.search.windows.net': ''           
   'privatelink.blob.core.windows.net': ''                            
-  'privatelink.documents.azure.com': ''                       
+  'privatelink.documents.azure.com': ''
+  'privatelink.azurecr.io': ''                       
 }
 
 //DNSZones names for validating if they exist
@@ -41,6 +42,7 @@ param dnsZoneNames = [
   'privatelink.search.windows.net'
   'privatelink.blob.core.windows.net'
   'privatelink.documents.azure.com'
+  'privatelink.azurecr.io'
 ]
 
 
@@ -67,4 +69,3 @@ param dnsZoneNames = [
 param vnetAddressPrefix = ''
 param agentSubnetPrefix = ''
 param peSubnetPrefix = ''
-

--- a/infrastructure/infrastructure-setup-bicep/17-private-network-standard-user-assigned-identity-agent-setup/modules-network-secured/ai-account-identity.bicep
+++ b/infrastructure/infrastructure-setup-bicep/17-private-network-standard-user-assigned-identity-agent-setup/modules-network-secured/ai-account-identity.bicep
@@ -41,7 +41,7 @@ resource account 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
       }
       ] : null )
     // Set disable local auth to true or false. Agent service does not support API key based authentication
-    disableLocalAuth: false
+    disableLocalAuth: true
   }
 }
 

--- a/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network/modules-network-secured/ai-account-identity.bicep
+++ b/infrastructure/infrastructure-setup-bicep/18-managed-virtual-network/modules-network-secured/ai-account-identity.bicep
@@ -35,7 +35,7 @@ resource account 'Microsoft.CognitiveServices/accounts@2025-10-01-preview' = {
         useMicrosoftManagedNetwork: true
       }
     ]
-    disableLocalAuth: false
+    disableLocalAuth: true
   }
 }
 

--- a/infrastructure/infrastructure-setup-bicep/19-private-network-agent-tools/main.bicepparam
+++ b/infrastructure/infrastructure-setup-bicep/19-private-network-agent-tools/main.bicepparam
@@ -77,5 +77,6 @@ param existingDnsZones = {
   'privatelink.search.windows.net':          { subscriptionId: '', resourceGroup: '' }
   'privatelink.blob.core.windows.net':       { subscriptionId: '', resourceGroup: '' }
   'privatelink.documents.azure.com':         { subscriptionId: '', resourceGroup: '' }
+  'privatelink.azurecr.io':                  { subscriptionId: '', resourceGroup: '' }
   'privatelink.fabric.microsoft.com':        { subscriptionId: '', resourceGroup: '' }
 }

--- a/infrastructure/infrastructure-setup-bicep/19-private-network-agent-tools/modules-network-secured/ai-account-identity.bicep
+++ b/infrastructure/infrastructure-setup-bicep/19-private-network-agent-tools/modules-network-secured/ai-account-identity.bicep
@@ -41,7 +41,7 @@ resource account 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' = {
           }
         ]
       : null)
-    disableLocalAuth: false
+    disableLocalAuth: true
   }
 }
 


### PR DESCRIPTION
- Set disableLocalAuth=true in templates 16, 17, 18, and 19 AI account modules to match templates 15 and 15a.
- Add privatelink.azurecr.io defaults to 16/17/19 parameter files so default ACR paths are fully configured.