### PR TITLE
[DO NOT MERGE] P3.3 detect-failure scheduler proof

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -53,7 +53,10 @@ jobs:
         # Reads $GITHUB_EVENT_NAME (pull_request) + $GITHUB_BASE_REF (target branch), diffs
         # scoped to samples/, and emits has_changes/count/samples to $GITHUB_OUTPUT. Fails
         # loud (exit 1) if the git diff itself errors — never a fake empty set.
-        run: bash .github/scripts/detect-changed-samples.sh
+        # TEMPORARY P3.3 CONTROLLED PROOF — intentional failure, do not merge.
+        run: |
+          echo "::error::P3.3 controlled scheduler proof: detect fails intentionally"
+          exit 97
 
   # --- Validate each changed sample to L3, one runner per sample ---------------
   validate:


### PR DESCRIPTION
**⚠️ DO NOT MERGE — temporary controlled proof, will be closed without merging.**

Stacked on `brandom-msft-p3-3-ruleset-flip` (base of this PR), NOT on `main`. Contains a single proof-only commit that intentionally makes the `validate.yml` `detect` job fail (exit 97) via a hardcoded error block, replacing the real detector invocation.

**Purpose:** prove the fail-closed contract of the `validate / trusted` required check — that a failed `detect` dependency causes `trusted` to run (via `if: !cancelled()`) and fail immediately at its first "Validate sample detection contract" step, without reaching checkout, docs-only short-circuit, or any Azure/OIDC/L4 step.

This PR intentionally targets a non-`main` base and will remain unmerged. It will be closed out once evidence is captured.