### PR TITLE
Add State Store Chat sample with durable conversation history

### DIFF
--- a/samples/python/hosted-agents/README.md
+++ b/samples/python/hosted-agents/README.md
@@ -191,6 +191,7 @@ Already built an agent with CrewAI or your own code? The protocol SDKs (`azure-a
 | Sample                                                                 | What it shows                                                                                               |
 | ---------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | **[Hello World](bring-your-own/invocations/hello-world/)**             | Minimal agent — arbitrary JSON in, streaming SSE out. The simplest possible BYO invocations starting point. |
+| **[State Store Chat](bring-your-own/invocations/state-store-chat/)**   | Multi-turn chat that persists conversation history in Foundry durable storage (`FoundryStateStore`) so it survives container restarts, with `if_match` optimistic concurrency. |
 | **[LangGraph Chat](bring-your-own/invocations/langgraph-chat/)**       | LangGraph conversational agent over the Invocations protocol with client-managed sessions.                  |
 | **[Notetaking Agent](bring-your-own/invocations/notetaking-agent/)**   | Note-taking agent with the Invocations protocol.                                                            |
 | **[Toolbox](bring-your-own/invocations/toolbox/)**                     | BYO invocations agent wired to a Foundry Toolbox MCP endpoint.                                              |

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/AGENTS.md
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/AGENTS.md
@@ -1,0 +1,40 @@
+# Coding Agent Instructions
+
+This project is a **Microsoft Foundry hosted agent** — a containerized AI agent that runs in [Foundry Agent Service](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/hosted-agents). The platform handles containerization, hosting, security, scaling, and observability so you can focus on agent logic.
+
+## Key files
+
+- `Dockerfile` — container definition
+
+## Development workflow
+
+The **Azure Developer CLI (`azd`)** manages the full lifecycle:
+
+```bash
+azd ai agent run                           # Run locally on http://localhost:8088
+azd ai agent invoke --local "your message" # Test the local agent
+azd deploy                                 # Deploy to Foundry
+azd ai agent invoke "your message"         # Invoke the deployed agent
+```
+
+## Microsoft Foundry Skill
+
+Install the **Microsoft Foundry Skill** for guided deployment, evaluation, and troubleshooting workflows.
+
+Direct install (preferred, works with any coding agent):
+
+```bash
+npx skills add https://github.com/microsoft/azure-skills --skill microsoft-foundry
+```
+
+Or install the Azure Skills Plugin:
+
+- **Copilot CLI**: `/plugin marketplace add microsoft/azure-skills` then `/plugin install azure@azure-skills`
+- **Claude Code**: `/plugin install azure@claude-plugins-official`
+
+Then ask naturally, e.g. `Use the Microsoft Foundry Skill to deploy this agent.`
+
+## References
+
+- [Hosted agents overview](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/hosted-agents)
+- [Microsoft Foundry Skill](https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/use-microsoft-foundry-skill)

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/CLAUDE.md
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This project uses [AGENTS.md](./AGENTS.md) as the single source of truth for coding agent instructions. The import below loads it into Claude Code's context.
+
+@AGENTS.md

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/README.md
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/README.md
@@ -1,0 +1,264 @@
+<!-- Begin standard disclaimer — do not modify -->
+**IMPORTANT!** All samples and other resources made available in this GitHub repository ("samples") are designed to assist in accelerating development of agents, solutions, and agent workflows for various scenarios. Review all provided resources and carefully test output behavior in the context of your use case. AI responses may be inaccurate and AI actions should be monitored with human oversight. Learn more in the transparency note for [Agent Service](https://learn.microsoft.com/en-us/azure/ai-foundry/responsible-ai/agents/transparency-note).
+
+Agents, solutions, or other output you create may be subject to legal and regulatory requirements, may require licenses, or may not be suitable for all industries, scenarios, or use cases. By using any sample, you are acknowledging that any output created using those samples are solely your responsibility, and that you will comply with all applicable laws, regulations, and relevant safety standards, terms of service, and codes of conduct.
+
+Third-party samples contained in this folder are subject to their own designated terms, and they have not been tested or verified by Microsoft or its affiliates.
+
+Microsoft has no responsibility to you or others with respect to any of these samples or any resulting output.
+<!-- End standard disclaimer -->
+
+# What this sample demonstrates
+
+A multi-turn chat hosted agent using the **Bring Your Own** approach with the **Invocations protocol** in Python that persists its conversation history in **Foundry durable storage**. It builds on the [Hello World](../hello-world) sample by replacing the in-memory history dict with [`FoundryStateStore`](https://pypi.org/project/azure-ai-agentserver-core/), so history survives container restarts, scale-out, and redeployments.
+
+The Invocations protocol does **not** provide built-in server-side conversation history. Rather than keep it in memory (lost on every restart), this sample stores it in `FoundryStateStore` — a durable, server-backed key-value store scoped to your Foundry project and reachable from the same `FOUNDRY_PROJECT_ENDPOINT` the agent already uses.
+
+## How It Works
+
+### Durable conversation history
+
+The agent uses [`FoundryStateStore`](https://pypi.org/project/azure-ai-agentserver-core/) from `azure.ai.agentserver.core.storage`:
+
+- **One store per conversation** — named `chat-history/<agent_session_id>`. Encoding the session id into the store name is how you scope data to a conversation; there is no separate session-isolation knob. `FoundryStateStore.get_or_create(name, ...)` resolves (or creates, on first use) the store in a single call.
+- **One item holds the transcript** — the full message list is stored as a single item under the key `history`, with value `{"messages": [{"role": ..., "content": ...}, ...]}`. Item values are plain JSON objects (a `dict`), up to 1 MB.
+- **Guarded writes** — each turn is appended with an optimistic-concurrency (`if_match`) read-modify-write, so two requests racing on the same session cannot lose each other's messages. On a precondition failure the agent reloads the latest history and retries.
+- **TTL** — the store's `item_ttl_seconds` (30 days here) ages out idle conversations automatically; any write renews the window. Set it to `-1` to keep history forever.
+
+On each request the handler loads the persisted history, sends it plus the new user message to the model, streams the reply, then durably appends the completed user/assistant turn before emitting the final `done` event.
+
+See [main.py](src/state-store-chat-python-invocations/main.py) for the full implementation, and the [Durable State Store Guide](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/agentserver/azure-ai-agentserver-core/docs/state-store-guide.md) for the complete API.
+
+### Model Integration
+
+The agent uses the Foundry SDK to create a Responses client from the project endpoint and model deployment name. When a request arrives, the handler looks up the durable history for the session, appends the new user message, calls the model via the Responses API with streaming, and returns a `StreamingResponse` of SSE events — `token` events during generation, then a final `done` event.
+
+### Agent Hosting
+
+The agent is hosted using the [Azure AI AgentServer Invocations SDK](https://pypi.org/project/azure-ai-agentserver-invocations/), which provisions a REST API endpoint compatible with the Azure AI Invocations protocol.
+
+### Agent Deployment
+
+The hosted agent can be developed and deployed to Microsoft Foundry using the [Azure Developer CLI](https://learn.microsoft.com/en-us/azure/foundry/agents/quickstarts/quickstart-hosted-agent?view=foundry&pivots=azd).
+
+## Running the Agent Locally
+
+### Prerequisites
+
+Before running this sample, ensure you have:
+
+1. **Azure Developer CLI (`azd`)**
+   - [Install azd](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd) (1.25 or later) and the unified Foundry CLI extension: `azd ext install microsoft.foundry`
+   - Authenticated: `azd auth login`
+
+2. **Azure CLI**
+   - Installed and authenticated: `az login`
+
+3. **Python 3.10 or later**
+   - Verify your version: `python --version`
+
+> [!NOTE]
+> You do **not** need an existing [Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/what-is-foundry?view=foundry) project or model deployment to get started — `azd provision` creates them for you. If you already have a project, see the [note below](#using-azd) on how to target it.
+
+> [!NOTE]
+> The durable state store is reached through your Foundry project endpoint using the agent's identity. When running with `azd ai agent run` (locally) or hosted in Foundry, that identity is configured automatically. Running `python main.py` manually uses `DefaultAzureCredential`, so the signed-in `az login` identity needs access to the project.
+
+### Environment Variables
+
+See [`.env.example`](src/state-store-chat-python-invocations/.env.example) or `.env` for the full list of environment variables this sample uses.
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `FOUNDRY_PROJECT_ENDPOINT` | Yes | Foundry project endpoint. Used for both the model call and the durable state store. Auto-injected in hosted containers; set automatically by `azd ai agent run` locally. |
+| `AZURE_AI_MODEL_DEPLOYMENT_NAME` | Yes | Model deployment name — must match your Foundry project deployment. Declared in `azure.yaml`. |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | Recommended | Enables telemetry. Auto-injected in hosted containers; set manually for local dev. |
+
+**Local development (without `azd`):**
+
+```bash
+cp .env.example .env  # skip if .env already exists
+# Edit .env and fill in your values, then:
+export $(grep -v '^#' .env | xargs)
+```
+
+> [!NOTE]
+> When using `azd ai agent run`, environment variables are handled automatically — no manual setup needed.
+
+### Installing Dependencies
+
+> [!NOTE]
+> If using `azd ai agent run`, dependencies are installed automatically — skip to [Running the Sample](#running-the-sample).
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Running the Sample
+
+Run and test hosted agents locally with the Azure Developer CLI (`azd`) or the Foundry Toolkit VS Code extension.
+
+<details>
+<summary><h4>Using the Foundry Toolkit VS Code Extension</h4></summary>
+
+**Prerequisites**
+
+1. **VS Code** with the **[Foundry Toolkit](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio)** extension installed.
+2. For debugging Python in VS Code, install the **[Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)** extension pack.
+
+**Set up the Python virtual environment**
+
+- Open the Command Palette (`Ctrl+Shift+P`) and run **Python: Create Environment...** to create a virtual environment in the workspace (or **Python: Select Interpreter** to use an existing one).
+- Install dependencies in the virtual environment:
+
+  ```bash
+  # use uv to accelerate
+  pip install uv
+  uv pip install -r requirements.txt
+
+  # or pure pip
+  pip install -r requirements.txt
+  ```
+
+**Run and debug the agent**
+
+Press **F5** to start the agent. The agent starts and the **Agent Inspector** opens automatically. Chat with the agent in the Inspector.
+
+**Or run manually, then open the Inspector**
+
+1. Set the required environment variables and sign in to Azure with the Azure CLI (`az login`).
+2. Start the agent: `python main.py` (listens on `http://localhost:8088`).
+3. Command Palette (`Ctrl+Shift+P`) → **Foundry Toolkit: Open Agent Inspector**, then send a message to test.
+
+</details>
+
+#### Using [`azd`](https://learn.microsoft.com/en-us/azure/foundry/agents/quickstarts/quickstart-hosted-agent?view=foundry&pivots=azd)
+
+No cloning required. Create a new folder, point `azd` at the manifest on GitHub, and it sets up the sample and adopts its `azure.yaml` as the project manifest and configures your environment automatically:
+
+```bash
+# Create a new folder for the agent and navigate into it
+mkdir state-store-chat-agent && cd state-store-chat-agent
+
+# Initialize from the manifest — azd reads it, downloads the sample,
+# and adopts its azure.yaml as the project manifest and configures your environment
+azd ai agent init -m https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/azure.yaml
+
+# Provision Azure resources (Foundry project, model deployment, App Insights)
+azd provision
+
+# Run the agent locally (handles env vars, dependency install, and startup)
+azd ai agent run
+```
+
+> [!NOTE]
+> If you've already cloned this repository, pass a local path to the manifest instead:
+> `azd ai agent init -m <path-to-repo>/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/azure.yaml`
+
+> [!NOTE]
+> If you already have a Foundry project and model deployment, add `-p <project-id> -d <deployment-name>` to `azd ai agent init` to target existing resources. You can also skip provisioning entirely and configure env vars manually — see [Manual setup](#manual-setup).
+
+The agent starts on `http://localhost:8088/`. To invoke it:
+
+```bash
+azd ai agent invoke --local "My name is Ada. Remember it."
+```
+
+Or use curl directly. The `-N` flag disables output buffering so you see SSE tokens as they arrive:
+
+> [!NOTE]
+> `agent_session_id` is optional. If omitted, the server auto-generates one and returns it in the `done` event (`session_id` field). To continue a conversation across turns — and reload its durable history — pass the same `agent_session_id` in each request.
+
+```bash
+# Turn 1 — start a new conversation
+curl -sS -N -X POST "http://localhost:8088/invocations?agent_session_id=chat-001" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "My name is Ada. Remember it."}'
+
+# Turn 2 — continue the same conversation
+curl -sS -N -X POST "http://localhost:8088/invocations?agent_session_id=chat-001" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "What is my name?"}'
+```
+
+**Verify durability:** stop the agent (`Ctrl+C`), start it again, then repeat the "What is my name?" request with the same `agent_session_id=chat-001`. Because history lives in the state store rather than in process memory, the agent still remembers the name — an in-memory sample would have forgotten it.
+
+Each response is a stream of SSE events: `token` events with incremental text, followed by a `done` event with the complete reply.
+
+#### Manual setup
+
+If running without `azd`, set environment variables manually (see [Environment Variables](#environment-variables)), then:
+
+```bash
+python main.py
+```
+
+### Deploying the Agent to Microsoft Foundry
+
+Once you've tested locally, deploy to Microsoft Foundry:
+
+```bash
+# Provision Azure resources (skip if already done during local setup)
+azd provision
+
+# Build, push, and deploy the agent to Foundry
+azd deploy
+```
+
+After deploying, invoke the agent running in Foundry:
+
+```bash
+azd ai agent invoke "My name is Ada. Remember it."
+```
+
+To stream logs from the running agent:
+
+```bash
+azd ai agent monitor
+```
+
+For the full deployment guide, see [Azure AI Foundry hosted agents](https://aka.ms/azdaiagent/docs).
+
+#### Deploying with the Foundry Toolkit VS Code Extension
+
+1. Open the Command Palette (`Ctrl+Shift+P`) and run **Foundry Toolkit: Deploy Hosted Agent**. The extension opens a tab-based **Deploy Hosted Agent** wizard and reads `agent.yaml` to auto-populate what it can.
+2. If prompted, complete **Foundry Project Setup** to pick the subscription and Foundry project (or create a new one) to deploy to.
+3. On the **Basics** tab, configure the core deployment settings:
+   - **Deployment Method**: **Code** (upload as a ZIP) or **Container** (Docker image via ACR).
+   - For **Code**, pick a packaging option: **Remote** or **Local**.
+   - For **Container**, pick a registry option: default ACR, your own ACR, or a prebuilt ACR image.
+   - **Hosted Agent Name**: confirm the name to register with the hosting service.
+4. On the **Review + Deploy** tab, finalize the runtime and resources:
+   - Confirm the auto-detected runtime details (language, entry point, or Dockerfile).
+   - Pick a **CPU and Memory** size.
+   - Click **Deploy**. Fields are validated inline, and the extension handles the build/upload, agent version creation, and RBAC role assignment.
+5. After deployment, invoke the agent in the Agent Playground and stream live logs from the **Logs** tab.
+
+## Customization
+
+- **Scope per user, not just per conversation** — pass `user_isolation=True` to `get_or_create` when the same store name is shared across users and the platform should partition items per user. For trusted callers acting on behalf of an end user, also pass `user_id` to send the delegated `x-ms-user-id` header. See [User Isolation](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/agentserver/azure-ai-agentserver-core/docs/state-store-guide.md#user-isolation-and-delegated-user-ids).
+- **Store more than a transcript** — put checkpoints, tool results, or workflow state in additional items and filter them with `tags` via `list_keys()`.
+- **Change retention** — adjust `item_ttl_seconds` (store-level, fixed at creation). Use `-1` to keep history forever.
+
+## Troubleshooting
+
+### Images built on Apple Silicon or other ARM64 machines do not work on our service
+
+**Deploy with `azd deploy`**, which uses ACR remote build and always produces images with the correct architecture.
+
+If you choose to **build locally**, and your machine is **not `linux/amd64`** (for example, an Apple Silicon Mac), the image will **not be compatible with our service**, causing runtime failures.
+
+**Fix for local builds:**
+
+```bash
+docker build --platform=linux/amd64 -t image .
+```
+
+This forces the image to be built for the required `amd64` architecture.
+
+## Next steps
+
+- [Hello World (Python, Invocations)](../hello-world) — the in-memory starting point this sample builds on.
+- [Durable State Store Guide](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/agentserver/azure-ai-agentserver-core/docs/state-store-guide.md) — full `FoundryStateStore` API: items, tags, TTL, optimistic concurrency, and key listing.
+- [Hosted agents overview](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/hosted-agents).

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/azure.yaml
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/azure.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+requiredVersions:
+  extensions:
+    azure.ai.agents: '>=1.0.0-beta.4'
+name: state-store-chat-python-invocations
+services:
+  ai-project:
+    host: azure.ai.project
+    deployments:
+      - name: gpt-5.4-mini
+        model:
+          format: OpenAI
+          name: gpt-5.4-mini
+          version: '2026-03-17'
+        sku:
+          name: GlobalStandard
+          capacity: 10
+  state-store-chat-python-invocations:
+    host: azure.ai.agent
+    metadata:
+      tags:
+        - AI Agent Hosting
+        - Invocations Protocol
+        - Bring Your Own
+        - Durable State Store
+        - Python
+    project: src/state-store-chat-python-invocations
+    language: python
+    codeConfiguration:
+      runtime: python_3_13
+      entryPoint: main.py
+    uses:
+      - ai-project
+    kind: hosted
+    name: state-store-chat-python-invocations
+    displayName: State Store Chat (Python, Invocations)
+    description: Multi-turn chat agent using the Invocations protocol with a bring-your-own approach. Persists conversation history in Foundry durable storage (FoundryStateStore) so it survives container restarts, and streams the model reply as SSE events.
+    protocols:
+      - protocol: invocations
+        version: 2.0.0
+    environmentVariables:
+      - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+        value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+    container:
+      resources:
+        cpu: '0.5'
+        memory: 1Gi
+infra:
+  provider: microsoft.foundry

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/.azdignore
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/.azdignore
@@ -1,0 +1,1 @@
+.env.example

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/.dockerignore
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/.dockerignore
@@ -1,0 +1,26 @@
+**/__pycache__/
+**/*.py[cod]
+**/*.egg-info/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# IDE settings
+.vscode/
+.idea/
+
+# Version control
+.git/
+.gitignore
+
+# Docker files
+.dockerignore
+
+# Docs
+README.md
+
+# Local environment (never bake credentials into the image)
+.env

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/.env.example
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/.env.example
@@ -1,0 +1,17 @@
+# Foundry project endpoint — auto-injected in hosted containers.
+# Also used to resolve the durable state-store endpoint.
+# Only set manually if running without `azd ai agent run`.
+# FOUNDRY_PROJECT_ENDPOINT=https://<account>.services.ai.azure.com/api/projects/<project>
+
+# Model deployment name — must match a deployment in your Foundry project.
+AZURE_AI_MODEL_DEPLOYMENT_NAME=
+
+# Partition each conversation's durable history per end user. Optional; off by
+# default. When "true", the store is created with user_isolation=True and item
+# operations are scoped to the end user (derived from the caller's token, or from
+# an x-ms-user-id header for trusted delegated callers).
+# ENABLE_USER_ISOLATION=true
+
+# Application Insights — auto-injected in hosted containers.
+# Set for local telemetry (optional but recommended).
+# APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/Dockerfile
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . user_agent/
+WORKDIR /app/user_agent
+RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+EXPOSE 8088
+CMD ["python", "main.py"]

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/main.py
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/main.py
@@ -1,0 +1,300 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""State Store Chat — Bring Your Own Invocations agent with durable history.
+
+A hosted agent that behaves like the Hello World invocations sample, but stores
+its conversation history in **Foundry durable storage** instead of an in-memory
+dict. History therefore survives container restarts, scale-out, and
+redeployments.
+
+The Invocations protocol does **not** provide built-in server-side conversation
+history, so the agent persists it itself using ``FoundryStateStore`` from
+``azure.ai.agentserver.core.storage`` — a durable, server-backed key-value store
+scoped to the Foundry project.
+
+Storage model:
+    * One state store per conversation, named ``chat-history/<agent_session_id>``.
+      Encoding the session id into the store name is how you scope data to a
+      conversation (there is no separate session-isolation knob).
+    * The full message list is kept as a single item under the key ``history``,
+      with value ``{"messages": [{"role": ..., "content": ...}, ...]}``.
+    * Each turn is appended with an optimistic-concurrency (``if_match``) guarded
+      read-modify-write, so concurrent requests to the same session cannot
+      lose each other's messages.
+
+Required environment variables:
+    FOUNDRY_PROJECT_ENDPOINT: Foundry project endpoint (auto-injected in hosted containers).
+        Also used to resolve the durable-storage endpoint.
+    AZURE_AI_MODEL_DEPLOYMENT_NAME: Model deployment name (declared in azure.yaml).
+
+Optional environment variables:
+    ENABLE_USER_ISOLATION: Set to "true" to partition each conversation's history
+        per end user (see the user-isolation notes below). Defaults to off.
+
+Usage::
+
+    # Set environment variables
+    export FOUNDRY_PROJECT_ENDPOINT="https://<account>.services.ai.azure.com/api/projects/<project>"
+    export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-5.4-mini"
+
+    # Start the agent
+    python main.py
+
+    # Turn 1 — start a new conversation
+    curl -sS -N -X POST "http://localhost:8088/invocations?agent_session_id=chat-001" \\
+        -H "Content-Type: application/json" \\
+        -d '{"message": "My name is Ada. Remember it."}'
+
+    # Restart the process, then continue the SAME conversation — history persists
+    curl -sS -N -X POST "http://localhost:8088/invocations?agent_session_id=chat-001" \\
+        -H "Content-Type: application/json" \\
+        -d '{"message": "What is my name?"}'
+"""
+
+import json
+import logging
+import os
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, StreamingResponse
+
+from azure.ai.projects.aio import AIProjectClient
+from azure.identity.aio import DefaultAzureCredential
+
+from azure.ai.agentserver.core.storage import (
+    FoundryStateStore,
+    FoundryStoragePreconditionError,
+)
+from azure.ai.agentserver.invocations import InvocationAgentServerHost
+
+logger = logging.getLogger(__name__)
+
+if not os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING"):
+    logger.warning(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING not set — traces will not be sent to "
+        "Application Insights. Set it to enable local telemetry. "
+        "(This variable is auto-injected in hosted Foundry containers — do not declare it in azure.yaml.)"
+    )
+
+# Initialize Foundry project client — reads FOUNDRY_PROJECT_ENDPOINT.
+# FOUNDRY_PROJECT_ENDPOINT is auto-injected in hosted Foundry containers.
+# Locally, set it manually or use 'azd ai agent run' which sets it automatically.
+_endpoint = os.environ.get("FOUNDRY_PROJECT_ENDPOINT")
+if not _endpoint:
+    raise EnvironmentError(
+        "FOUNDRY_PROJECT_ENDPOINT environment variable is not set. "
+        "Set it to your Foundry project endpoint, or use 'azd ai agent run' "
+        "which sets it automatically."
+    )
+
+_model = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME")
+if not _model:
+    raise EnvironmentError(
+        "AZURE_AI_MODEL_DEPLOYMENT_NAME environment variable is not set. "
+        "Set it to your model deployment name as declared in azure.yaml."
+    )
+
+# One shared credential drives both the model client and the storage client.
+_credential = DefaultAzureCredential()
+_project_client = AIProjectClient(endpoint=_endpoint, credential=_credential)
+
+# Use the Responses API — not chat.completions (Chat Completions API is legacy).
+_openai_client = _project_client.get_openai_client()
+
+_SYSTEM_PROMPT = "You are a helpful AI assistant. Be concise and informative."
+
+# Store-level TTL: idle conversations age out after 30 days. Any write to a
+# conversation renews its window. Set to -1 to keep history forever.
+_HISTORY_TTL_SECONDS = 30 * 24 * 60 * 60
+
+# The single item key that holds the whole message list for a conversation.
+_HISTORY_KEY = "history"
+
+# Retries for the optimistic-concurrency guarded write when another request for
+# the same session commits first.
+_MAX_WRITE_ATTEMPTS = 3
+
+# ── User isolation ────────────────────────────────────────────────────────────
+# When enabled, item operations on a store are partitioned per end user, so two
+# users sharing the same store name never see each other's items. This is a
+# store-level property fixed at creation (get_or_create) — it cannot be toggled
+# later. Turn it on with ENABLE_USER_ISOLATION=true.
+#
+# There are two ways the platform learns *which* user an item belongs to:
+#   1. Direct callers — the platform derives the user identity from the caller's
+#      token automatically. You only set user_isolation=True; you pass no id.
+#   2. Trusted/delegated callers — a service calling on behalf of an end user
+#      passes that user's id as `user_id`. The SDK then sends it as the
+#      `x-ms-user-id` header on item operations (get_item/set_item/etc.), and the
+#      platform partitions by that delegated id.
+# Store-management calls (get_or_create/get/update/delete) stay store-scoped and
+# never send the delegated header — isolation only applies to item operations.
+_USER_ISOLATION = os.environ.get("ENABLE_USER_ISOLATION", "false").lower() == "true"
+
+# Header a trusted upstream may set to name the end user it is acting for. Only
+# consulted when user isolation is on; direct callers can leave it unset and let
+# the platform derive identity from the token.
+_DELEGATED_USER_ID_HEADER = "x-ms-user-id"
+
+app = InvocationAgentServerHost()
+
+# Cache one durable-store client per (conversation, user) pair. Each client owns
+# an HTTP pipeline, so reuse it across turns instead of reconstructing it per
+# request. With user isolation on, the delegated user id is part of the cache key
+# because a store client carries that id (and thus the x-ms-user-id header).
+_stores: dict[tuple[str, str | None], FoundryStateStore] = {}
+
+
+async def _get_store(
+    session_id: str, user_id: str | None = None
+) -> FoundryStateStore:
+    """Return a durable state store bound to this conversation, creating it once.
+
+    The store name encodes the conversation scope. ``get_or_create`` resolves the
+    server-side resource in a single call, so the store is ready for item reads
+    and writes immediately.
+
+    When ``_USER_ISOLATION`` is on, the store is created with
+    ``user_isolation=True`` so its items are partitioned per user. For a trusted
+    caller acting on behalf of an end user, ``user_id`` is forwarded so the SDK
+    tags item operations with the delegated ``x-ms-user-id`` header; a direct
+    caller can omit it and let the platform derive identity from the token.
+    """
+    cache_key = (session_id, user_id if _USER_ISOLATION else None)
+    store = _stores.get(cache_key)
+    if store is None:
+        store = await FoundryStateStore.get_or_create(
+            f"chat-history/{session_id}",
+            credential=_credential,
+            user_isolation=_USER_ISOLATION,
+            # user_id only has an effect when the store is user-isolated; it is
+            # ignored otherwise, so it is always safe to pass through.
+            user_id=user_id,
+            item_ttl_seconds=_HISTORY_TTL_SECONDS,
+            description="Durable chat history for a single conversation.",
+            tags={"scenario": "state-store-chat"},
+        )
+        _stores[cache_key] = store
+    return store
+
+
+async def _load_history(store: FoundryStateStore) -> list[dict[str, str]]:
+    """Return the persisted messages for this conversation (empty if none yet)."""
+    item = await store.get_item(_HISTORY_KEY)
+    if item is None:
+        return []
+    return list(item.value.get("messages", []))
+
+
+async def _append_turn(
+    store: FoundryStateStore, user_message: str, assistant_message: str
+) -> None:
+    """Durably append one user/assistant turn with an ``if_match`` guard.
+
+    Re-reads the latest history immediately before writing so a concurrent
+    request that committed first is not clobbered; on a precondition failure it
+    reloads and retries.
+    """
+    messages: list[dict[str, str]] = []
+    for _ in range(_MAX_WRITE_ATTEMPTS):
+        item = await store.get_item(_HISTORY_KEY)
+        messages = list(item.value.get("messages", [])) if item is not None else []
+        etag = item.etag if item is not None else None
+
+        messages.append({"role": "user", "content": user_message})
+        messages.append({"role": "assistant", "content": assistant_message})
+
+        try:
+            await store.set_item(_HISTORY_KEY, {"messages": messages}, if_match=etag)
+            return
+        except FoundryStoragePreconditionError:
+            # Another request for this session wrote first — reload and retry.
+            logger.info("Concurrent history write for a session; retrying")
+
+    # Best-effort final write without the guard so the turn is not lost.
+    await store.set_item(_HISTORY_KEY, {"messages": messages})
+
+
+# ── Required handler ──────────────────────────────────────────────────────────
+# @app.invoke_handler is the only handler you must implement. It receives every
+# POST /invocations request. The function name below is arbitrary.
+# ─────────────────────────────────────────────────────────────────────────────
+@app.invoke_handler
+async def handle_invoke(request: Request):
+    """Handle a streaming multi-turn chat request with durable history."""
+    # Accept either a JSON object ({"message": "..."} or {"input": "..."}) or a
+    # plain-text body (e.g. sent directly from the Foundry portal chat UI).
+    try:
+        body = await request.body()
+        if not body:
+            raise ValueError("empty body")
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            user_message = body.decode("utf-8", errors="replace").strip()
+        else:
+            if isinstance(data, dict):
+                user_message = data.get("message") or data.get("input") or ""
+            else:
+                user_message = body.decode("utf-8", errors="replace").strip()
+        if not isinstance(user_message, str) or not user_message.strip():
+            raise ValueError("missing message text")
+    except ValueError:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_request",
+                "message": (
+                    'Request body must be a non-empty JSON object with a "message" (or "input") '
+                    'string, or a plain-text body, e.g. {"message": "What is Microsoft Foundry?"}'
+                ),
+            },
+        )
+
+    # The Invocations SDK resolves session and invocation identity from the
+    # incoming request and exposes them via request.state.
+    session_id = request.state.session_id
+    invocation_id = request.state.invocation_id
+
+    # For user-isolated stores, a trusted upstream may name the end user it is
+    # acting for via the x-ms-user-id header. Direct callers can leave this unset
+    # and let the platform derive identity from the token. Ignored when user
+    # isolation is off.
+    delegated_user_id = request.headers.get(_DELEGATED_USER_ID_HEADER)
+
+    logger.info("Processing invocation %s (session %s)", invocation_id, session_id)
+
+    # Load durable history for this conversation and build the model input. With
+    # user isolation on, history is additionally partitioned by the end user, so
+    # the same session_id yields separate transcripts per user.
+    store = await _get_store(session_id, delegated_user_id)
+    prior_messages = await _load_history(store)
+    model_input = prior_messages + [{"role": "user", "content": user_message}]
+
+    async def event_generator():
+        full_reply = ""
+        async for event in await _openai_client.responses.create(
+            model=_model,
+            instructions=_SYSTEM_PROMPT,
+            input=model_input,
+            store=False,
+            stream=True,
+        ):
+            if event.type == "response.output_text.delta":
+                full_reply += event.delta
+                yield f"data: {json.dumps({'type': 'token', 'content': event.delta})}\n\n"
+
+        # Persist the completed turn durably before signalling done.
+        await _append_turn(store, user_message, full_reply)
+
+        yield f"data: {json.dumps({'type': 'done', 'full_text': full_reply, 'session_id': session_id})}\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache"},
+    )
+
+
+if __name__ == "__main__":
+    app.run()

--- a/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/state-store-chat/src/state-store-chat-python-invocations/requirements.txt
@@ -1,0 +1,10 @@
+aiohttp==3.13.5
+azure-ai-agentserver-invocations==1.0.0b6
+# azure-ai-agentserver-core provides the durable state-store layer
+# (azure.ai.agentserver.core.storage). 2.0.0b8 is the first version to include it.
+azure-ai-agentserver-core==2.0.0b8
+azure-ai-projects==2.0.1
+azure-identity==1.25.3
+
+# debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
+debugpy


### PR DESCRIPTION
## Summary

Adds a new **State Store Chat** sample under BYO Invocations that persists conversation history durably using the new Foundry `FoundryStateStore` (from `azure-ai-agentserver-core`). Unlike the in-memory `hello-world` sample, chat history survives container restarts and scale events.

## What it does

- Stores each conversation as a single JSON item (the full message list) in a per-session store, keyed by `session_id`.
- Uses `if_match` optimistic concurrency with a bounded retry loop on concurrent writes.
- Store-level TTL (30 days by default) so idle conversations expire automatically.
- Optional per-user history partitioning via `ENABLE_USER_ISOLATION` (creates the store with `user_isolation=True`; item ops scoped to the end user from the caller token, or an `x-ms-user-id` header for trusted delegated callers).

## Files

- `bring-your-own/invocations/state-store-chat/` — full runnable sample (main.py, Dockerfile, azure.yaml, requirements, .env.example, README, AGENTS/CLAUDE docs).
- Updated `hosted-agents/README.md` — added the sample to the BYO Invocations index.

## Notes

- Depends on `azure-ai-agentserver-core==2.0.0b8` (first version shipping the storage layer; currently unreleased).