### PR TITLE
P3.1 real probe 3: create-agent trusted failure (do not merge)

### DIFF
--- a/samples/python/quickstart/create-agent/p31-parity-probe-broken.py
+++ b/samples/python/quickstart/create-agent/p31-parity-probe-broken.py
@@ -1,0 +1,5 @@
+"""Throwaway deliberately broken P3.1 validation probe. Do not merge."""
+
+
+def p31_probe(:
+    pass


### PR DESCRIPTION
## P3.1 existing-sample validation probe — do not merge

Throwaway BROKEN same-repo probe for `samples/python/quickstart/create-agent/`.

- Adds one isolated Python file with a deliberate syntax error.
- Expected: floor `validate` fails after the real dependency build.
- Expected: `trusted` fails during its in-job L3 validation before OIDC/L4.

This PR exists only to collect parity evidence for ADO 5449698. **Do not merge.**