### PR TITLE
Fix incorrect model names in REST quickstart samples

### DIFF
--- a/samples/REST/quickstart/quickstart-create-agent.sh
+++ b/samples/REST/quickstart/quickstart-create-agent.sh
@@ -5,7 +5,7 @@ curl -X POST https://YOUR-FOUNDRY-RESOURCE-NAME.services.ai.azure.com/api/projec
     "name": "MyAgent",
     "definition": {
       "kind": "prompt",
-      "model": "gpt-4.1-mini",
+      "model": "gpt-5-mini",
       "instructions": "You are a helpful assistant that answers general questions"
     }
   }'

--- a/samples/REST/quickstart/quickstart-responses.sh
+++ b/samples/REST/quickstart/quickstart-responses.sh
@@ -2,6 +2,6 @@ curl -X POST https://YOUR-FOUNDRY-RESOURCE-NAME.services.ai.azure.com/api/projec
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $AZURE_AI_AUTH_TOKEN" \
 -d '{
-        "model": "gpt-5.1-mini",
+        "model": "gpt-5-mini",
         "input": "What is the size of France in square miles?"
 }'


### PR DESCRIPTION
These two REST quickstart samples back the tabs on [learn.microsoft.com/azure/foundry/quickstarts/get-started-code](https://learn.microsoft.com/azure/foundry/quickstarts/get-started-code), and use model ids that don't match the other language tabs on the same page.

- **`samples/REST/quickstart/quickstart-responses.sh`**: `"model": "gpt-5.1-mini"` -> `"model": "gpt-5-mini"`. All five other "Chat with a model" tabs (Python, C#, TypeScript, Java, portal) use `gpt-5-mini`; `gpt-5.1-mini` is a spurious id.
- **`samples/REST/quickstart/quickstart-create-agent.sh`**: `"model": "gpt-4.1-mini"` -> `"model": "gpt-5-mini"`. All four "Create an agent" SDK tabs use `gpt-5-mini`.

Sample/docs text only; no behavior change.