### PR TITLE
Add default App Insights provisioning to core templates

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/00-basic/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/00-basic/main.bicep
@@ -1,6 +1,7 @@
 param aiFoundryName string = 'foundry-name'
 param aiProjectName string = '${aiFoundryName}-proj'
 param location string = 'eastus2'
+param appInsightsName string = 'appi-${aiFoundryName}'
 
 /*
   An AI Foundry resources is a variant of a CognitiveServices/account resource type
@@ -78,3 +79,53 @@ resource modelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2025-
 //     }
 //   }
 // }
+
+/*
+  A Log Analytics workspace backing Application Insights (workspace-based Application Insights is recommended).
+*/
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: 'law-${aiFoundryName}'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+/*
+  Application Insights enables Tracing in AI Foundry so you can monitor and debug agent runs,
+  evaluations, and other AI workloads end-to-end.
+*/
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+  }
+}
+
+/*
+  Connect Application Insights to the AI Foundry account so all projects can use it for tracing.
+  The connection string is shared with AI Foundry so it can route telemetry to this resource.
+*/
+resource appInsightsConnection 'Microsoft.CognitiveServices/accounts/connections@2025-06-01' = {
+  name: '${aiFoundryName}-appinsights'
+  parent: aiFoundry
+  properties: {
+    category: 'AppInsights'
+    target: appInsights.id
+    authType: 'ApiKey'
+    isSharedToAll: true
+    credentials: {
+      key: appInsights.properties.ConnectionString
+    }
+    metadata: {
+      ApiType: 'Azure'
+      ResourceId: appInsights.id
+    }
+  }
+}

--- a/infrastructure/infrastructure-setup-bicep/01-connections/connection-application-insights.bicep
+++ b/infrastructure/infrastructure-setup-bicep/01-connections/connection-application-insights.bicep
@@ -9,7 +9,7 @@ param aiFoundryName string = '<your-foundry-name>'
 param connectedResourceName string = 'appi${aiFoundryName}'
 param location string = 'westus'
 
-// Whether to create a new Azure AI Search resource
+// Whether to create a new Application Insights resource
 @allowed([
   'new'
   'existing'
@@ -22,18 +22,31 @@ resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' exi
   scope: resourceGroup()
 }
 
-// Conditionally refers your existing Azure AI Search resource
+// Log Analytics workspace backing the new Application Insights instance (workspace-based)
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = if (newOrExisting == 'new') {
+  name: 'law-${connectedResourceName}'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// Conditionally refers your existing Application Insights resource
 resource existingAppInsights 'Microsoft.Insights/components@2020-02-02' existing = if (newOrExisting == 'existing') {
   name: connectedResourceName
 }
 
-// Conditionally creates a new Azure AI Search resource
+// Conditionally creates a new Application Insights resource (workspace-based)
 resource newAppInsights 'Microsoft.Insights/components@2020-02-02' = if (newOrExisting == 'new') {
   name: connectedResourceName
   location: location
   kind: 'web'
   properties: {
     Application_Type: 'web'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
   }
 }
 

--- a/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/40-basic-agent-setup/main.bicep
@@ -125,6 +125,56 @@ resource modelDeployment 'Microsoft.CognitiveServices/accounts/deployments@2024-
   }
 }
 
+/*
+  A Log Analytics workspace backing Application Insights (workspace-based Application Insights is recommended).
+*/
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: 'law-${accountName}'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+/*
+  Application Insights enables Tracing in AI Foundry so you can monitor and debug agent runs,
+  evaluations, and other AI workloads end-to-end.
+*/
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: 'appi-${accountName}'
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+  }
+}
+
+/*
+  Connect Application Insights to the AI Foundry account so all projects can use it for tracing.
+  The connection string is shared with AI Foundry so it can route telemetry to this resource.
+*/
+resource appInsightsConnection 'Microsoft.CognitiveServices/accounts/connections@2025-04-01-preview' = {
+  name: '${accountName}-appinsights'
+  parent: account
+  properties: {
+    category: 'AppInsights'
+    target: appInsights.id
+    authType: 'ApiKey'
+    isSharedToAll: true
+    credentials: {
+      key: appInsights.properties.ConnectionString
+    }
+    metadata: {
+      ApiType: 'Azure'
+      ResourceId: appInsights.id
+    }
+  }
+}
+
 output accountName string = account.name
 output projectName string = project.name
 output accountEndpoint string = account.properties.endpoint

--- a/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/main.bicep
@@ -81,6 +81,8 @@ var projectName = toLower('${firstProjectName}${uniqueSuffix}')
 var cosmosDBName = toLower('${uniqueSuffix}cosmosdb')
 var aiSearchName = toLower('${uniqueSuffix}search')
 var azureStorageName = toLower('${uniqueSuffix}storage')
+var appInsightsName = toLower('${uniqueSuffix}appi')
+var logAnalyticsWorkspaceName = toLower('${uniqueSuffix}law')
 
 // Check if existing resources have been passed in
 var storagePassedIn = azureStorageAccountResourceId != ''
@@ -271,4 +273,18 @@ module cosmosContainerRoleAssignments 'modules-standard/cosmos-container-role-as
 dependsOn: [
   addProjectCapabilityHost, storageContainersRoleAssignment
   ]
+}
+
+/*
+  Creates Application Insights and connects it to the AI Foundry account so that Tracing
+  is available in all projects without any additional configuration.
+*/
+module applicationInsights 'modules-standard/application-insights.bicep' = {
+  name: 'app-insights-${uniqueSuffix}-deployment'
+  params: {
+    location: location
+    appInsightsName: appInsightsName
+    logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
+    accountName: aiAccount.outputs.accountName
+  }
 }

--- a/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/modules-standard/application-insights.bicep
+++ b/infrastructure/infrastructure-setup-bicep/41-standard-agent-setup/modules-standard/application-insights.bicep
@@ -1,0 +1,60 @@
+// Creates Application Insights (workspace-based) and wires it to an AI Foundry account connection
+// so that Tracing is available for all projects under that account.
+
+@description('Azure region of the deployment')
+param location string
+
+@description('Name of the Application Insights resource')
+param appInsightsName string
+
+@description('Name of the Log Analytics workspace that backs Application Insights')
+param logAnalyticsWorkspaceName string
+
+@description('Name of the existing AI Foundry account to attach the connection to')
+param accountName string
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: logAnalyticsWorkspaceName
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: appInsightsName
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+  }
+}
+
+resource account 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' existing = {
+  name: accountName
+}
+
+resource appInsightsConnection 'Microsoft.CognitiveServices/accounts/connections@2025-04-01-preview' = {
+  name: '${accountName}-appinsights'
+  parent: account
+  properties: {
+    category: 'AppInsights'
+    target: appInsights.id
+    authType: 'ApiKey'
+    isSharedToAll: true
+    credentials: {
+      key: appInsights.properties.ConnectionString
+    }
+    metadata: {
+      ApiType: 'Azure'
+      ResourceId: appInsights.id
+    }
+  }
+}
+
+output appInsightsName string = appInsights.name
+output appInsightsId string = appInsights.id

--- a/infrastructure/infrastructure-setup-terraform/00-basic/code/monitor.tf
+++ b/infrastructure/infrastructure-setup-terraform/00-basic/code/monitor.tf
@@ -1,0 +1,46 @@
+########## Create Application Insights resources for agent tracing
+##########
+
+## Create the Log Analytics workspace that backs Application Insights
+##
+resource "azurerm_log_analytics_workspace" "loganalytics" {
+  name                = "law-${azapi_resource.ai_foundry.name}"
+  location            = var.location
+  resource_group_name = azapi_resource.rg.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+## Create workspace-based Application Insights and connect it to the Foundry account
+##
+resource "azurerm_application_insights" "app_insights" {
+  name                = "appi-${azapi_resource.ai_foundry.name}"
+  location            = var.location
+  resource_group_name = azapi_resource.rg.name
+  workspace_id        = azurerm_log_analytics_workspace.loganalytics.id
+  application_type    = "web"
+}
+
+## Create the Foundry account connection to Application Insights so tracing is available
+##
+resource "azapi_resource" "app_insights_connection" {
+  type      = "Microsoft.CognitiveServices/accounts/connections@2025-06-01"
+  name      = "${azapi_resource.ai_foundry.name}-appinsights"
+  parent_id = azapi_resource.ai_foundry.id
+
+  body = {
+    properties = {
+      category      = "AppInsights"
+      target        = azurerm_application_insights.app_insights.id
+      authType      = "ApiKey"
+      isSharedToAll = true
+      credentials = {
+        key = azurerm_application_insights.app_insights.connection_string
+      }
+      metadata = {
+        ApiType    = "Azure"
+        ResourceId = azurerm_application_insights.app_insights.id
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n- add default Application Insights + Log Analytics provisioning to bicep 00-basic and 40-basic-agent-setup\n- add reusable application-insights module and wire it into bicep 41-standard-agent-setup\n- update 01-connections application-insights example to workspace-based App Insights\n- add matching terraform monitoring/app-insights wiring for 00-basic\n\n## Validation\n- az bicep build for changed bicep templates\n- az deployment group what-if for 00-basic, 40-basic-agent-setup, and 41-standard-agent-setup\n- terraform validate for infrastructure-setup-terraform/00-basic/code\n