### PR TITLE
fix: replace agent-framework meta-package with agent-framework-foundry to resolve pip conflicts

### DIFF
--- a/samples/python/hosted-agents/agent-framework/responses/01-basic/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/01-basic/requirements.txt
@@ -1,2 +1,6 @@
-agent-framework>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0

--- a/samples/python/hosted-agents/agent-framework/responses/02-tools/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/02-tools/requirements.txt
@@ -1,2 +1,6 @@
-agent-framework>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0

--- a/samples/python/hosted-agents/agent-framework/responses/03-mcp/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/03-mcp/requirements.txt
@@ -1,3 +1,6 @@
-agent-framework>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
 mcp>=1.24.0,<2

--- a/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox/requirements.txt
@@ -1,7 +1,7 @@
-# `agent-framework[foundry]` is required because main.py imports
-# `from agent_framework.foundry import FoundryChatClient`. In 1.3+ the
-# foundry submodule is an optional extra; installing the bare package
-# leaves agent_framework.foundry unimportable and the container crashes
-# at startup so /readiness never returns 200 -> 424 session_not_ready.
-agent-framework[foundry]>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package
+# (or agent-framework[foundry]) to avoid pip resolution failures:
+# agent-framework pins agent-framework-core==1.2.2 but
+# agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0

--- a/samples/python/hosted-agents/agent-framework/responses/05-workflows/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/05-workflows/requirements.txt
@@ -1,2 +1,6 @@
-agent-framework>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0

--- a/samples/python/hosted-agents/agent-framework/responses/06-files/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/06-files/requirements.txt
@@ -1,2 +1,6 @@
-agent-framework
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0

--- a/samples/python/hosted-agents/agent-framework/responses/07-skills/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/07-skills/requirements.txt
@@ -1,2 +1,6 @@
-agent-framework>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0

--- a/samples/python/hosted-agents/agent-framework/responses/07-teams-activity/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/07-teams-activity/requirements.txt
@@ -1,7 +1,7 @@
-# `agent-framework[foundry]` is required because main.py imports
-# `from agent_framework.foundry import FoundryChatClient`. In 1.3+ the
-# foundry submodule is an optional extra; installing the bare package
-# leaves agent_framework.foundry unimportable and the container crashes
-# at startup so /readiness never returns 200 -> 424 session_not_ready.
-agent-framework[foundry]>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package
+# (or agent-framework[foundry]) to avoid pip resolution failures:
+# agent-framework pins agent-framework-core==1.2.2 but
+# agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0

--- a/samples/python/hosted-agents/agent-framework/responses/08-observability/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/08-observability/requirements.txt
@@ -1,2 +1,6 @@
-agent-framework
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0

--- a/samples/python/hosted-agents/agent-framework/responses/09-declarative-customer-support/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/09-declarative-customer-support/requirements.txt
@@ -1,2 +1,7 @@
-agent-framework
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
+agent-framework-declarative
 agent-framework-foundry-hosting
+mcp>=1.24.0

--- a/samples/python/hosted-agents/agent-framework/responses/10-downstream-azure/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/10-downstream-azure/requirements.txt
@@ -1,4 +1,8 @@
-agent-framework>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0
 azure-storage-blob
 azure-servicebus

--- a/samples/python/hosted-agents/agent-framework/responses/15-optimization-travel-approver/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/15-optimization-travel-approver/requirements.txt
@@ -1,4 +1,8 @@
-agent-framework>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0
 azure-identity>=1.15.0
 azure-ai-agentserver-optimization>=1.0.0b1

--- a/samples/python/hosted-agents/agent-framework/responses/16-content-safety-guardrail/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/16-content-safety-guardrail/requirements.txt
@@ -1,2 +1,6 @@
-agent-framework>=1.2.2
+# Use agent-framework-foundry instead of the agent-framework meta-package to
+# avoid pip resolution failures: agent-framework pins agent-framework-core==1.2.2
+# but agent-framework-orchestrations 1.0.0 requires agent-framework-core>=1.9.0.
+agent-framework-foundry
 agent-framework-foundry-hosting
+mcp>=1.24.0


### PR DESCRIPTION
## Problem

`agent-framework>=1.2.2` in `requirements.txt` can resolve to version 1.2.2, which pins `agent-framework-core==1.2.2`. However, `agent-framework-orchestrations 1.0.0` (a transitive dependency) requires `agent-framework-core>=1.9.0`. This makes pip unable to resolve dependencies, breaking the hosted agent quickstart and all downstream samples (Tracing, Evaluate).

```
ERROR: Cannot install agent-framework-core and agent-framework-core[all]==1.2.2
  agent-framework 1.2.2 depends on agent-framework-core==1.2.2
  agent-framework-orchestrations 1.0.0 depends on agent-framework-core>=1.9.0
ERROR: ResolutionImpossible
```

## Fix

Replace `agent-framework` / `agent-framework[foundry]>=1.2.2` with the narrow `agent-framework-foundry` subpackage in all affected samples. This follows the pattern already used successfully by samples **11-azure-search-rag**, **12-foundry-skills**, and **13-foundry-memory**.

Also adds `mcp>=1.24.0` as an explicit dependency where missing, since it is needed at runtime but not declared by `agent-framework-core`.

## Affected samples (13 total)

- `01-basic` (Hosted Agent quickstart)
- `02-tools`
- `03-mcp`
- `04-foundry-toolbox`
- `05-workflows`
- `06-files`
- `07-skills`
- `07-teams-activity`
- `08-observability`
- `09-declarative-customer-support`
- `10-downstream-azure`
- `15-optimization-travel-approver`
- `16-content-safety-guardrail`

## Verification

Tested all 13 samples with `pip install --dry-run` using Python 3.13:

| Scenario | Result |
|----------|--------|
| **Before** (`agent-framework==1.2.2`) | ❌ `ResolutionImpossible` for all 13 |
| **After** (`agent-framework-foundry`) | ✅ Resolves cleanly for all 13 |

cc @AniketSinha-Microsoft