### PR TITLE
P3.1 probe 3: trusted broken sample (do not merge)

### DIFF
--- a/samples/python/parity-probe-p31-broken/probe.py
+++ b/samples/python/parity-probe-p31-broken/probe.py
@@ -1,0 +1,5 @@
+"""Throwaway deliberately broken P3.1 validation probe. Do not merge."""
+
+
+def main(:
+    print("This deliberate syntax error must fail validation.")

--- a/samples/python/parity-probe-p31-broken/sample.yaml
+++ b/samples/python/parity-probe-p31-broken/sample.yaml
@@ -1,0 +1,5 @@
+name: P3.1 Parity Probe - Broken
+description: Throwaway deterministic validation probe for P3.1. Do not merge.
+
+build: "echo 'P3.1 probe: no dependencies'"
+validate: "python -m py_compile probe.py"


### PR DESCRIPTION
## P3.1 validation probe — do not merge

Throwaway deterministic BROKEN probe for the public-first trusted validation lane.

- Adds one dependency-free Python sample with a deliberate syntax error.
- Expected: `detect` passes; floor `validate` fails at `py_compile`.
- Expected: `trusted` executes for this same-repo PR and fails during its in-job L3 step before OIDC/L4.

This PR exists only to collect parity evidence for ADO 5449698. **Do not merge.** It will be preserved closed after checks complete.