### PR TITLE
Fail trusted validation for fork pull requests

### DIFF
--- a/.github/scripts/test/run-workflow-structure-tests.sh
+++ b/.github/scripts/test/run-workflow-structure-tests.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Structural regression gate for the single required `trusted` job.
+#
+# Root cause pinned here: a job-level `if:` skip concludes `skipped`, and GitHub treats a
+# skipped required check as satisfied. The job must run and fail forks explicitly after L3.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_SOURCE="$HERE/../../workflows/validate.yml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS_N=0
+FAIL_N=0
+
+pass() {
+    echo "  PASS  $1"
+    PASS_N=$((PASS_N + 1))
+}
+
+fail() {
+    echo "  FAIL  $1"
+    FAIL_N=$((FAIL_N + 1))
+}
+
+expect_count() {
+    local desc="$1" pattern="$2" expected="$3" file="${4:-$WORKFLOW}" count
+    count="$(grep -cE "$pattern" "$file" 2>/dev/null || true)"
+    if [ "$count" = "$expected" ]; then
+        pass "$desc (count=$count)"
+    else
+        fail "$desc expected count=$expected got=$count"
+    fi
+}
+
+expect_has() {
+    local desc="$1" pattern="$2" file="${3:-$WORKFLOW}"
+    if grep -qE "$pattern" "$file"; then
+        pass "$desc"
+    else
+        fail "$desc"
+    fi
+}
+
+expect_not_has() {
+    local desc="$1" pattern="$2" file="${3:-$WORKFLOW}"
+    if grep -qE "$pattern" "$file"; then
+        fail "$desc"
+    else
+        pass "$desc"
+    fi
+}
+
+extract_step() {
+    local name="$1" output="$2"
+    awk -v wanted="$name" '
+        $0 == "      - name: " wanted { in_step=1 }
+        in_step && seen && /^      - (name:|uses:)/ { exit }
+        in_step { print; seen=1 }
+    ' "$TRUSTED" > "$output"
+}
+
+if [ ! -f "$WORKFLOW_SOURCE" ]; then
+    echo "FAIL: workflow not found: $WORKFLOW_SOURCE"
+    exit 1
+fi
+
+# Keep the hermetic structure assertions stable in Windows worktrees where Git may check out
+# YAML with CRLF. The committed workflow remains untouched.
+WORKFLOW="$TMP/validate.yml"
+tr -d '\r' < "$WORKFLOW_SOURCE" > "$WORKFLOW"
+
+# Extract the trusted job by top-level job indentation. It is currently the final job, but this
+# stops correctly if a later top-level job is added.
+awk '
+    /^  trusted:$/ { in_trusted=1 }
+    in_trusted && seen && /^  [A-Za-z0-9_-]+:$/ { exit }
+    in_trusted { print; seen=1 }
+' "$WORKFLOW" > "$TMP/trusted.yml"
+TRUSTED="$TMP/trusted.yml"
+
+steps_line="$(grep -n '^    steps:$' "$TRUSTED" | cut -d: -f1 | head -1)"
+if [ -z "$steps_line" ]; then
+    echo "FAIL: trusted job has no steps block"
+    exit 1
+fi
+head -n "$((steps_line - 1))" "$TRUSTED" > "$TMP/trusted-job.yml"
+
+echo "=============================================================="
+echo " validate.yml required trusted-gate structure"
+echo "=============================================================="
+
+expect_count "workflow name remains validate" '^name: validate$' 1
+expect_count "pull_request trigger remains present" '^  pull_request:$' 1
+expect_not_has "pull_request_target is absent" '^[[:space:]]*pull_request_target:'
+expect_count "exactly one trusted job exists" '^  trusted:$' 1
+expect_not_has "trusted job has no job-level if" '^    if:' "$TMP/trusted-job.yml"
+expect_not_has "trusted job has no matrix" '^    (strategy:|matrix:)' "$TRUSTED"
+expect_has "trusted job keeps L4-validation environment" '^    environment: L4-validation$' "$TRUSTED"
+expect_not_has "job-level fork skip is absent" 'head\.repo\.fork != true' "$TMP/trusted-job.yml"
+
+extract_step "Short-circuit docs-only PRs before secrets" "$TMP/docs-only.yml"
+expect_has "docs-only success is same-repo guarded" 'head\.repo\.fork != true' "$TMP/docs-only.yml"
+
+extract_step "Validate changed samples to L3 (in-job parallel)" "$TMP/l3.yml"
+extract_step "Reject fork until maintainer promotion" "$TMP/fork-reject.yml"
+expect_has "fork rejection is fork-only" 'head\.repo\.fork == true' "$TMP/fork-reject.yml"
+expect_has "fork rejection runs after an L3 failure" '!cancelled\(\)' "$TMP/fork-reject.yml"
+expect_has "fork rejection checks OIDC request surface" 'ACTIONS_ID_TOKEN_REQUEST_(URL|TOKEN)' "$TMP/fork-reject.yml"
+expect_has "fork rejection emits promotion error" '::error::.*promot' "$TMP/fork-reject.yml"
+expect_has "fork rejection exits non-zero" '^[[:space:]]*exit 1$' "$TMP/fork-reject.yml"
+
+l3_line="$(grep -nF -- '- name: Validate changed samples to L3 (in-job parallel)' "$TRUSTED" | cut -d: -f1)"
+fork_line="$(grep -nF -- '- name: Reject fork until maintainer promotion' "$TRUSTED" | cut -d: -f1)"
+if [ -n "$l3_line" ] && [ -n "$fork_line" ] && [ "$l3_line" -lt "$fork_line" ]; then
+    pass "credential-free L3 runs before fork rejection"
+else
+    fail "credential-free L3 must run before fork rejection"
+fi
+
+# Any step containing a current credential/L4 marker must carry an explicit same-repo guard.
+if awk '
+    function flush() {
+        if (active && credentialed && !same_repo) {
+            print "unguarded credentialed step: " step
+            bad=1
+        }
+    }
+    /^      - (name:|uses:)/ {
+        flush()
+        active=1
+        step=$0
+        credentialed=0
+        same_repo=0
+    }
+    active && /azure\/login|vars\.AZURE_|az account|get-access-token|L4 smoke/ {
+        credentialed=1
+    }
+    active && /head\.repo\.fork != true/ {
+        same_repo=1
+    }
+    END {
+        flush()
+        exit bad
+    }
+' "$TRUSTED"; then
+    pass "every credentialed/L4 step has a same-repo guard"
+else
+    fail "every credentialed/L4 step must have a same-repo guard"
+fi
+
+extract_step "Trusted verdict" "$TMP/verdict.yml"
+expect_has "trusted success verdict is same-repo guarded" 'head\.repo\.fork != true' "$TMP/verdict.yml"
+
+echo ""
+echo "==================================================="
+echo "  checks passed: $PASS_N   failed: $FAIL_N"
+echo "==================================================="
+
+if [ "$FAIL_N" -ne 0 ]; then
+    echo "workflow structure exit gate: RED"
+    exit 1
+fi
+echo "workflow structure exit gate: GREEN"

--- a/.github/scripts/test/run-workflow-structure-tests.sh
+++ b/.github/scripts/test/run-workflow-structure-tests.sh
@@ -94,10 +94,72 @@ expect_count "workflow name remains validate" '^name: validate$' 1
 expect_count "pull_request trigger remains present" '^  pull_request:$' 1
 expect_not_has "pull_request_target is absent" '^[[:space:]]*pull_request_target:'
 expect_count "exactly one trusted job exists" '^  trusted:$' 1
-expect_not_has "trusted job has no job-level if" '^    if:' "$TMP/trusted-job.yml"
+expect_count "trusted has exactly one job-level condition" '^    if:' 1 "$TMP/trusted-job.yml"
+expect_count "trusted job runs after dependency failure unless cancelled" '^    if: \$\{\{ !cancelled\(\) \}\}$' 1 "$TMP/trusted-job.yml"
 expect_not_has "trusted job has no matrix" '^    (strategy:|matrix:)' "$TRUSTED"
 expect_has "trusted job keeps L4-validation environment" '^    environment: L4-validation$' "$TRUSTED"
 expect_not_has "job-level fork skip is absent" 'head\.repo\.fork != true' "$TMP/trusted-job.yml"
+expect_not_has "job-level draft skip is absent" 'pull_request\.draft' "$TMP/trusted-job.yml"
+
+extract_step "Validate sample detection contract" "$TMP/detect-contract.yml"
+first_step="$(tail -n "+$((steps_line + 1))" "$TRUSTED" | grep -m1 -E '^      - (name:|uses:)')"
+if [ "$first_step" = "      - name: Validate sample detection contract" ]; then
+    pass "detection contract is the first trusted step"
+else
+    fail "detection contract must be the first trusted step (got: ${first_step:-<none>})"
+fi
+contract_line="$(grep -nF -- '- name: Validate sample detection contract' "$TRUSTED" | cut -d: -f1)"
+checkout_line="$(grep -nF -- '- uses: actions/checkout@v4' "$TRUSTED" | cut -d: -f1 | head -1)"
+if [ -n "$contract_line" ] && [ -n "$checkout_line" ] && [ "$contract_line" -lt "$checkout_line" ]; then
+    pass "detection contract runs before checkout"
+else
+    fail "detection contract must run before checkout"
+fi
+expect_has "contract reads needs.detect.result" 'DETECT_RESULT: \$\{\{ needs\.detect\.result \}\}' "$TMP/detect-contract.yml"
+expect_has "contract reads has_changes output" 'HAS_CHANGES: \$\{\{ needs\.detect\.outputs\.has_changes \}\}' "$TMP/detect-contract.yml"
+expect_has "contract reads count output" 'COUNT: \$\{\{ needs\.detect\.outputs\.count \}\}' "$TMP/detect-contract.yml"
+expect_has "contract reads samples output" 'SAMPLES: \$\{\{ needs\.detect\.outputs\.samples \}\}' "$TMP/detect-contract.yml"
+expect_has "contract requires successful dependency" 'DETECT_RESULT.*!=.*success' "$TMP/detect-contract.yml"
+expect_has "contract restricts has_changes domain" 'true\|false' "$TMP/detect-contract.yml"
+expect_has "contract parses samples as JSON array" 'type == "array"' "$TMP/detect-contract.yml"
+expect_has "contract validates sample path shape" 'startswith\("samples/"\)' "$TMP/detect-contract.yml"
+expect_has "contract fails non-zero" '^[[:space:]]*exit 1$' "$TMP/detect-contract.yml"
+expect_not_has "contract cannot ignore failures" 'continue-on-error:' "$TMP/detect-contract.yml"
+
+# Execute the inline contract hermetically. Static assertions prove its position and Actions
+# wiring; these cases prove the shell logic rejects dependency/output corruption.
+awk '
+    /^        run: \|$/ { in_run=1; next }
+    in_run {
+        sub(/^          /, "")
+        print
+    }
+' "$TMP/detect-contract.yml" > "$TMP/detect-contract.sh"
+
+run_contract_case() {
+    local desc="$1" expected="$2" result="$3" has_changes="$4" count="$5" samples="$6"
+    local output="$TMP/contract-output.txt" rc
+    if DETECT_RESULT="$result" HAS_CHANGES="$has_changes" COUNT="$count" SAMPLES="$samples" \
+        bash "$TMP/detect-contract.sh" > "$output" 2>&1; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [ "$rc" = "$expected" ]; then
+        pass "$desc (exit=$rc)"
+    else
+        fail "$desc expected exit=$expected got=$rc: $(tr '\n' '|' < "$output")"
+    fi
+}
+
+run_contract_case "valid changed-sample contract passes" 0 success true 1 '["samples/python/foo"]'
+run_contract_case "valid docs-only contract passes" 0 success false 0 '[]'
+run_contract_case "failed detect result fails closed" 1 failure false 0 '[]'
+run_contract_case "malformed samples JSON fails closed" 1 success true 1 '{'
+run_contract_case "non-array samples fails closed" 1 success true 1 '{"sample":"samples/python/foo"}'
+run_contract_case "true with empty samples fails closed" 1 success true 0 '[]'
+run_contract_case "false with samples fails closed" 1 success false 1 '["samples/python/foo"]'
+run_contract_case "count mismatch fails closed" 1 success true 2 '["samples/python/foo"]'
 
 extract_step "Short-circuit docs-only PRs before secrets" "$TMP/docs-only.yml"
 expect_has "docs-only success is same-repo guarded" 'head\.repo\.fork != true' "$TMP/docs-only.yml"

--- a/.github/workflows/scripts-selftest.yml
+++ b/.github/workflows/scripts-selftest.yml
@@ -11,19 +11,30 @@ name: scripts self-test
 # construction: permissions is contents:read only, no secrets, no OIDC, no privileged runners.
 # These are pure script tests. Do NOT make any job here a required check and do NOT edit rulesets.
 #
-# Trigger scope: only PRs that touch `.github/scripts/**` run this — a normal sample-authoring PR
-# (samples/**, docs, etc.) never triggers it, so there is zero added friction for contributors.
+# Trigger scope: validation scripts, their tests, or the two validation workflow definitions.
+# A normal sample-authoring PR (samples/**, docs, etc.) never triggers it, so there is zero added
+# friction for contributors.
 # No `push:` trigger: PR-time is the gate that matters; `workflow_dispatch` covers manual/backfill.
 on:
   workflow_dispatch:
   pull_request:
     paths:
       - '.github/scripts/**'
+      - '.github/workflows/validate.yml'
+      - '.github/workflows/scripts-selftest.yml'
 
 permissions:
   contents: read
 
 jobs:
+  # --- Required-gate structure: hermetic Bash assertions, no credentials -------------------------
+  workflow-structure-harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: validate.yml trusted-gate structure exit gate
+        run: bash .github/scripts/test/run-workflow-structure-tests.sh
+
   # --- Detector harness: hermetic (git + coreutils only), runs fully GREEN anywhere --------------
   detect-harness:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,8 @@ name: validate
 #   - The required `trusted` job ALWAYS runs. Forks execute its credential-free L3 path, then
 #     fail explicitly with a promotion-required error. A job-level fork skip is forbidden:
 #     GitHub treats a required check that concludes `skipped` as satisfied.
+#   - `trusted` uses the status-function condition `!cancelled()` so a failed/malformed `detect`
+#     dependency starts the job and fails its first contract-check step instead of skipping open.
 #   - Every credentialed setup/L4 step has an explicit same-repo guard. Fork isolation remains
 #     layered: read-only fork token/no secrets/no OIDC issuance + step-level guards.
 #   - The job checks out and EXECUTES untrusted fork code (dotnet build, npm install,
@@ -154,6 +156,9 @@ jobs:
   #   - ALWAYS RUNS for every triggered PR. Forks run credential-free L3, then fail in-job with
   #     a promotion-required error. Never restore a job-level fork/draft `if:`: P3.3 proved that
   #     GitHub treats a required job that concludes `skipped` as satisfying the merge gate.
+  #   - FAILS CLOSED when `detect` fails or emits malformed outputs. The exact job-level
+  #     `!cancelled()` status condition starts trusted after dependency failure; the FIRST step
+  #     validates the dependency result/output contract before checkout or docs-only handling.
   #   - Docs-only PRs SHORT-CIRCUIT before any Azure/secret step (has_changes gate). A docs-only
   #     same-repo PR yields a PRESENT, PASSING check (correct "no sample owes L4"); every fork
   #     yields a PRESENT, FAILING check and requires maintainer promotion.
@@ -164,6 +169,7 @@ jobs:
   #     binds the environment, an environment reviewer rule would stall a fork instead of failing it.
   trusted:
     needs: detect
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     # Binds the OIDC subject to environment:L4-validation (matches the Azure federated credential)
     # and scopes vars.AZURE_* to that environment.
@@ -182,6 +188,53 @@ jobs:
       # the cadence lane only and must never be "warmed" here for speed).
       SKIP_PROVISION: "true"
     steps:
+      # MUST remain first. A failed `needs` job normally skips dependents; the job-level
+      # !cancelled() condition starts trusted, and this contract check turns dependency/output
+      # corruption into a terminal failure before missing values can resemble "docs-only".
+      - name: Validate sample detection contract
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          HAS_CHANGES: ${{ needs.detect.outputs.has_changes }}
+          COUNT: ${{ needs.detect.outputs.count }}
+          SAMPLES: ${{ needs.detect.outputs.samples }}
+        run: |
+          set -euo pipefail
+          fail_contract() {
+            echo "::error::$1"
+            exit 1
+          }
+
+          if [ "$DETECT_RESULT" != "success" ]; then
+            fail_contract "Sample detection did not succeed (result=${DETECT_RESULT:-missing}); trusted fails closed."
+          fi
+          case "$HAS_CHANGES" in
+            true|false) ;;
+            *) fail_contract "Invalid detect output has_changes='${HAS_CHANGES:-missing}'; expected exactly true or false." ;;
+          esac
+          case "$COUNT" in
+            ''|*[!0-9]*) fail_contract "Invalid detect output count='${COUNT:-missing}'; expected a non-negative integer." ;;
+          esac
+
+          if ! sample_count="$(printf '%s' "$SAMPLES" | jq -er '
+            if type == "array"
+              and all(.[]; type == "string" and startswith("samples/") and length > 8)
+            then length
+            else error("samples must be an array of sample paths")
+            end
+          ')"; then
+            fail_contract "Invalid detect output samples; expected JSON array of paths under samples/."
+          fi
+          if [ "$COUNT" != "$sample_count" ]; then
+            fail_contract "Detect output count=$COUNT does not match samples length=$sample_count."
+          fi
+          if [ "$HAS_CHANGES" = "true" ] && [ "$sample_count" = "0" ]; then
+            fail_contract "Detect output has_changes=true requires at least one sample."
+          fi
+          if [ "$HAS_CHANGES" = "false" ] && [ "$sample_count" != "0" ]; then
+            fail_contract "Detect output has_changes=false requires samples=[] and count=0."
+          fi
+          echo "Detection contract valid: has_changes=$HAS_CHANGES count=$COUNT."
+
       - uses: actions/checkout@v4
 
       # --- Docs-only short-circuit (BEFORE any secret/Azure step) ---------------

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,9 +7,11 @@ name: validate
 # FORK-SAFE BY CONSTRUCTION (this is the headline property):
 #   - on: pull_request  (NEVER pull_request_target) — so PRs from forks run this with a
 #     read-only GITHUB_TOKEN and NO access to secrets, per GitHub's documented behavior.
-#   - permissions: contents: read is the workflow default. No `environment:` and no secret
-#     references on any FORK-REACHABLE job (detect/validate) — the credentialed `trusted` L4
-#     lane below is structurally unreachable from forks (if: fork != true), so it never runs here.
+#   - The required `trusted` job ALWAYS runs. Forks execute its credential-free L3 path, then
+#     fail explicitly with a promotion-required error. A job-level fork skip is forbidden:
+#     GitHub treats a required check that concludes `skipped` as satisfied.
+#   - Every credentialed setup/L4 step has an explicit same-repo guard. Fork isolation remains
+#     layered: read-only fork token/no secrets/no OIDC issuance + step-level guards.
 #   - The job checks out and EXECUTES untrusted fork code (dotnet build, npm install,
 #     pip install, mvn compile, ...). That is intentional and safe *because* the runner is
 #     barren: nothing here can exfiltrate a credential, because there is no credential.
@@ -19,13 +21,12 @@ name: validate
 # decided IN-JOB by detect-changed-samples.sh and fanned out via needs.*.outputs. The
 # trusted L4 lane (secrets, fork-gated) is the `trusted` job at the BOTTOM of THIS workflow
 # (P2.2, ADO 5449696) — a SINGLE job (never a matrix), so its required-check context is exactly
-# `validate / trusted` (workflow name `validate` + job name `trusted`).
+# `trusted` (displayed by Actions as `validate / trusted`).
 
 on:
   pull_request:
-    # `ready_for_review` is added for the fork-gated `trusted` job (P2.2): it re-triggers the
-    # workflow when a draft is marked ready. The floor lane still runs on drafts via the default
-    # opened/synchronize; draft-skip is enforced ONLY on the `trusted` job's `if:` (not here).
+    # `ready_for_review` preserves an explicit re-trigger when a draft is marked ready. The
+    # trusted job also runs on drafts: a job-level draft skip would produce a skipped check.
     # No `branches:` filter (runs for every PR, incl. those targeting main) and no `paths:`
     # filter (path detection is data-driven in-job, not a trigger shim).
     types: [opened, synchronize, reopened, ready_for_review]
@@ -150,24 +151,19 @@ jobs:
   #   - SINGLE JOB, no per-language matrix. A matrix of required checks reinstates the rejected
   #     aggregator/gate-shim. Speed comes from IN-JOB parallelism (the L3 step backgrounds
   #     validate-sample.sh per changed sample), never from fan-out into multiple checks.
-  #   - if: fork != true → fork PRs skip this job, so a fork structurally cannot produce the
-  #     `validate / trusted` check → un-mergeable once P3 makes it required → promotion forced.
+  #   - ALWAYS RUNS for every triggered PR. Forks run credential-free L3, then fail in-job with
+  #     a promotion-required error. Never restore a job-level fork/draft `if:`: P3.3 proved that
+  #     GitHub treats a required job that concludes `skipped` as satisfying the merge gate.
   #   - Docs-only PRs SHORT-CIRCUIT before any Azure/secret step (has_changes gate). A docs-only
-  #     PR still yields a PRESENT, PASSING check (correct "no sample owes L4"); a fork yields NO
-  #     check at all. Those two outcomes are deliberately different and handled at different levels
-  #     (fork/draft at the job `if:`; docs-only in-job).
-  #   - Draft-skipped; concurrency cancels superseded runs.
+  #     same-repo PR yields a PRESENT, PASSING check (correct "no sample owes L4"); every fork
+  #     yields a PRESENT, FAILING check and requires maintainer promotion.
+  #   - Concurrency cancels superseded runs.
   #   - L4 = the pre-provisioned WARM validation project via SKIP_PROVISION=true (never provisions
   #     per PR — cold provisioning is the cadence lane's sole job). OIDC federated login, no stored
-  #     secret. Env L4-validation verified 2026-07-29 to carry zero protection_rules, so the
-  #     environment binding does not pause docs-only runs.
+  #     secret. Env L4-validation MUST carry zero protection_rules: because this always-running job
+  #     binds the environment, an environment reviewer rule would stall a fork instead of failing it.
   trusted:
     needs: detect
-    # Fork + draft gate ONLY. The docs-only short-circuit is in-job (below) so it yields a passing
-    # check; forks/drafts skip the job entirely. head.repo.fork is a boolean.
-    if: >-
-      github.event.pull_request.head.repo.fork != true &&
-      github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     # Binds the OIDC subject to environment:L4-validation (matches the Azure federated credential)
     # and scopes vars.AZURE_* to that environment.
@@ -190,10 +186,10 @@ jobs:
 
       # --- Docs-only short-circuit (BEFORE any secret/Azure step) ---------------
       # If detect found no changed sample, nothing owes L4 → the trusted gate is satisfied. Log and
-      # let the job end green WITHOUT touching OIDC/secrets. Every real step below is guarded on
-      # has_changes == 'true', so a docs-only PR can never reach azure/login.
+      # let a SAME-REPO job end green WITHOUT touching OIDC/secrets. Forks never short-circuit to
+      # success; they reach the explicit promotion failure below.
       - name: Short-circuit docs-only PRs before secrets
-        if: needs.detect.outputs.has_changes != 'true'
+        if: needs.detect.outputs.has_changes != 'true' && github.event.pull_request.head.repo.fork != true
         run: echo "No changed samples (docs-only) -> no sample owes L4 -> trusted gate satisfied. Skipping L3+L4 without touching secrets."
 
       # --- Derive which toolchains the changed samples actually need ------------
@@ -321,11 +317,24 @@ jobs:
           fi
           echo "L3 green for all $pass changed sample(s)."
 
+      # A fork must produce a terminal FAILURE, never a skipped required check. This step uses a
+      # status function so it still emits the promotion instruction after a broken fork's L3 fails.
+      - name: Reject fork until maintainer promotion
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.fork == true }}
+        run: |
+          set -euo pipefail
+          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            echo "::error::Fork runner unexpectedly received an OIDC request surface; refusing to continue."
+            exit 1
+          fi
+          echo "::error::Fork PRs cannot satisfy the trusted gate directly. A maintainer must promote this commit to a same-repo branch, where the credentialed L4 path can run."
+          exit 1
+
       # --- L4: reach the WARM project via OIDC (only after L3 green) ------------
       # Reached only when real samples changed AND L3 passed (default step success() gating). This
       # is the trusted secret boundary: federated OIDC login, no stored secret.
       - name: Azure login via OIDC (no secret)
-        if: needs.detect.outputs.has_changes == 'true'
+        if: needs.detect.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork != true
         uses: azure/login@v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
@@ -333,7 +342,7 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: L4 smoke against the warm project (SKIP_PROVISION)
-        if: needs.detect.outputs.has_changes == 'true'
+        if: needs.detect.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork != true
         env:
           AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
           MODEL_DEPLOYMENT: gpt-5.4-mini
@@ -353,5 +362,5 @@ jobs:
           echo "L4 OK: OIDC + SKIP_PROVISION warm-project reach + least-priv inference all green."
 
       - name: Trusted verdict
-        if: needs.detect.outputs.has_changes == 'true'
+        if: needs.detect.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork != true
         run: echo "validate / trusted GREEN — L3 passed for all changed samples AND the L4 warm-project smoke passed."


### PR DESCRIPTION
## Summary

- keep the single `trusted` job running for every `pull_request`
- run credential-free L3 before explicitly failing fork PRs with a maintainer-promotion instruction
- guard every Azure/OIDC/L4 step on same-repo origin
- add a hermetic workflow-structure regression harness to the existing self-test workflow

## Root cause

Live enforcement proof on [microsoft-foundry/foundry-samples#874](https://github.com/microsoft-foundry/foundry-samples/pull/874) showed that a job-level fork `if:` concludes `trusted` as `SKIPPED`, and GitHub accepts that skipped required check as satisfied. The PR became mergeable when the review requirement was temporarily removed.

The corrected job always runs. Forks perform credential-free L3 work, verify that no OIDC request surface is present, emit an explicit promotion-required error, and exit 1. Same-repo PRs retain the existing docs-only and conditional L4 paths.

## Credential isolation

- event remains `pull_request`, never `pull_request_target`
- fork token/secrets/OIDC boundary remains GitHub-enforced
- Azure login, environment-variable consumption, L4 smoke, and trusted success verdict each require same-repo origin
- `L4-validation` was verified to have no protection rules before implementation

## Validation

- `bash .github/scripts/test/run-workflow-structure-tests.sh` — 17 passed, 0 failed
- `bash -n .github/scripts/test/run-workflow-structure-tests.sh`
- `git diff --check`

`actionlint` and `shellcheck` are not installed or configured in the current repository tooling, so no new linter dependency was introduced.

## Tracking

- ADO 5494970: https://msdata.visualstudio.com/Vienna/_workitems/edit/5494970
- ADO 5449700: https://msdata.visualstudio.com/Vienna/_workitems/edit/5449700

No ruleset or environment mutation is included in this PR.