### PR TITLE
fix(template-15a): honor location param for private endpoints (#657)

### DIFF
--- a/infrastructure/infrastructure-setup-bicep/15a-private-network-evaluation-only-setup/azuredeploy.json
+++ b/infrastructure/infrastructure-setup-bicep/15a-private-network-evaluation-only-setup/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.44.1.10279",
-      "templateHash": "9005518444680591480"
+      "templateHash": "9672416477166736753"
     }
   },
   "parameters": {
@@ -1236,6 +1236,9 @@
           "aiAccountName": {
             "value": "[reference(resourceId('Microsoft.Resources/deployments', format('{0}-{1}-deployment', variables('accountName'), variables('uniqueSuffix'))), '2025-04-01').outputs.accountName.value]"
           },
+          "location": {
+            "value": "[parameters('location')]"
+          },
           "storageName": {
             "value": "[reference(resourceId('Microsoft.Resources/deployments', format('dependencies-{0}-deployment', variables('uniqueSuffix'))), '2025-04-01').outputs.azureStorageName.value]"
           },
@@ -1274,10 +1277,17 @@
             "_generator": {
               "name": "bicep",
               "version": "0.44.1.10279",
-              "templateHash": "11525768866797919522"
+              "templateHash": "2137547566661638544"
             }
           },
           "parameters": {
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Azure region for the private endpoints. Defaults to the resource group location for backward compatibility; pass the deployment location so private endpoints are co-located with their target resources when the resource group is in a different region."
+              }
+            },
             "aiAccountName": {
               "type": "string",
               "metadata": {
@@ -1374,7 +1384,7 @@
               "type": "Microsoft.Network/privateEndpoints",
               "apiVersion": "2024-05-01",
               "name": "[format('{0}-private-endpoint', parameters('aiAccountName'))]",
-              "location": "[resourceGroup().location]",
+              "location": "[parameters('location')]",
               "properties": {
                 "subnet": {
                   "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('vnetSubscriptionId'), parameters('vnetResourceGroupName')), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('peSubnetName'))]"
@@ -1396,7 +1406,7 @@
               "type": "Microsoft.Network/privateEndpoints",
               "apiVersion": "2024-05-01",
               "name": "[format('{0}-private-endpoint', parameters('storageName'))]",
-              "location": "[resourceGroup().location]",
+              "location": "[parameters('location')]",
               "properties": {
                 "subnet": {
                   "id": "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', parameters('vnetSubscriptionId'), parameters('vnetResourceGroupName')), 'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('peSubnetName'))]"

--- a/infrastructure/infrastructure-setup-bicep/15a-private-network-evaluation-only-setup/main.bicep
+++ b/infrastructure/infrastructure-setup-bicep/15a-private-network-evaluation-only-setup/main.bicep
@@ -215,6 +215,7 @@ module privateEndpointAndDNS 'modules-network-secured/private-endpoint-and-dns.b
   name: '${uniqueSuffix}-private-endpoint'
   params: {
     aiAccountName: aiAccount.outputs.accountName
+    location: location                               // Co-locate PEs with target resources (issue #657)
     storageName: aiDependencies.outputs.azureStorageName
     vnetName: vnet.outputs.virtualNetworkName
     peSubnetName: vnet.outputs.peSubnetName

--- a/infrastructure/infrastructure-setup-bicep/15a-private-network-evaluation-only-setup/modules-network-secured/private-endpoint-and-dns.bicep
+++ b/infrastructure/infrastructure-setup-bicep/15a-private-network-evaluation-only-setup/modules-network-secured/private-endpoint-and-dns.bicep
@@ -18,6 +18,8 @@ No Cosmos DB or AI Search private endpoints are created.
 */
 
 // Resource names and identifiers
+@description('Azure region for the private endpoints. Defaults to the resource group location for backward compatibility; pass the deployment location so private endpoints are co-located with their target resources when the resource group is in a different region.')
+param location string = resourceGroup().location
 @description('Name of the AI Foundry account')
 param aiAccountName string
 @description('Name of the storage account')
@@ -77,7 +79,7 @@ resource peSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' existin
 
 resource aiAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
   name: '${aiAccountName}-private-endpoint'
-  location: resourceGroup().location
+  location: location
   properties: {
     subnet: { id: peSubnet.id }
     privateLinkServiceConnections: [
@@ -96,7 +98,7 @@ resource aiAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01
 
 resource storagePrivateEndpoint 'Microsoft.Network/privateEndpoints@2024-05-01' = {
   name: '${storageName}-private-endpoint'
-  location: resourceGroup().location
+  location: location
   properties: {
     subnet: { id: peSubnet.id }
     privateLinkServiceConnections: [


### PR DESCRIPTION
### Problem

Private endpoints in template **15a** hardcoded `resourceGroup().location`, so they were created in the resource group's region even when the deployment targeted a different `location`. Because Microsoft.Network only resolves subnet references within the private endpoint's own region, a cross-region reference fails with a misleading error:

```
InvalidResourceReference: Resource .../virtualNetworks/<vnet> referenced by
resource .../privateEndpoints/<pe> was not found. Please make sure that the
referenced resource exists, and that both resources are in the same region.
```

The VNet exists and the resource ID is correct — only the region differs, which makes this hard to self-diagnose.

This is the same defect as #657, which was fixed for template 15 in c8d6d93 but **never ported to 15a**. It also affects the compiled `azuredeploy.json`, so the "Deploy to Azure" button and the portal path were impacted too.

This is currently causing a live Azure support escalation on a South India deployment.

### Fix

Mirrors c8d6d93 exactly:

- Add a `location` param to `modules-network-secured/private-endpoint-and-dns.bicep`, defaulting to `resourceGroup().location` for backward compatibility
- Use it on both `aiAccountPrivateEndpoint` and `storagePrivateEndpoint`
- Thread the top-level `location` param through from `main.bicep`
- Regenerate `azuredeploy.json`

Note that the sibling `container-registry` module in this same template **already** honoured `parameters('location')` for its private endpoint. So this change removes an internal inconsistency rather than introducing new behaviour — two of the three private endpoints in the compiled template were pinned to the resource group region while the third was not.

### Verification

- `bicep build` succeeds with no new warnings (the remaining warnings are pre-existing)
- All three private endpoints in `azuredeploy.json` now resolve to `[parameters('location')]`
- `azuredeploy.json` was rebuilt with **bicep 0.44.1**, the same version that produced the existing artifact, so the only JSON churn is the two template hashes — no generator-version noise
- Backward compatible: the param defaults to `resourceGroup().location`, so existing same-region deployments are unaffected

### Follow-up (deliberately not in this PR)

`modules-network-secured/existing-vnet.bicep` scopes the VNet lookup with `resourceGroup(vnetResourceGroupName)`, omitting the subscription argument. The accepted `vnetSubscriptionId` param is therefore only echoed to outputs and never used for scoping, so **cross-subscription BYO VNet is silently unsupported** in 15a. It should be `resourceGroup(vnetSubscriptionId, vnetResourceGroupName)`. Kept out of this PR to keep the fix focused — happy to send it separately.

Fixes #657 for template 15a.
