### PR TITLE
Add project AI Gateway enablement sample under 01-connections

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/README.md
+++ b/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/README.md
@@ -1,0 +1,62 @@
+# Project AI Gateway Enablement
+
+This sample creates a new **Azure AI Foundry project** under an existing,
+already **AI-Gateway-enabled** Foundry account and enables the AI Gateway on the
+new project by default.
+
+Unlike the other samples in [01-connections](../README.md) — which create a
+`Microsoft.CognitiveServices/accounts/connections` resource — this sample
+provisions the per-project **API Management (APIM)** artifacts that mark a
+project as *gateway enabled*.
+
+## What it deploys
+
+1. **Project** (`Microsoft.CognitiveServices/accounts/projects`) under the
+   existing account.
+2. **APIM Product** (`subscriptionRequired: true`, `state: 'published'`) on the
+   account's gateway APIM service.
+3. **Product ↔ API association** — associates the gateway's shared API (named
+   after the Foundry account) with the product.
+4. **APIM Subscription** — an active subscription scoped to the product.
+5. **ARM resource link** (`Microsoft.Resources/links`) from the project to the
+   product. The presence of this link is what marks the project as **Enabled**
+   on the gateway.
+
+## Prerequisites
+
+1. Azure CLI installed and configured.
+2. An existing Azure AI Foundry account that already fronts an AI Gateway (i.e.
+   an APIM service).
+3. The full ARM resource id of the APIM service that backs the account gateway.
+
+## Parameters
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `aiFoundryAccountName` | Yes | Name of the existing gateway-enabled Foundry account. |
+| `projectName` | Yes | Name of the new project to create. |
+| `apimResourceId` | Yes | Full ARM resource id of the APIM service backing the account gateway. |
+| `projectDisplayName` | No | Display name for the project. Defaults to `projectName`. |
+| `projectDescription` | No | Description for the project. |
+| `location` | No | Location for the project. Defaults to the resource group location. |
+| `sharedApiId` | No | Gateway shared API id to associate with the product. Defaults to the account name (lowercased). |
+
+## How to Deploy
+
+```bash
+# 1. Edit main.parameters.json with your account name, project name, and APIM resource id
+# 2. Deploy into the resource group / subscription where the Foundry account lives
+az deployment group create \
+  --resource-group <foundry-rg> \
+  --template-file main.bicep \
+  --parameters @main.parameters.json
+```
+
+## Outputs
+
+| Output | Description |
+| --- | --- |
+| `projectResourceId` | Resource ID of the newly created project. |
+| `projectPrincipalId` | System-assigned principal ID of the new project. |
+| `productName` | Name of the per-project APIM product created on the gateway. |
+| `gatewayProductScope` | Resource-link target (the APIM product) that marks the project Enabled. |

--- a/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/main.bicep
@@ -1,0 +1,149 @@
+/*
+  Create a new Azure AI Foundry project under an EXISTING (already AI-Gateway-enabled)
+  Foundry account and enable the AI Gateway on the new project by default.
+
+  This sample provisions the per-project API Management (APIM) artifacts that make a
+  project "gateway enabled":
+
+    1. Create the project (Microsoft.CognitiveServices/accounts/projects).
+    2. Provision the per-project APIM artifacts on the account's gateway:
+         a. an APIM Product (subscriptionRequired: true, state: 'published'),
+         b. an association of that Product to the gateway's shared API
+            (the shared API is named after the Foundry account),
+         c. an active APIM Subscription scoped to the Product,
+         d. an ARM resource link from the project -> the Product. The presence of this
+            link is what marks the project as Enabled on the gateway.
+
+  The parent account is already "gateway enabled" because it has an ARM resource link
+  whose target is an APIM service. Pass that APIM service resource id as apimResourceId.
+
+  Prerequisites:
+    - An existing Azure AI Foundry (Cognitive Services) account that already fronts an
+      AI Gateway (i.e. an APIM service).
+    - The APIM service that backs the account gateway, and its full ARM resource id.
+
+  Run command (deploy into the resource group / subscription where the account lives):
+    az deployment group create \
+      --resource-group <foundry-rg> \
+      --template-file main.bicep \
+      --parameters @main.parameters.json
+*/
+
+targetScope = 'resourceGroup'
+
+// ========================================
+// REQUIRED PARAMETERS
+// ========================================
+
+@description('Name of the EXISTING Foundry (Cognitive Services) account that already fronts an AI Gateway.')
+param aiFoundryAccountName string = '<your-foundry-account-name>'
+
+@description('Name of the NEW project to create under the account.')
+param projectName string = '<your-new-project-name>'
+
+@description('Full ARM resource ID of the APIM service that backs the account AI Gateway (the target of the account APIM resource link).')
+param apimResourceId string = '<your-apim-resource-id>'
+
+// ========================================
+// OPTIONAL PARAMETERS
+// ========================================
+
+@description('Display name for the new project. Defaults to projectName.')
+param projectDisplayName string = projectName
+
+@description('Description for the new project.')
+param projectDescription string = 'Project created with AI Gateway enabled by default.'
+
+@description('Location for the new project. Defaults to the resource group location.')
+param location string = resourceGroup().location
+
+@description('Id of the gateway shared API in APIM to associate the product with. The gateway exposes one shared API named after the account, so this defaults to the account name.')
+param sharedApiId string = ''
+
+// ========================================
+// DERIVED VALUES
+// ========================================
+
+var apimSubscriptionId = split(apimResourceId, '/')[2]
+var apimResourceGroupName = split(apimResourceId, '/')[4]
+var apimServiceName = split(apimResourceId, '/')[8]
+
+// The gateway shared API is named after the Foundry account.
+var effectiveSharedApiId = empty(sharedApiId) ? toLower(aiFoundryAccountName) : sharedApiId
+
+// Per-project APIM entity name: {account}-{project}-ai-{unique}, lowercased.
+var productName = toLower('${take(aiFoundryAccountName, 24)}-${take(projectName, 24)}-ai-${uniqueString(subscription().id, resourceGroup().id, aiFoundryAccountName, projectName)}')
+
+// Resource-link target: the raw APIM service id + /products/{productName}.
+var productScope = '${apimResourceId}/products/${productName}'
+
+// ========================================
+// 1. NEW PROJECT
+// ========================================
+
+@description('The existing, already gateway-enabled Foundry account (parent).')
+resource aiFoundry 'Microsoft.CognitiveServices/accounts@2025-04-01-preview' existing = {
+  name: aiFoundryAccountName
+}
+
+@description('The newly created project under the existing Foundry account.')
+resource project 'Microsoft.CognitiveServices/accounts/projects@2025-04-01-preview' = {
+  parent: aiFoundry
+  name: projectName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    displayName: projectDisplayName
+    description: projectDescription
+  }
+}
+
+// ========================================
+// 2. PER-PROJECT APIM ARTIFACTS (product + api association + subscription)
+//    Created in the APIM service resource group / subscription.
+// ========================================
+
+module gatewayArtifacts 'modules/apim-gateway-artifacts.bicep' = {
+  name: 'apim-gateway-artifacts-${uniqueString(productName)}'
+  scope: resourceGroup(apimSubscriptionId, apimResourceGroupName)
+  params: {
+    apimServiceName: apimServiceName
+    productName: productName
+    sharedApiId: effectiveSharedApiId
+  }
+}
+
+// ========================================
+// 3. PROJECT -> PRODUCT RESOURCE LINK (drives gateway Enabled status)
+// ========================================
+
+@description('ARM resource link from the project to the per-project APIM product. Its presence marks the project as Enabled on the gateway.')
+resource gatewayLink 'Microsoft.Resources/links@2016-09-01' = {
+  scope: project
+  name: 'ai-gateway-${productName}'
+  properties: {
+    targetId: productScope
+    notes: 'Enables the project on the account AI Gateway (project -> APIM product).'
+  }
+  dependsOn: [
+    gatewayArtifacts
+  ]
+}
+
+// ========================================
+// OUTPUTS
+// ========================================
+
+@description('Resource ID of the newly created project.')
+output projectResourceId string = project.id
+
+@description('System-assigned principal ID of the new project.')
+output projectPrincipalId string = project.identity.principalId
+
+@description('Name of the per-project APIM product created on the gateway.')
+output productName string = productName
+
+@description('Resource-link target (the APIM product) that marks the project Enabled.')
+output gatewayProductScope string = productScope

--- a/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/main.json
+++ b/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/main.json
@@ -1,0 +1,233 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.45.15.27210",
+      "templateHash": "4807468190052045038"
+    }
+  },
+  "parameters": {
+    "aiFoundryAccountName": {
+      "type": "string",
+      "defaultValue": "<your-foundry-account-name>",
+      "metadata": {
+        "description": "Name of the EXISTING Foundry (Cognitive Services) account that already fronts an AI Gateway."
+      }
+    },
+    "projectName": {
+      "type": "string",
+      "defaultValue": "<your-new-project-name>",
+      "metadata": {
+        "description": "Name of the NEW project to create under the account."
+      }
+    },
+    "apimResourceId": {
+      "type": "string",
+      "defaultValue": "<your-apim-resource-id>",
+      "metadata": {
+        "description": "Full ARM resource ID of the APIM service that backs the account AI Gateway (the target of the account APIM resource link)."
+      }
+    },
+    "projectDisplayName": {
+      "type": "string",
+      "defaultValue": "[parameters('projectName')]",
+      "metadata": {
+        "description": "Display name for the new project. Defaults to projectName."
+      }
+    },
+    "projectDescription": {
+      "type": "string",
+      "defaultValue": "Project created with AI Gateway enabled by default.",
+      "metadata": {
+        "description": "Description for the new project."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for the new project. Defaults to the resource group location."
+      }
+    },
+    "sharedApiId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Id of the gateway shared API in APIM to associate the product with. The gateway exposes one shared API named after the account, so this defaults to the account name."
+      }
+    }
+  },
+  "variables": {
+    "apimSubscriptionId": "[split(parameters('apimResourceId'), '/')[2]]",
+    "apimResourceGroupName": "[split(parameters('apimResourceId'), '/')[4]]",
+    "apimServiceName": "[split(parameters('apimResourceId'), '/')[8]]",
+    "effectiveSharedApiId": "[if(empty(parameters('sharedApiId')), toLower(parameters('aiFoundryAccountName')), parameters('sharedApiId'))]",
+    "productName": "[toLower(format('{0}-{1}-ai-{2}', take(parameters('aiFoundryAccountName'), 24), take(parameters('projectName'), 24), uniqueString(subscription().id, resourceGroup().id, parameters('aiFoundryAccountName'), parameters('projectName'))))]",
+    "productScope": "[format('{0}/products/{1}', parameters('apimResourceId'), variables('productName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.CognitiveServices/accounts/projects",
+      "apiVersion": "2025-04-01-preview",
+      "name": "[format('{0}/{1}', parameters('aiFoundryAccountName'), parameters('projectName'))]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "properties": {
+        "displayName": "[parameters('projectDisplayName')]",
+        "description": "[parameters('projectDescription')]"
+      },
+      "metadata": {
+        "description": "The newly created project under the existing Foundry account."
+      }
+    },
+    {
+      "type": "Microsoft.Resources/links",
+      "apiVersion": "2016-09-01",
+      "scope": "[resourceId('Microsoft.CognitiveServices/accounts/projects', parameters('aiFoundryAccountName'), parameters('projectName'))]",
+      "name": "[format('ai-gateway-{0}', variables('productName'))]",
+      "properties": {
+        "targetId": "[variables('productScope')]",
+        "notes": "Enables the project on the account AI Gateway (project -> APIM product)."
+      },
+      "dependsOn": [
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', variables('apimSubscriptionId'), variables('apimResourceGroupName')), 'Microsoft.Resources/deployments', format('apim-gateway-artifacts-{0}', uniqueString(variables('productName'))))]",
+        "[resourceId('Microsoft.CognitiveServices/accounts/projects', parameters('aiFoundryAccountName'), parameters('projectName'))]"
+      ],
+      "metadata": {
+        "description": "ARM resource link from the project to the per-project APIM product. Its presence marks the project as Enabled on the gateway."
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "[format('apim-gateway-artifacts-{0}', uniqueString(variables('productName')))]",
+      "subscriptionId": "[variables('apimSubscriptionId')]",
+      "resourceGroup": "[variables('apimResourceGroupName')]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "apimServiceName": {
+            "value": "[variables('apimServiceName')]"
+          },
+          "productName": {
+            "value": "[variables('productName')]"
+          },
+          "sharedApiId": {
+            "value": "[variables('effectiveSharedApiId')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.45.15.27210",
+              "templateHash": "12804189482156169266"
+            }
+          },
+          "parameters": {
+            "apimServiceName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the existing APIM service backing the gateway."
+              }
+            },
+            "productName": {
+              "type": "string",
+              "metadata": {
+                "description": "Name of the per-project APIM product to create."
+              }
+            },
+            "sharedApiId": {
+              "type": "string",
+              "metadata": {
+                "description": "Id of the gateway shared API to associate with the product (named after the Foundry account)."
+              }
+            }
+          },
+          "resources": [
+            {
+              "type": "Microsoft.ApiManagement/service/products",
+              "apiVersion": "2022-08-01",
+              "name": "[format('{0}/{1}', parameters('apimServiceName'), parameters('productName'))]",
+              "properties": {
+                "displayName": "[parameters('productName')]",
+                "subscriptionRequired": true,
+                "state": "published"
+              }
+            },
+            {
+              "type": "Microsoft.ApiManagement/service/products/apis",
+              "apiVersion": "2022-08-01",
+              "name": "[format('{0}/{1}/{2}', parameters('apimServiceName'), parameters('productName'), parameters('sharedApiId'))]",
+              "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service/products', parameters('apimServiceName'), parameters('productName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.ApiManagement/service/subscriptions",
+              "apiVersion": "2022-08-01",
+              "name": "[format('{0}/{1}', parameters('apimServiceName'), parameters('productName'))]",
+              "properties": {
+                "displayName": "[parameters('productName')]",
+                "scope": "[resourceId('Microsoft.ApiManagement/service/products', parameters('apimServiceName'), parameters('productName'))]",
+                "state": "active",
+                "allowTracing": false
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.ApiManagement/service/products', parameters('apimServiceName'), parameters('productName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "productId": {
+              "type": "string",
+              "metadata": {
+                "description": "Resource ID of the created product."
+              },
+              "value": "[resourceId('Microsoft.ApiManagement/service/products', parameters('apimServiceName'), parameters('productName'))]"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "projectResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "Resource ID of the newly created project."
+      },
+      "value": "[resourceId('Microsoft.CognitiveServices/accounts/projects', parameters('aiFoundryAccountName'), parameters('projectName'))]"
+    },
+    "projectPrincipalId": {
+      "type": "string",
+      "metadata": {
+        "description": "System-assigned principal ID of the new project."
+      },
+      "value": "[reference(resourceId('Microsoft.CognitiveServices/accounts/projects', parameters('aiFoundryAccountName'), parameters('projectName')), '2025-04-01-preview', 'full').identity.principalId]"
+    },
+    "productName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the per-project APIM product created on the gateway."
+      },
+      "value": "[variables('productName')]"
+    },
+    "gatewayProductScope": {
+      "type": "string",
+      "metadata": {
+        "description": "Resource-link target (the APIM product) that marks the project Enabled."
+      },
+      "value": "[variables('productScope')]"
+    }
+  }
+}

--- a/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/main.parameters.json
+++ b/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/main.parameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "aiFoundryAccountName": {
+            "value": "<your-foundry-account-name>"
+        },
+        "projectName": {
+            "value": "<your-new-project-name>"
+        },
+        "apimResourceId": {
+            "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/<apim-rg>/providers/Microsoft.ApiManagement/service/<apim-service-name>"
+        },
+        "projectDisplayName": {
+            "value": "My New Project"
+        },
+        "projectDescription": {
+            "value": "Project created with AI Gateway enabled by default."
+        },
+        "sharedApiId": {
+            "value": ""
+        }
+    }
+}

--- a/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/modules/apim-gateway-artifacts.bicep
+++ b/infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/modules/apim-gateway-artifacts.bicep
@@ -1,0 +1,57 @@
+/*
+  Per-project APIM artifacts for enabling a Foundry project on an AI Gateway.
+  Deployed into the APIM service's resource group / subscription.
+
+  Creates:
+    - APIM Product     : subscriptionRequired = true, state = 'published'
+    - Product <-> API  : associate the gateway's shared API (named after the account)
+    - APIM Subscription: scoped to the product, state = 'active', allowTracing = false
+
+  The ARM resource link (project -> product) that marks the project Enabled is
+  created by the parent template at the project's scope.
+*/
+
+@description('Name of the existing APIM service backing the gateway.')
+param apimServiceName string
+
+@description('Name of the per-project APIM product to create.')
+param productName string
+
+@description('Id of the gateway shared API to associate with the product (named after the Foundry account).')
+param sharedApiId string
+
+resource apim 'Microsoft.ApiManagement/service@2022-08-01' existing = {
+  name: apimServiceName
+}
+
+// a. Per-project product (subscription required, published).
+resource product 'Microsoft.ApiManagement/service/products@2022-08-01' = {
+  parent: apim
+  name: productName
+  properties: {
+    displayName: productName
+    subscriptionRequired: true
+    state: 'published'
+  }
+}
+
+// b. Associate the gateway's shared API with the product.
+resource productApi 'Microsoft.ApiManagement/service/products/apis@2022-08-01' = {
+  parent: product
+  name: sharedApiId
+}
+
+// c. Active subscription scoped to the product.
+resource productSubscription 'Microsoft.ApiManagement/service/subscriptions@2022-08-01' = {
+  parent: apim
+  name: productName
+  properties: {
+    displayName: productName
+    scope: product.id
+    state: 'active'
+    allowTracing: false
+  }
+}
+
+@description('Resource ID of the created product.')
+output productId string = product.id


### PR DESCRIPTION
## Summary

Adds a new self-contained sample under infrastructure/infrastructure-setup-bicep/01-connections/project-ai-gateway/ that creates a new Azure AI Foundry **project** under an existing, already AI-Gateway-enabled account and **enables the AI Gateway on the project by default**.

Unlike the other 01-connections samples (which create a `Microsoft.CognitiveServices/accounts/connections` resource), this sample provisions the per-project **API Management** artifacts that mark a project as gateway-enabled.

## What it deploys

1. **Project** under the existing account.
2. **APIM Product** (`subscriptionRequired: true`, `state: 'published'`).
3. **Product ↔ API association** to the gateway's shared API (named after the account).
4. **Active APIM Subscription** scoped to the product.
5. **ARM resource link** (`Microsoft.Resources/links`) from the project to the product — its presence marks the project **Enabled** on the gateway.

## Notes

- Does **not** modify any existing connection samples.
- `main.bicep` compiles cleanly (only the expected `BCP081` info warning for `Microsoft.Resources/links`, which does not block deployment).
- Includes `README.md`, `main.bicep`, compiled `main.json`, `main.parameters.json`, and `modules/apim-gateway-artifacts.bicep`.