### PR TITLE
fix: Spaces are not allowed in the agent_name

### DIFF
--- a/samples/python/enterprise-agent-tutorial/1-idea-to-prototype/main.py
+++ b/samples/python/enterprise-agent-tutorial/1-idea-to-prototype/main.py
@@ -170,7 +170,7 @@ CAPABILITIES:
     print(f"   Total tools: {len(tools)}")
 
     agent = project_client.agents.create_version(
-        agent_name="Modern Workplace Assistant",
+        agent_name="Modern-Workplace-Assistant",
         definition=PromptAgentDefinition(
             model=os.environ["FOUNDRY_MODEL_NAME"],
             instructions=instructions,


### PR DESCRIPTION
This pull request makes a minor update to the agent creation process by standardizing the agent name format. Agent name with spaces are not allowed. we are getting the following error when we try to create an agent with spaces.

<img width="2236" height="423" alt="image" src="https://github.com/user-attachments/assets/ac0d5da3-6de8-4c8a-b313-0f7ca60a40a4" />



- Changed the `agent_name` parameter from "Modern Workplace Assistant" to "Modern-Workplace-Assistant" in the `create_workplace_assistant` function in `main.py`.