### PR TITLE
P1.2 - in-job path detection (self-test)

### DIFF
--- a/.github/scripts/detect-changed-samples.sh
+++ b/.github/scripts/detect-changed-samples.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# detect-changed-samples.sh — reusable in-job change detector for the public-first
+# validation pipeline. Ports the private ADO `DetectChanges` stage (job AnalyzeChanges,
+# step detectChanges) from .azure-pipelines/validation.yml into a GitHub-Actions-native,
+# dependency-light script (git + coreutils only).
+#
+# Single responsibility: answer "which sample directories were affected by this push/PR?"
+# by mapping every changed file under <samples-root>/ to its NEAREST ANCESTOR sample.yaml
+# directory, then deduping. The caller (P2.1/P2.2 validate lanes) consumes the result as
+# GitHub Actions job outputs via needs.<detect>.outputs.* and fans out — deriving each
+# sample's --language from its path (samples/<language>/...); this script deliberately does
+# NOT pre-group by language (see "Design" below).
+#
+# Usage:
+#   detect-changed-samples.sh [--base-ref <ref>] [--event <pull_request|push|dispatch>]
+#                             [--target-branch <branch>] [--samples-root samples]
+#                             [--output-dir <dir>] [--print-base-ref]
+#
+# Base-ref resolution (faithful to ADO DetectChanges):
+#   --base-ref <ref>     wins outright (used by tests + callers that already know the base).
+#   event pull_request   git fetch origin <target> (best-effort) then BASE_REF=origin/<target>,
+#                        where <target> is --target-branch or $GITHUB_BASE_REF.
+#   otherwise (push/etc) BASE_REF=HEAD~1.
+#
+# Outputs (the contract P2 consumes):
+#   has_changes  "true" | "false"   — false == docs-only / no sample touched (short-circuit flag)
+#   count        integer            — number of affected sample dirs
+#   samples      JSON array         — deduped, sorted affected sample dirs (repo-relative)
+# Written to $GITHUB_OUTPUT when set; always printed to stdout. When --output-dir is given,
+# also writes changed_files.txt + unique_changed_samples.txt (mirrors ADO's artifacts).
+#
+# Exit codes (2-way — intentionally simpler than validate-sample.sh's 0/1/2 classifier;
+# detection has no "sample broken" tier):
+#   0  OK      detection completed — INCLUDING an empty (docs-only) result.
+#   1  ERROR   fail loud: bad args, not a git repo, or the git diff itself errored.
+#
+# FAIL-LOUD invariant (ADO 5247751 lesson): a git diff *error* must NEVER be swallowed into
+# an empty "nothing changed" result — that fail-opens the sync gate. A diff that SUCCEEDS
+# with zero lines is legitimate docs-only (has_changes=false, exit 0). The two are never
+# conflated: only `git diff` returning non-zero triggers the exit-1 refusal below.
+#
+# NOTE: `set -e` is intentionally NOT used; error paths are routed through error() so no
+# external command can abort the script with an unclassified status.
+set -uo pipefail
+
+BASE_REF=""
+EVENT=""
+TARGET_BRANCH=""
+SAMPLES_ROOT="samples"
+OUTPUT_DIR=""
+PRINT_BASE_REF=false
+
+usage() {
+    cat <<'EOF'
+Usage: detect-changed-samples.sh [options]
+
+  --base-ref <ref>        Explicit base ref to diff HEAD against (overrides resolution).
+  --event <name>          Event kind: pull_request | push | dispatch (default: $GITHUB_EVENT_NAME or push).
+  --target-branch <br>    PR target branch (default: $GITHUB_BASE_REF). Used only for pull_request.
+  --samples-root <dir>    Root under which samples live (default: samples).
+  --output-dir <dir>      If set, write changed_files.txt + unique_changed_samples.txt here.
+  --print-base-ref        Resolve and print the base ref, then exit 0 (no fetch, no diff).
+
+Exit codes: 0 = detection ok (incl. empty/docs-only), 1 = error (fail loud).
+EOF
+}
+
+# error <reason>: fail loud — print to stderr and exit 1. Never emit a fake empty result.
+error() {
+    echo "ERROR: ${1:-detection failure}" >&2
+    exit 1
+}
+
+# --- Argument parsing --------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --base-ref)      BASE_REF="${2:-}";      shift $(( $# > 1 ? 2 : 1 )) ;;
+        --event)         EVENT="${2:-}";         shift $(( $# > 1 ? 2 : 1 )) ;;
+        --target-branch) TARGET_BRANCH="${2:-}"; shift $(( $# > 1 ? 2 : 1 )) ;;
+        --samples-root)  SAMPLES_ROOT="${2:-}";  shift $(( $# > 1 ? 2 : 1 )) ;;
+        --output-dir)    OUTPUT_DIR="${2:-}";    shift $(( $# > 1 ? 2 : 1 )) ;;
+        --print-base-ref) PRINT_BASE_REF=true;   shift ;;
+        -h|--help)       usage; exit 0 ;;
+        *)               usage >&2; error "unknown argument: $1" ;;
+    esac
+done
+
+# --- Guards ------------------------------------------------------------------
+git rev-parse --git-dir >/dev/null 2>&1 || error "not a git repository (cwd=$(pwd))"
+[ -n "$SAMPLES_ROOT" ] || error "missing/empty --samples-root"
+SAMPLES_ROOT="${SAMPLES_ROOT%/}"
+
+# --- Base-ref resolution -----------------------------------------------------
+resolve_base_ref() {
+    if [ -n "$BASE_REF" ]; then
+        echo "$BASE_REF"
+        return 0
+    fi
+    local ev="$EVENT"
+    [ -n "$ev" ] || ev="${GITHUB_EVENT_NAME:-push}"
+    if [ "$ev" = "pull_request" ]; then
+        local target="$TARGET_BRANCH"
+        [ -n "$target" ] || target="${GITHUB_BASE_REF:-}"
+        [ -n "$target" ] || error "pull_request event but no target branch (--target-branch / \$GITHUB_BASE_REF)"
+        # Best-effort fetch (ADO parity). If offline/absent, the diff below fails loud.
+        if [ "$PRINT_BASE_REF" != true ]; then
+            git fetch origin "$target" --quiet 2>/dev/null || true
+        fi
+        echo "origin/$target"
+    else
+        echo "HEAD~1"
+    fi
+}
+
+BASE_REF="$(resolve_base_ref)" || exit 1
+
+if [ "$PRINT_BASE_REF" = true ]; then
+    echo "$BASE_REF"
+    exit 0
+fi
+
+# --- Diff (FAIL LOUD on error; empty-but-successful is legit docs-only) -------
+CHANGED_FILES="$(mktemp)"
+trap 'rm -f "$CHANGED_FILES"' EXIT
+# core.quotepath=false keeps non-ASCII paths literal (no octal escaping) so dirname works.
+if ! git -c core.quotepath=false diff --name-only "$BASE_REF" HEAD -- "$SAMPLES_ROOT/" > "$CHANGED_FILES"; then
+    error "git diff '$BASE_REF'..HEAD failed; refusing to continue with an empty change set (would fail-open the gate)"
+fi
+
+# --- Walk each changed file UP to its nearest ancestor sample.yaml dir --------
+UNIQUE="$(mktemp)"
+trap 'rm -f "$CHANGED_FILES" "$UNIQUE"' EXIT
+{
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        dir="$(dirname "$f")"
+        while [ "$dir" != "$SAMPLES_ROOT" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+            if [ -f "$dir/sample.yaml" ]; then
+                echo "$dir"
+                break
+            fi
+            dir="$(dirname "$dir")"
+        done
+    done < "$CHANGED_FILES"
+} | sort -u > "$UNIQUE"
+
+# --- Compute outputs ---------------------------------------------------------
+COUNT="$(grep -c . "$UNIQUE" 2>/dev/null || echo 0)"
+if [ "$COUNT" -gt 0 ]; then HAS_CHANGES="true"; else HAS_CHANGES="false"; fi
+
+# Build a JSON array (dependency-light; escape backslash and double-quote).
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+SAMPLES_JSON="["
+first=true
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    if [ "$first" = true ]; then first=false; else SAMPLES_JSON="$SAMPLES_JSON,"; fi
+    SAMPLES_JSON="$SAMPLES_JSON\"$(json_escape "$line")\""
+done < "$UNIQUE"
+SAMPLES_JSON="$SAMPLES_JSON]"
+
+# --- Emit --------------------------------------------------------------------
+echo "=== detect-changed-samples: base=$BASE_REF root=$SAMPLES_ROOT ==="
+echo "has_changes=$HAS_CHANGES"
+echo "count=$COUNT"
+echo "samples=$SAMPLES_JSON"
+if [ "$COUNT" -gt 0 ]; then
+    echo "affected sample dirs:"
+    sed 's/^/  - /' "$UNIQUE"
+else
+    echo "no affected samples (docs-only / nothing under a sample.yaml) — short-circuit"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "has_changes=$HAS_CHANGES"
+        echo "count=$COUNT"
+        echo "samples=$SAMPLES_JSON"
+    } >> "$GITHUB_OUTPUT"
+fi
+
+if [ -n "$OUTPUT_DIR" ]; then
+    mkdir -p "$OUTPUT_DIR" || error "could not create --output-dir: $OUTPUT_DIR"
+    cp "$CHANGED_FILES" "$OUTPUT_DIR/changed_files.txt"
+    cp "$UNIQUE" "$OUTPUT_DIR/unique_changed_samples.txt"
+fi
+
+exit 0

--- a/.github/scripts/test/run-detect-tests.sh
+++ b/.github/scripts/test/run-detect-tests.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# run-detect-tests.sh — hermetic exit gate for detect-changed-samples.sh.
+#
+# Sibling to run-tests.sh (the P1.1 validator harness). Where that harness needs real
+# toolchains, THIS one needs only git + coreutils, so it runs fully GREEN both locally
+# and on a runner — no BLOCKED-on-env cases. It builds a throwaway git repo with a
+# crafted samples/ tree, makes controlled commits, and asserts the detector's outputs
+# over specific base..HEAD ranges.
+#
+# Proves the three acceptance criteria of ADO 5449686 plus the fail-loud invariant:
+#   (a) a changed file inside a sample resolves to that sample's nearest sample.yaml dir
+#   (b) a docs-only change yields has_changes=false / samples=[] / exit 0  (short-circuit)
+#   (c) multiple changed files in one sample dir dedupe to a single entry
+#   (d) a deeply-nested changed file resolves to its nearest ancestor sample.yaml (walk-up)
+#   (e) two different samples changed -> both present, sorted
+#   (f) FAIL LOUD: a nonexistent base ref makes git diff error -> exit 1 (ADO 5247751)
+#   (g) base-ref RESOLUTION: pull_request -> origin/<target>, push -> HEAD~1 (--print-base-ref)
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../detect-changed-samples.sh"
+
+PASS_N=0
+FAIL_N=0
+
+pass() { echo "  PASS  $1"; PASS_N=$((PASS_N + 1)); }
+fail() { echo "  FAIL  $1"; FAIL_N=$((FAIL_N + 1)); }
+
+# run_detect <base-ref> [extra args...] -> populates OUT (stdout+stderr) and RC.
+run_detect() {
+    local base="$1"; shift
+    OUT="$(bash "$SCRIPT" --base-ref "$base" "$@" 2>&1)"
+    RC=$?
+}
+
+# field <key> — extract the last `key=value` line the script printed to stdout.
+field() { printf '%s\n' "$OUT" | sed -n "s/^$1=\(.*\)$/\1/p" | tail -1; }
+
+# expect_out <desc> <expected-value> — assert the `samples=` JSON equals expected.
+expect_samples() {
+    local desc="$1" want="$2" got
+    got="$(field samples)"
+    if [ "$got" = "$want" ]; then pass "$desc  (samples=$got)"; else fail "$desc  expected samples=$want got=${got:-<none>}"; fi
+}
+expect_field() {
+    local desc="$1" key="$2" want="$3" got
+    got="$(field "$key")"
+    if [ "$got" = "$want" ]; then pass "$desc  ($key=$got)"; else fail "$desc  expected $key=$want got=${got:-<none>}"; fi
+}
+expect_rc() {
+    local desc="$1" want="$2"
+    if [ "$RC" = "$want" ]; then pass "$desc  (exit=$RC)"; else fail "$desc  expected exit=$want got=$RC"; fi
+}
+
+# --- Build a throwaway git repo with a crafted samples/ tree -----------------
+REPO="$(mktemp -d)"
+trap 'rm -rf "$REPO"' EXIT
+cd "$REPO" || { echo "cannot cd to temp repo"; exit 1; }
+
+git init -q
+git config user.email t@t.test
+git config user.name  test
+git config commit.gpgsign false
+
+mkdir -p samples/python/quickstart/foo
+mkdir -p samples/csharp/quickstart/bar
+mkdir -p samples/python/deep/a/b/c/src
+mkdir -p samples/docs                      # docs area under samples/, NO sample.yaml
+printf 'name: foo\n'  > samples/python/quickstart/foo/sample.yaml
+printf 'print("v1")\n' > samples/python/quickstart/foo/main.py
+printf 'name: bar\n'  > samples/csharp/quickstart/bar/sample.yaml
+printf 'x\n'          > samples/csharp/quickstart/bar/Program.cs
+printf 'y\n'          > samples/csharp/quickstart/bar/extra.cs
+printf 'name: deep\n' > samples/python/deep/a/b/c/sample.yaml
+printf 'deep\n'       > samples/python/deep/a/b/c/src/x.py
+printf '# top\n'      > samples/docs/README.md
+printf '# repo\n'     > README.md            # root doc, entirely outside samples/
+git add -A >/dev/null
+git commit -qm "base"
+BASE="$(git rev-parse HEAD)"
+
+echo "=============================================================="
+echo " detect-changed-samples: acceptance cases (git + coreutils only)"
+echo "=============================================================="
+
+# (a) change a file inside foo -> resolves to foo
+printf 'print("v2")\n' > samples/python/quickstart/foo/main.py
+git commit -qam "touch foo/main.py"
+run_detect "$BASE"
+expect_rc      "(a) changed sample -> ok"                 0
+expect_field   "(a) has_changes true"        has_changes  true
+expect_field   "(a) count 1"                 count        1
+expect_samples "(a) resolves to foo"         '["samples/python/quickstart/foo"]'
+BASE="$(git rev-parse HEAD)"
+
+# (b) docs-only: change a file under samples/ with no sample.yaml ancestor + a root doc
+printf '# top v2\n' > samples/docs/README.md
+printf '# repo v2\n' > README.md
+git commit -qam "docs only"
+run_detect "$BASE"
+expect_rc      "(b) docs-only -> ok"                      0
+expect_field   "(b) has_changes false"      has_changes   false
+expect_field   "(b) count 0"                count         0
+expect_samples "(b) empty set"              '[]'
+BASE="$(git rev-parse HEAD)"
+
+# (c) multiple files in ONE sample dir -> dedupe to a single entry
+printf 'x2\n' > samples/csharp/quickstart/bar/Program.cs
+printf 'y2\n' > samples/csharp/quickstart/bar/extra.cs
+git commit -qam "two files in bar"
+run_detect "$BASE"
+expect_rc      "(c) multi-file one dir -> ok"             0
+expect_field   "(c) count 1 (deduped)"      count         1
+expect_samples "(c) single bar entry"       '["samples/csharp/quickstart/bar"]'
+BASE="$(git rev-parse HEAD)"
+
+# (d) deeply-nested changed file -> nearest ancestor sample.yaml (walk-up)
+printf 'deep v2\n' > samples/python/deep/a/b/c/src/x.py
+git commit -qam "nested deep change"
+run_detect "$BASE"
+expect_rc      "(d) nested -> ok"                         0
+expect_samples "(d) walks up to c"          '["samples/python/deep/a/b/c"]'
+BASE="$(git rev-parse HEAD)"
+
+# (e) two different samples changed -> both present, sorted (csharp < python)
+printf 'print("v3")\n' > samples/python/quickstart/foo/main.py
+printf 'x3\n'          > samples/csharp/quickstart/bar/Program.cs
+git commit -qam "two samples"
+run_detect "$BASE"
+expect_rc      "(e) two samples -> ok"                    0
+expect_field   "(e) count 2"                count         2
+expect_samples "(e) both, sorted"           '["samples/csharp/quickstart/bar","samples/python/quickstart/foo"]'
+BASE="$(git rev-parse HEAD)"
+
+echo ""
+echo "=============================================================="
+echo " FAIL-LOUD invariant (ADO 5247751)"
+echo "=============================================================="
+# (f) nonexistent base ref -> git diff errors -> exit 1, and NOT a fake empty set
+OUT="$(bash "$SCRIPT" --base-ref does-not-exist-ref 2>&1)"; RC=$?
+expect_rc "(f) bad base ref -> fail loud" 1
+if printf '%s\n' "$OUT" | grep -q "refusing to continue"; then
+    pass "(f) prints refusal (no fake empty set)"
+else
+    fail "(f) missing refusal message"
+fi
+
+echo ""
+echo "=============================================================="
+echo " Base-ref RESOLUTION (--print-base-ref, no network)"
+echo "=============================================================="
+# (g) pull_request event -> origin/<target>; push -> HEAD~1
+G="$(bash "$SCRIPT" --event pull_request --target-branch main --print-base-ref 2>&1)"; GRC=$?
+if [ "$GRC" = 0 ] && [ "$G" = "origin/main" ]; then pass "(g) pull_request -> origin/main"; else fail "(g) pull_request expected origin/main got '$G' (rc=$GRC)"; fi
+G="$(bash "$SCRIPT" --event push --print-base-ref 2>&1)"; GRC=$?
+if [ "$GRC" = 0 ] && [ "$G" = "HEAD~1" ]; then pass "(g) push -> HEAD~1"; else fail "(g) push expected HEAD~1 got '$G' (rc=$GRC)"; fi
+# env fallback: GITHUB_BASE_REF supplies the target when --target-branch is absent
+G="$(GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=release bash "$SCRIPT" --print-base-ref 2>&1)"; GRC=$?
+if [ "$GRC" = 0 ] && [ "$G" = "origin/release" ]; then pass "(g) env pull_request -> origin/release"; else fail "(g) env pull_request expected origin/release got '$G' (rc=$GRC)"; fi
+
+echo ""
+echo "=============================================================="
+echo " --output-dir artifacts"
+echo "=============================================================="
+# The last real diff (e) had 2 samples; re-run it with --output-dir and assert files.
+ART="$(mktemp -d)"
+bash "$SCRIPT" --base-ref "$(git rev-parse HEAD~1)" --output-dir "$ART" >/dev/null 2>&1
+if [ -f "$ART/unique_changed_samples.txt" ] && [ -f "$ART/changed_files.txt" ]; then
+    if grep -q "samples/python/quickstart/foo" "$ART/unique_changed_samples.txt"; then
+        pass "--output-dir wrote unique_changed_samples.txt"
+    else
+        fail "--output-dir unique_changed_samples.txt missing expected entry"
+    fi
+else
+    fail "--output-dir did not write expected artifact files"
+fi
+rm -rf "$ART"
+
+echo ""
+echo "==================================================="
+echo "  checks passed: $PASS_N   failed: $FAIL_N"
+echo "==================================================="
+
+if [ "$FAIL_N" -ne 0 ]; then
+    echo "detect exit gate: RED — a check failed."
+    exit 1
+fi
+echo "detect exit gate: GREEN — all detection acceptance cases + fail-loud proved."

--- a/.github/workflows/detect-changed-samples-selftest.yml
+++ b/.github/workflows/detect-changed-samples-selftest.yml
@@ -1,0 +1,97 @@
+name: detect-changed-samples self-test
+
+# INERT DEV HARNESS — proves .github/scripts/detect-changed-samples.sh (the P1.2 in-job
+# path detector) is callable from a real GitHub Actions runner, that its acceptance cases
+# hold, and that its results flow through GH Actions job outputs into a downstream job via
+# needs.<job>.outputs.* (the exact plumbing P2.1/P2.2 validate lanes will consume).
+#
+# Scoped so it NEVER fires on real public-repo traffic:
+#   - workflow_dispatch: inert stub for the FINAL intended manual trigger. (Dispatch only
+#     works once the workflow lives on the default branch, which we are NOT touching yet.)
+#   - pull_request scoped to base == the integration branch below. Real public PRs target
+#     `main`, so they can never match — only a throwaway internal PR whose BASE is the
+#     integration branch runs this.
+#
+# Deliberately NO `on: paths:` filter (frozen constraint): "what changed" is decided IN-JOB
+# by the detector script, never by a trigger-path shim. Adding paths here would reintroduce
+# the rejected required-check brick + gate-shim.
+#
+# Credential-free by construction: permissions is contents:read only. No secrets, no OIDC,
+# no privileged runners. Do NOT add broad push/schedule triggers here — activation on main
+# is a separate, final, reviewed change.
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ brandom-msft-brandom-public-validation-pipeline ]
+
+permissions:
+  contents: read
+
+jobs:
+  # --- Unit proof: the detector's acceptance cases + fail-loud, hermetic (git only) -------
+  detect-selftest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect exit gate — resolve/dedupe/walk-up/docs-only/fail-loud
+        run: bash .github/scripts/test/run-detect-tests.sh
+
+  # --- Plumbing proof: detect -> job outputs -> downstream job reads needs.*.outputs ------
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.detect.outputs.has_changes }}
+      count: ${{ steps.detect.outputs.count }}
+      samples: ${{ steps.detect.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build a deterministic temp scenario and run the detector
+        id: detect
+        run: |
+          set -euo pipefail
+          SCRIPT="$GITHUB_WORKSPACE/.github/scripts/detect-changed-samples.sh"
+          REPO="$(mktemp -d)"
+          cd "$REPO"
+          git init -q
+          git config user.email t@t.test
+          git config user.name test
+          mkdir -p samples/python/quickstart/foo samples/csharp/quickstart/bar
+          printf 'name: foo\n'  > samples/python/quickstart/foo/sample.yaml
+          printf 'print("v1")\n' > samples/python/quickstart/foo/main.py
+          printf 'name: bar\n'  > samples/csharp/quickstart/bar/sample.yaml
+          printf 'x\n'          > samples/csharp/quickstart/bar/Program.cs
+          git add -A >/dev/null; git commit -qm base
+          BASE="$(git rev-parse HEAD)"
+          printf 'print("v2")\n' > samples/python/quickstart/foo/main.py
+          printf 'x2\n'          > samples/csharp/quickstart/bar/Program.cs
+          git commit -qam change
+          # Runs with the REAL $GITHUB_OUTPUT -> emits has_changes/count/samples as STEP outputs.
+          bash "$SCRIPT" --base-ref "$BASE"
+
+  consume:
+    needs: detect
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read needs.detect.outputs.* and assert
+        env:
+          HAS_CHANGES: ${{ needs.detect.outputs.has_changes }}
+          COUNT: ${{ needs.detect.outputs.count }}
+          SAMPLES: ${{ needs.detect.outputs.samples }}
+        run: |
+          set -euo pipefail
+          echo "consumed via needs.detect.outputs.*:"
+          echo "  has_changes=$HAS_CHANGES"
+          echo "  count=$COUNT"
+          echo "  samples=$SAMPLES"
+          fail=0
+          [ "$HAS_CHANGES" = "true" ] || { echo "FAIL: has_changes expected true"; fail=1; }
+          [ "$COUNT" = "2" ]          || { echo "FAIL: count expected 2"; fail=1; }
+          expected='["samples/csharp/quickstart/bar","samples/python/quickstart/foo"]'
+          [ "$SAMPLES" = "$expected" ] || { echo "FAIL: samples expected $expected"; fail=1; }
+          if [ "$fail" -ne 0 ]; then
+            echo "needs.*.outputs plumbing proof: RED"
+            exit 1
+          fi
+          echo "needs.*.outputs plumbing proof: GREEN — downstream job consumed the detected set."


### PR DESCRIPTION
P1.2 - in-job path detection. Ports the private ADO `DetectChanges` stage into `.github/scripts/detect-changed-samples.sh` (GH-Actions-native).

Throwaway internal PR to exercise the inert self-test on a real runner. Base is the integration branch, not `main`. Do not merge to `main`.

ADO Task 5449686: https://msdata.visualstudio.com/Vienna/_workitems/edit/5449686