### PR TITLE
Add canonical public transition manifest classifier

### DIFF
--- a/.github/public-transition-manifest.json
+++ b/.github/public-transition-manifest.json
@@ -1,0 +1,213 @@
+{
+  "schema_version": 1,
+  "match_semantics": "first-match",
+  "glob_dialect": "p5-posix-v1",
+  "default_classification": "unresolved",
+  "default_check_class": "none",
+  "default_disposition": "unresolved",
+  "rules": [
+    {
+      "id": "internal-azure-pipelines",
+      "glob": ".azure-pipelines/**",
+      "classification": "internal-only",
+      "check_class": "none",
+      "disposition": "internal-only"
+    },
+    {
+      "id": "internal-github",
+      "glob": ".github/**",
+      "classification": "internal-only",
+      "check_class": "none",
+      "disposition": "internal-only"
+    },
+    {
+      "id": "internal-docs",
+      "glob": "docs/**",
+      "classification": "internal-only",
+      "check_class": "none",
+      "disposition": "internal-only"
+    },
+    {
+      "id": "internal-root",
+      "glob": "internal/**",
+      "classification": "internal-only",
+      "check_class": "none",
+      "disposition": "internal-only"
+    },
+    {
+      "id": "internal-public-overlay",
+      "glob": "public-overlay/**",
+      "classification": "internal-only",
+      "check_class": "none",
+      "disposition": "internal-only"
+    },
+    {
+      "id": "internal-readme",
+      "glob": "README.md",
+      "classification": "internal-only",
+      "check_class": "none",
+      "disposition": "internal-only"
+    },
+    {
+      "id": "internal-contributing",
+      "glob": "CONTRIBUTING.md",
+      "classification": "internal-only",
+      "check_class": "none",
+      "disposition": "internal-only"
+    },
+    {
+      "id": "internal-ci-skip",
+      "glob": "**/.ci-skip",
+      "classification": "internal-only",
+      "check_class": "none",
+      "disposition": "internal-only"
+    },
+    {
+      "id": "internal-code-ci-skip",
+      "glob": "**/.code-ci-skip",
+      "classification": "internal-only",
+      "check_class": "none",
+      "disposition": "internal-only"
+    },
+    {
+      "id": "python-hosted-agents-private-dependent",
+      "glob": "samples/python/hosted-agents/**",
+      "classification": "private-workflow-dependent",
+      "check_class": "hosted-agents",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "csharp-hosted-agents-private-dependent",
+      "glob": "samples/csharp/hosted-agents/**",
+      "classification": "private-workflow-dependent",
+      "check_class": "hosted-agents",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "bicep-private-dependent",
+      "glob": "infrastructure/infrastructure-setup-bicep/**",
+      "classification": "private-workflow-dependent",
+      "check_class": "bicep",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "samples-public-ready",
+      "glob": "samples/**",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "samples-classic-public-ready",
+      "glob": "samples-classic/**",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "samples-mistral-public-ready",
+      "glob": "samples-mistral/**",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "infrastructure-public-ready",
+      "glob": "infrastructure/**",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "migration-public-ready",
+      "glob": "migration/**",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "infra-public-ready",
+      "glob": ".infra/**",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "gitattributes-public-ready",
+      "glob": ".gitattributes",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "gitignore-public-ready",
+      "glob": ".gitignore",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "pre-commit-config-public-ready",
+      "glob": ".pre-commit-config.yaml",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "code-of-conduct-public-ready",
+      "glob": "CODE_OF_CONDUCT.md",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "license-public-ready",
+      "glob": "LICENSE",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "security-public-ready",
+      "glob": "SECURITY.md",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "support-public-ready",
+      "glob": "SUPPORT.md",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "conftest-public-ready",
+      "glob": "conftest.py",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "dev-requirements-public-ready",
+      "glob": "dev-requirements.txt",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "package-lock-public-ready",
+      "glob": "package-lock.json",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    },
+    {
+      "id": "tox-public-ready",
+      "glob": "tox.ini",
+      "classification": "public-ready",
+      "check_class": "none",
+      "disposition": "public-facing"
+    }
+  ]
+}

--- a/.github/public-transition-manifest.json
+++ b/.github/public-transition-manifest.json
@@ -74,21 +74,33 @@
       "glob": "samples/python/hosted-agents/**",
       "classification": "private-workflow-dependent",
       "check_class": "hosted-agents",
-      "disposition": "public-facing"
+      "disposition": "public-facing",
+      "delegation": {
+        "mode": "tracked-sample-yaml-roots",
+        "root": "samples/python/hosted-agents"
+      }
     },
     {
       "id": "csharp-hosted-agents-private-dependent",
       "glob": "samples/csharp/hosted-agents/**",
       "classification": "private-workflow-dependent",
       "check_class": "hosted-agents",
-      "disposition": "public-facing"
+      "disposition": "public-facing",
+      "delegation": {
+        "mode": "tracked-sample-yaml-roots",
+        "root": "samples/csharp/hosted-agents"
+      }
     },
     {
       "id": "bicep-private-dependent",
       "glob": "infrastructure/infrastructure-setup-bicep/**",
       "classification": "private-workflow-dependent",
       "check_class": "bicep",
-      "disposition": "public-facing"
+      "disposition": "public-facing",
+      "delegation": {
+        "mode": "rule-root",
+        "root": "infrastructure/infrastructure-setup-bicep"
+      }
     },
     {
       "id": "samples-public-ready",

--- a/.github/scripts/public_transition_manifest.py
+++ b/.github/scripts/public_transition_manifest.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Validate and apply the public-transition path classification manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Sequence
+
+
+SCHEMA_VERSION = 1
+MATCH_SEMANTICS = "first-match"
+GLOB_DIALECT = "p5-posix-v1"
+CLASSIFICATIONS = frozenset(
+    {"internal-only", "private-workflow-dependent", "public-ready"}
+)
+CHECK_CLASSES = frozenset({"none", "hosted-agents", "bicep"})
+DISPOSITIONS = frozenset({"internal-only", "public-facing"})
+DEFAULT_CLASSIFICATION = "unresolved"
+DEFAULT_CHECK_CLASS = "none"
+DEFAULT_DISPOSITION = "unresolved"
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_version",
+        "match_semantics",
+        "glob_dialect",
+        "default_classification",
+        "default_check_class",
+        "default_disposition",
+        "rules",
+    }
+)
+_RULE_FIELDS = frozenset({"id", "glob", "classification", "check_class", "disposition"})
+_EXTGLOB_PREFIXES = ("@(", "+(", "?(", "*(", "!(")
+
+
+class ManifestError(ValueError):
+    """Raised when a manifest, glob, or input path violates the v1 contract."""
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any], expected: frozenset[str], location: str
+) -> None:
+    actual = frozenset(value)
+    missing = sorted(expected - actual)
+    extra = sorted(actual - expected)
+    if missing or extra:
+        details = []
+        if missing:
+            details.append(f"missing {missing}")
+        if extra:
+            details.append(f"unexpected {extra}")
+        raise ManifestError(f"{location} fields are invalid: {', '.join(details)}")
+
+
+def _require_nonempty_string(value: Any, location: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ManifestError(
+            f"{location} must be a non-empty string without edge whitespace"
+        )
+    return value
+
+
+def validate_repo_path(path: Any, *, location: str = "path") -> str:
+    """Return a valid repository-relative POSIX path or raise ManifestError."""
+
+    path = _require_nonempty_string(path, location)
+    if path.startswith("/") or path.startswith("./"):
+        raise ManifestError(f"{location} must be repository-relative")
+    if "\\" in path:
+        raise ManifestError(f"{location} must use POSIX '/' separators")
+    if path.endswith("/"):
+        raise ManifestError(f"{location} must not end with '/'")
+
+    segments = path.split("/")
+    if any(segment == "" for segment in segments):
+        raise ManifestError(f"{location} must not contain empty segments")
+    if any(segment in {".", ".."} for segment in segments):
+        raise ManifestError(f"{location} must not contain '.' or '..' segments")
+    return path
+
+
+def validate_glob(glob: Any, *, location: str = "glob") -> str:
+    """Return a valid p5-posix-v1 glob or raise ManifestError."""
+
+    glob = validate_repo_path(glob, location=location)
+    if any(character in glob for character in "[]{}!"):
+        raise ManifestError(f"{location} uses unsupported classes, braces, or negation")
+    if any(prefix in glob for prefix in _EXTGLOB_PREFIXES):
+        raise ManifestError(f"{location} uses unsupported extglob syntax")
+    if "***" in glob:
+        raise ManifestError(f"{location} contains an invalid run of '*' operators")
+    return glob
+
+
+def glob_to_regex(glob: str) -> re.Pattern[str]:
+    """Compile a validated p5-posix-v1 glob into a full-path regex."""
+
+    glob = validate_glob(glob)
+    pieces = [r"\A"]
+    index = 0
+    while index < len(glob):
+        if glob.startswith("**/", index):
+            pieces.append(r"(?:[^/]+/)*")
+            index += 3
+        elif glob.startswith("**", index):
+            pieces.append(r".*")
+            index += 2
+        elif glob[index] == "*":
+            pieces.append(r"[^/]*")
+            index += 1
+        elif glob[index] == "?":
+            pieces.append(r"[^/]")
+            index += 1
+        else:
+            pieces.append(re.escape(glob[index]))
+            index += 1
+    pieces.append(r"\Z")
+    return re.compile("".join(pieces))
+
+
+def path_matches_glob(path: str, glob: str) -> bool:
+    """Return whether a repository path fully matches a p5-posix-v1 glob."""
+
+    path = validate_repo_path(path)
+    return glob_to_regex(glob).fullmatch(path) is not None
+
+
+def validate_manifest(manifest: Any) -> Mapping[str, Any]:
+    """Validate a decoded manifest and return it unchanged."""
+
+    if not isinstance(manifest, Mapping):
+        raise ManifestError("manifest must be a JSON object")
+    _require_exact_fields(manifest, _TOP_LEVEL_FIELDS, "manifest")
+
+    if (
+        not isinstance(manifest["schema_version"], int)
+        or isinstance(manifest["schema_version"], bool)
+        or manifest["schema_version"] != SCHEMA_VERSION
+    ):
+        raise ManifestError(f"schema_version must be integer {SCHEMA_VERSION}")
+    expected_constants = {
+        "match_semantics": MATCH_SEMANTICS,
+        "glob_dialect": GLOB_DIALECT,
+        "default_classification": DEFAULT_CLASSIFICATION,
+        "default_check_class": DEFAULT_CHECK_CLASS,
+        "default_disposition": DEFAULT_DISPOSITION,
+    }
+    for field, expected in expected_constants.items():
+        if manifest[field] != expected:
+            raise ManifestError(f"{field} must be {expected!r}")
+
+    rules = manifest["rules"]
+    if not isinstance(rules, list) or not rules:
+        raise ManifestError("rules must be a non-empty ordered array")
+
+    seen_ids: set[str] = set()
+    seen_globs: set[str] = set()
+    for index, rule in enumerate(rules):
+        location = f"rules[{index}]"
+        if not isinstance(rule, Mapping):
+            raise ManifestError(f"{location} must be an object")
+        _require_exact_fields(rule, _RULE_FIELDS, location)
+
+        rule_id = _require_nonempty_string(rule["id"], f"{location}.id")
+        glob = validate_glob(rule["glob"], location=f"{location}.glob")
+        if rule_id in seen_ids:
+            raise ManifestError(f"duplicate rule id {rule_id!r}")
+        if glob in seen_globs:
+            raise ManifestError(f"duplicate rule glob {glob!r}")
+        seen_ids.add(rule_id)
+        seen_globs.add(glob)
+
+        if rule["classification"] not in CLASSIFICATIONS:
+            raise ManifestError(
+                f"{location}.classification must be one of {sorted(CLASSIFICATIONS)}"
+            )
+        if rule["check_class"] not in CHECK_CLASSES:
+            raise ManifestError(
+                f"{location}.check_class must be one of {sorted(CHECK_CLASSES)}"
+            )
+        if rule["disposition"] not in DISPOSITIONS:
+            raise ManifestError(
+                f"{location}.disposition must be one of {sorted(DISPOSITIONS)}"
+            )
+    return manifest
+
+
+def canonical_manifest_bytes(manifest: Any) -> bytes:
+    """Return the canonical validated JSON representation used for hashing."""
+
+    validate_manifest(manifest)
+    return json.dumps(
+        manifest, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+    ).encode("utf-8")
+
+
+def manifest_sha256(manifest: Any) -> str:
+    """Return the canonical SHA-256 digest for a validated manifest."""
+
+    return hashlib.sha256(canonical_manifest_bytes(manifest)).hexdigest()
+
+
+def load_manifest(path: str | Path) -> Mapping[str, Any]:
+    """Load and validate a UTF-8 JSON manifest."""
+
+    manifest_path = Path(path)
+    try:
+        with manifest_path.open("r", encoding="utf-8") as manifest_file:
+            manifest = json.load(manifest_file)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ManifestError(f"cannot load manifest {manifest_path}: {error}") from error
+    return validate_manifest(manifest)
+
+
+def _classify_validated_path(manifest: Mapping[str, Any], path: str) -> dict[str, Any]:
+    for rule in manifest["rules"]:
+        if path_matches_glob(path, rule["glob"]):
+            return {
+                "path": path,
+                "rule_id": rule["id"],
+                "glob": rule["glob"],
+                "classification": rule["classification"],
+                "check_class": rule["check_class"],
+                "disposition": rule["disposition"],
+            }
+    return {
+        "path": path,
+        "rule_id": None,
+        "glob": None,
+        "classification": manifest["default_classification"],
+        "check_class": manifest["default_check_class"],
+        "disposition": manifest["default_disposition"],
+    }
+
+
+def classify_path(manifest: Any, path: str) -> dict[str, Any]:
+    """Classify one path using first-match semantics."""
+
+    validated_manifest = validate_manifest(manifest)
+    validated_path = validate_repo_path(path)
+    return _classify_validated_path(validated_manifest, validated_path)
+
+
+def classify_paths(manifest: Any, paths: Iterable[str]) -> dict[str, Any]:
+    """Classify unique paths and return deterministic path-sorted JSON data."""
+
+    validated_manifest = validate_manifest(manifest)
+    validated_paths = [validate_repo_path(path) for path in paths]
+    if not validated_paths:
+        raise ManifestError("at least one input path is required")
+    if len(validated_paths) != len(set(validated_paths)):
+        raise ManifestError("input paths must be unique")
+
+    return {
+        "schema_version": validated_manifest["schema_version"],
+        "manifest_sha256": manifest_sha256(validated_manifest),
+        "results": [
+            _classify_validated_path(validated_manifest, path)
+            for path in sorted(validated_paths)
+        ],
+    }
+
+
+def _read_paths_file(path: str | Path) -> list[str]:
+    paths_file = Path(path)
+    try:
+        text = paths_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as error:
+        raise ManifestError(f"cannot load paths file {paths_file}: {error}") from error
+    return text.splitlines()
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate and apply the public-transition manifest."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    classify = subparsers.add_parser("classify", help="classify repository paths")
+    classify.add_argument("--manifest", required=True)
+    classify.add_argument("--paths-file", required=True)
+    classify.add_argument("--format", choices=("json",), default="json")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the deterministic command-line interface."""
+
+    args = _build_parser().parse_args(argv)
+    try:
+        manifest = load_manifest(args.manifest)
+        output = classify_paths(manifest, _read_paths_file(args.paths_file))
+    except ManifestError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(output, ensure_ascii=True, separators=(",", ":"), sort_keys=True))
+    if any(
+        result["classification"] == DEFAULT_CLASSIFICATION
+        for result in output["results"]
+    ):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/public_transition_manifest.py
+++ b/.github/scripts/public_transition_manifest.py
@@ -20,6 +20,7 @@ CLASSIFICATIONS = frozenset(
 )
 CHECK_CLASSES = frozenset({"none", "hosted-agents", "bicep"})
 DISPOSITIONS = frozenset({"internal-only", "public-facing"})
+DELEGATION_MODES = frozenset({"tracked-sample-yaml-roots", "rule-root"})
 DEFAULT_CLASSIFICATION = "unresolved"
 DEFAULT_CHECK_CLASS = "none"
 DEFAULT_DISPOSITION = "unresolved"
@@ -36,6 +37,7 @@ _TOP_LEVEL_FIELDS = frozenset(
     }
 )
 _RULE_FIELDS = frozenset({"id", "glob", "classification", "check_class", "disposition"})
+_DELEGATION_FIELDS = frozenset({"mode", "root"})
 _EXTGLOB_PREFIXES = ("@(", "+(", "?(", "*(", "!(")
 
 
@@ -131,6 +133,26 @@ def path_matches_glob(path: str, glob: str) -> bool:
     return glob_to_regex(glob).fullmatch(path) is not None
 
 
+def _validate_delegation(delegation: Any, rule_glob: str, *, location: str) -> None:
+    if not isinstance(delegation, Mapping):
+        raise ManifestError(f"{location} must be an object")
+    _require_exact_fields(delegation, _DELEGATION_FIELDS, location)
+
+    if delegation["mode"] not in DELEGATION_MODES:
+        raise ManifestError(
+            f"{location}.mode must be one of {sorted(DELEGATION_MODES)}"
+        )
+    root = validate_repo_path(delegation["root"], location=f"{location}.root")
+    if any(character in root for character in "*?[]{}!"):
+        raise ManifestError(f"{location}.root must not contain glob syntax")
+    if any(prefix in root for prefix in _EXTGLOB_PREFIXES):
+        raise ManifestError(f"{location}.root must not contain extglob syntax")
+    if rule_glob != f"{root}/**":
+        raise ManifestError(
+            f"{location}.root must be covered by its rule glob as '<root>/**'"
+        )
+
+
 def validate_manifest(manifest: Any) -> Mapping[str, Any]:
     """Validate a decoded manifest and return it unchanged."""
 
@@ -165,7 +187,11 @@ def validate_manifest(manifest: Any) -> Mapping[str, Any]:
         location = f"rules[{index}]"
         if not isinstance(rule, Mapping):
             raise ManifestError(f"{location} must be an object")
-        _require_exact_fields(rule, _RULE_FIELDS, location)
+
+        expected_fields = _RULE_FIELDS
+        if rule.get("classification") == "private-workflow-dependent":
+            expected_fields = expected_fields | {"delegation"}
+        _require_exact_fields(rule, expected_fields, location)
 
         rule_id = _require_nonempty_string(rule["id"], f"{location}.id")
         glob = validate_glob(rule["glob"], location=f"{location}.glob")
@@ -187,6 +213,10 @@ def validate_manifest(manifest: Any) -> Mapping[str, Any]:
         if rule["disposition"] not in DISPOSITIONS:
             raise ManifestError(
                 f"{location}.disposition must be one of {sorted(DISPOSITIONS)}"
+            )
+        if rule["classification"] == "private-workflow-dependent":
+            _validate_delegation(
+                rule["delegation"], glob, location=f"{location}.delegation"
             )
     return manifest
 
@@ -228,6 +258,9 @@ def _classify_validated_path(manifest: Mapping[str, Any], path: str) -> dict[str
                 "classification": rule["classification"],
                 "check_class": rule["check_class"],
                 "disposition": rule["disposition"],
+                "delegation": (
+                    dict(rule["delegation"]) if "delegation" in rule else None
+                ),
             }
     return {
         "path": path,
@@ -236,6 +269,7 @@ def _classify_validated_path(manifest: Mapping[str, Any], path: str) -> dict[str
         "classification": manifest["default_classification"],
         "check_class": manifest["default_check_class"],
         "disposition": manifest["default_disposition"],
+        "delegation": None,
     }
 
 

--- a/.github/scripts/public_transition_manifest.py
+++ b/.github/scripts/public_transition_manifest.py
@@ -48,6 +48,8 @@ class ManifestError(ValueError):
 def _require_exact_fields(
     value: Mapping[str, Any], expected: frozenset[str], location: str
 ) -> None:
+    if any(not isinstance(field, str) for field in value):
+        raise ManifestError(f"{location} field names must be strings")
     actual = frozenset(value)
     missing = sorted(expected - actual)
     extra = sorted(actual - expected)
@@ -65,6 +67,14 @@ def _require_nonempty_string(value: Any, location: str) -> str:
         raise ManifestError(
             f"{location} must be a non-empty string without edge whitespace"
         )
+    return value
+
+
+def _require_enum_string(value: Any, allowed: frozenset[str], location: str) -> str:
+    if not isinstance(value, str):
+        raise ManifestError(f"{location} must be a string")
+    if value not in allowed:
+        raise ManifestError(f"{location} must be one of {sorted(allowed)}")
     return value
 
 
@@ -138,10 +148,7 @@ def _validate_delegation(delegation: Any, rule_glob: str, *, location: str) -> N
         raise ManifestError(f"{location} must be an object")
     _require_exact_fields(delegation, _DELEGATION_FIELDS, location)
 
-    if delegation["mode"] not in DELEGATION_MODES:
-        raise ManifestError(
-            f"{location}.mode must be one of {sorted(DELEGATION_MODES)}"
-        )
+    _require_enum_string(delegation["mode"], DELEGATION_MODES, f"{location}.mode")
     root = validate_repo_path(delegation["root"], location=f"{location}.root")
     if any(character in root for character in "*?[]{}!"):
         raise ManifestError(f"{location}.root must not contain glob syntax")
@@ -174,8 +181,7 @@ def validate_manifest(manifest: Any) -> Mapping[str, Any]:
         "default_disposition": DEFAULT_DISPOSITION,
     }
     for field, expected in expected_constants.items():
-        if manifest[field] != expected:
-            raise ManifestError(f"{field} must be {expected!r}")
+        _require_enum_string(manifest[field], frozenset({expected}), field)
 
     rules = manifest["rules"]
     if not isinstance(rules, list) or not rules:
@@ -188,8 +194,13 @@ def validate_manifest(manifest: Any) -> Mapping[str, Any]:
         if not isinstance(rule, Mapping):
             raise ManifestError(f"{location} must be an object")
 
+        if "classification" not in rule:
+            _require_exact_fields(rule, _RULE_FIELDS, location)
+        classification = _require_enum_string(
+            rule["classification"], CLASSIFICATIONS, f"{location}.classification"
+        )
         expected_fields = _RULE_FIELDS
-        if rule.get("classification") == "private-workflow-dependent":
+        if classification == "private-workflow-dependent":
             expected_fields = expected_fields | {"delegation"}
         _require_exact_fields(rule, expected_fields, location)
 
@@ -202,19 +213,13 @@ def validate_manifest(manifest: Any) -> Mapping[str, Any]:
         seen_ids.add(rule_id)
         seen_globs.add(glob)
 
-        if rule["classification"] not in CLASSIFICATIONS:
-            raise ManifestError(
-                f"{location}.classification must be one of {sorted(CLASSIFICATIONS)}"
-            )
-        if rule["check_class"] not in CHECK_CLASSES:
-            raise ManifestError(
-                f"{location}.check_class must be one of {sorted(CHECK_CLASSES)}"
-            )
-        if rule["disposition"] not in DISPOSITIONS:
-            raise ManifestError(
-                f"{location}.disposition must be one of {sorted(DISPOSITIONS)}"
-            )
-        if rule["classification"] == "private-workflow-dependent":
+        _require_enum_string(
+            rule["check_class"], CHECK_CLASSES, f"{location}.check_class"
+        )
+        _require_enum_string(
+            rule["disposition"], DISPOSITIONS, f"{location}.disposition"
+        )
+        if classification == "private-workflow-dependent":
             _validate_delegation(
                 rule["delegation"], glob, location=f"{location}.delegation"
             )

--- a/.github/tests/test_public_transition_manifest.py
+++ b/.github/tests/test_public_transition_manifest.py
@@ -52,14 +52,21 @@ def rule(
     classification="public-ready",
     check_class="none",
     disposition="public-facing",
+    delegation=None,
 ):
-    return {
+    result = {
         "id": rule_id,
         "glob": glob,
         "classification": classification,
         "check_class": check_class,
         "disposition": disposition,
     }
+    if classification == "private-workflow-dependent":
+        result["delegation"] = delegation or {
+            "mode": "tracked-sample-yaml-roots",
+            "root": glob.removesuffix("/**"),
+        }
+    return result
 
 
 def test_canonical_manifest_schema_and_rule_enums(manifest):
@@ -72,13 +79,16 @@ def test_canonical_manifest_schema_and_rule_enums(manifest):
     assert manifest["rules"]
 
     for manifest_rule in manifest["rules"]:
-        assert set(manifest_rule) == {
+        expected_fields = {
             "id",
             "glob",
             "classification",
             "check_class",
             "disposition",
         }
+        if manifest_rule["classification"] == "private-workflow-dependent":
+            expected_fields.add("delegation")
+        assert set(manifest_rule) == expected_fields
         assert manifest_rule["classification"] in MATCHER.CLASSIFICATIONS
         assert manifest_rule["check_class"] in MATCHER.CHECK_CLASSES
         assert manifest_rule["disposition"] in MATCHER.DISPOSITIONS
@@ -177,6 +187,62 @@ def test_rejects_duplicate_rule_ids_and_globs():
         )
 
 
+def test_requires_delegation_only_on_private_dependent_rules():
+    private_rule = rule(
+        "private",
+        "samples/python/hosted-agents/**",
+        "private-workflow-dependent",
+        "hosted-agents",
+    )
+    del private_rule["delegation"]
+    with pytest.raises(MATCHER.ManifestError, match="delegation"):
+        MATCHER.validate_manifest(make_manifest([private_rule]))
+
+    public_rule = rule("public", "samples/**")
+    public_rule["delegation"] = {
+        "mode": "tracked-sample-yaml-roots",
+        "root": "samples",
+    }
+    with pytest.raises(MATCHER.ManifestError, match="unexpected"):
+        MATCHER.validate_manifest(make_manifest([public_rule]))
+
+
+@pytest.mark.parametrize(
+    "delegation",
+    [
+        None,
+        {"mode": "inventory", "root": "samples/python/hosted-agents"},
+        {
+            "mode": "tracked-sample-yaml-roots",
+            "root": "samples/python/hosted-agents/*",
+        },
+        {
+            "mode": "tracked-sample-yaml-roots",
+            "root": "./samples/python/hosted-agents",
+        },
+        {
+            "mode": "tracked-sample-yaml-roots",
+            "root": "samples/csharp/hosted-agents",
+        },
+        {
+            "mode": "tracked-sample-yaml-roots",
+            "root": "samples/python/hosted-agents",
+            "targets": [],
+        },
+    ],
+)
+def test_rejects_invalid_delegation_objects(delegation):
+    candidate_rule = rule(
+        "private",
+        "samples/python/hosted-agents/**",
+        "private-workflow-dependent",
+        "hosted-agents",
+    )
+    candidate_rule["delegation"] = delegation
+    with pytest.raises(MATCHER.ManifestError):
+        MATCHER.validate_manifest(make_manifest([candidate_rule]))
+
+
 @pytest.mark.parametrize(
     "glob",
     [
@@ -265,6 +331,10 @@ def test_first_match_wins_and_records_provenance():
         "classification": "private-workflow-dependent",
         "check_class": "hosted-agents",
         "disposition": "public-facing",
+        "delegation": {
+            "mode": "tracked-sample-yaml-roots",
+            "root": "samples/python/hosted-agents",
+        },
     }
 
 
@@ -329,6 +399,48 @@ def test_all_current_repository_paths_follow_locked_rules(manifest):
     assert unresolved == []
 
 
+def test_delegation_is_path_derived_and_uses_stable_rule_ids(manifest):
+    rules_by_id = {item["id"]: item for item in manifest["rules"]}
+    python = rules_by_id["python-hosted-agents-private-dependent"]["delegation"]
+    csharp = rules_by_id["csharp-hosted-agents-private-dependent"]["delegation"]
+    bicep = rules_by_id["bicep-private-dependent"]["delegation"]
+
+    assert python == {
+        "mode": "tracked-sample-yaml-roots",
+        "root": "samples/python/hosted-agents",
+    }
+    assert csharp == {
+        "mode": "tracked-sample-yaml-roots",
+        "root": "samples/csharp/hosted-agents",
+    }
+    assert bicep == {
+        "mode": "rule-root",
+        "root": "infrastructure/infrastructure-setup-bicep",
+    }
+    assert all(set(value) == {"mode", "root"} for value in (python, csharp, bicep))
+
+    completed = subprocess.run(
+        ["git", "ls-files", "samples/**/sample.yaml"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    sample_yaml_paths = completed.stdout.splitlines()
+
+    def discovered_roots(delegation):
+        prefix = f"{delegation['root']}/"
+        return sorted(
+            str(Path(path).parent).replace("\\", "/")
+            for path in sample_yaml_paths
+            if path.startswith(prefix)
+        )
+
+    assert len(discovered_roots(python)) == 4
+    assert discovered_roots(csharp) == []
+    assert [bicep["root"]] == ["infrastructure/infrastructure-setup-bicep"]
+
+
 def test_unknown_paths_use_explicit_unresolved_defaults(manifest):
     assert MATCHER.classify_path(manifest, "new-root/file.txt") == {
         "path": "new-root/file.txt",
@@ -337,6 +449,7 @@ def test_unknown_paths_use_explicit_unresolved_defaults(manifest):
         "classification": "unresolved",
         "check_class": "none",
         "disposition": "unresolved",
+        "delegation": None,
     }
 
 

--- a/.github/tests/test_public_transition_manifest.py
+++ b/.github/tests/test_public_transition_manifest.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "public_transition_manifest.py"
+MANIFEST_PATH = REPO_ROOT / ".github" / "public-transition-manifest.json"
+
+SPEC = importlib.util.spec_from_file_location("public_transition_manifest", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MATCHER = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MATCHER)
+
+
+@pytest.fixture
+def manifest():
+    return MATCHER.load_manifest(MANIFEST_PATH)
+
+
+def make_manifest(rules=None):
+    return {
+        "schema_version": 1,
+        "match_semantics": "first-match",
+        "glob_dialect": "p5-posix-v1",
+        "default_classification": "unresolved",
+        "default_check_class": "none",
+        "default_disposition": "unresolved",
+        "rules": rules
+        or [
+            {
+                "id": "samples",
+                "glob": "samples/**",
+                "classification": "public-ready",
+                "check_class": "none",
+                "disposition": "public-facing",
+            }
+        ],
+    }
+
+
+def rule(
+    rule_id,
+    glob,
+    classification="public-ready",
+    check_class="none",
+    disposition="public-facing",
+):
+    return {
+        "id": rule_id,
+        "glob": glob,
+        "classification": classification,
+        "check_class": check_class,
+        "disposition": disposition,
+    }
+
+
+def test_canonical_manifest_schema_and_rule_enums(manifest):
+    assert manifest["schema_version"] == 1
+    assert manifest["match_semantics"] == "first-match"
+    assert manifest["glob_dialect"] == "p5-posix-v1"
+    assert manifest["default_classification"] == "unresolved"
+    assert manifest["default_check_class"] == "none"
+    assert manifest["default_disposition"] == "unresolved"
+    assert manifest["rules"]
+
+    for manifest_rule in manifest["rules"]:
+        assert set(manifest_rule) == {
+            "id",
+            "glob",
+            "classification",
+            "check_class",
+            "disposition",
+        }
+        assert manifest_rule["classification"] in MATCHER.CLASSIFICATIONS
+        assert manifest_rule["check_class"] in MATCHER.CHECK_CLASSES
+        assert manifest_rule["disposition"] in MATCHER.DISPOSITIONS
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    [
+        ("schema_version", 2),
+        ("schema_version", True),
+        ("match_semantics", "last-match"),
+        ("glob_dialect", "gitignore"),
+        ("default_classification", "public-ready"),
+        ("default_check_class", "hosted-agents"),
+        ("default_disposition", "public-facing"),
+        ("rules", []),
+    ],
+)
+def test_rejects_invalid_top_level_values(field, bad_value):
+    candidate = make_manifest()
+    candidate[field] = bad_value
+    with pytest.raises(MATCHER.ManifestError):
+        MATCHER.validate_manifest(candidate)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "schema_version",
+        "match_semantics",
+        "glob_dialect",
+        "default_classification",
+        "default_check_class",
+        "default_disposition",
+        "rules",
+    ],
+)
+def test_rejects_missing_top_level_fields(field):
+    candidate = make_manifest()
+    del candidate[field]
+    with pytest.raises(MATCHER.ManifestError, match="missing"):
+        MATCHER.validate_manifest(candidate)
+
+
+def test_rejects_unexpected_top_level_and_rule_fields():
+    candidate = make_manifest()
+    candidate["extra"] = True
+    with pytest.raises(MATCHER.ManifestError, match="unexpected"):
+        MATCHER.validate_manifest(candidate)
+
+    candidate = make_manifest()
+    candidate["rules"][0]["extra"] = True
+    with pytest.raises(MATCHER.ManifestError, match="unexpected"):
+        MATCHER.validate_manifest(candidate)
+
+
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    [
+        ("id", ""),
+        ("id", " edge"),
+        ("glob", ""),
+        ("classification", None),
+        ("classification", "unresolved"),
+        ("check_class", None),
+        ("check_class", "private"),
+        ("disposition", None),
+        ("disposition", "unresolved"),
+    ],
+)
+def test_rejects_invalid_rule_fields_and_enums(field, bad_value):
+    candidate = make_manifest()
+    candidate["rules"][0][field] = bad_value
+    with pytest.raises(MATCHER.ManifestError):
+        MATCHER.validate_manifest(candidate)
+
+
+@pytest.mark.parametrize(
+    "field", ["id", "glob", "classification", "check_class", "disposition"]
+)
+def test_rejects_missing_rule_fields(field):
+    candidate = make_manifest()
+    del candidate["rules"][0][field]
+    with pytest.raises(MATCHER.ManifestError, match="missing"):
+        MATCHER.validate_manifest(candidate)
+
+
+def test_rejects_duplicate_rule_ids_and_globs():
+    with pytest.raises(MATCHER.ManifestError, match="duplicate rule id"):
+        MATCHER.validate_manifest(
+            make_manifest([rule("same", "a/**"), rule("same", "b/**")])
+        )
+    with pytest.raises(MATCHER.ManifestError, match="duplicate rule glob"):
+        MATCHER.validate_manifest(
+            make_manifest([rule("one", "a/**"), rule("two", "a/**")])
+        )
+
+
+@pytest.mark.parametrize(
+    "glob",
+    [
+        "[ab].txt",
+        "a{b,c}.txt",
+        "@(a|b).txt",
+        "+(a).txt",
+        "?(a).txt",
+        "*(a).txt",
+        "!(a).txt",
+        "!private/**",
+        r"a\b",
+        "***",
+        "/root/**",
+        "./root/**",
+        "../root/**",
+        "root/../other",
+        "root//file",
+        "root/",
+        "",
+    ],
+)
+def test_rejects_invalid_glob_syntax_and_normalization(glob):
+    with pytest.raises(MATCHER.ManifestError):
+        MATCHER.validate_glob(glob)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/root/file",
+        "./root/file",
+        "../root/file",
+        "root/../file",
+        "root/./file",
+        r"root\file",
+        "root//file",
+        "root/",
+        "",
+        " edge",
+    ],
+)
+def test_rejects_invalid_input_path_normalization(path):
+    with pytest.raises(MATCHER.ManifestError):
+        MATCHER.validate_repo_path(path)
+
+
+def test_p5_posix_v1_operators_are_full_path_and_case_sensitive():
+    assert MATCHER.path_matches_glob("root/a.txt", "root/?.txt")
+    assert not MATCHER.path_matches_glob("root/ab.txt", "root/?.txt")
+    assert MATCHER.path_matches_glob("root/.txt", "root/*.txt")
+    assert MATCHER.path_matches_glob("root/ab.txt", "root/*.txt")
+    assert not MATCHER.path_matches_glob("root/nested/ab.txt", "root/*.txt")
+    assert MATCHER.path_matches_glob("root/nested/ab.txt", "root/**")
+    assert not MATCHER.path_matches_glob("prefix/root/a.txt", "root/**")
+    assert MATCHER.path_matches_glob("README.md", "README.md")
+    assert not MATCHER.path_matches_glob("readme.md", "README.md")
+
+
+def test_double_star_slash_matches_zero_or_more_complete_segments():
+    assert MATCHER.path_matches_glob(".ci-skip", "**/.ci-skip")
+    assert MATCHER.path_matches_glob("samples/.ci-skip", "**/.ci-skip")
+    assert MATCHER.path_matches_glob("samples/python/example/.ci-skip", "**/.ci-skip")
+    assert not MATCHER.path_matches_glob("samples/example.ci-skip", "**/.ci-skip")
+
+
+def test_first_match_wins_and_records_provenance():
+    candidate = make_manifest(
+        [
+            rule(
+                "override",
+                "samples/python/hosted-agents/**",
+                "private-workflow-dependent",
+                "hosted-agents",
+            ),
+            rule("fallback", "samples/**"),
+        ]
+    )
+    result = MATCHER.classify_path(
+        candidate, "samples/python/hosted-agents/example/sample.yaml"
+    )
+    assert result == {
+        "path": "samples/python/hosted-agents/example/sample.yaml",
+        "rule_id": "override",
+        "glob": "samples/python/hosted-agents/**",
+        "classification": "private-workflow-dependent",
+        "check_class": "hosted-agents",
+        "disposition": "public-facing",
+    }
+
+
+def test_every_canonical_rule_has_expected_first_match(manifest):
+    representative_paths = {
+        "internal-azure-pipelines": ".azure-pipelines/build.yml",
+        "internal-github": ".github/workflows/test.yml",
+        "internal-docs": "docs/validation.md",
+        "internal-root": "internal/tool.py",
+        "internal-public-overlay": "public-overlay/file.txt",
+        "internal-readme": "README.md",
+        "internal-contributing": "CONTRIBUTING.md",
+        "internal-ci-skip": ".ci-skip",
+        "internal-code-ci-skip": "samples/demo/.code-ci-skip",
+        "python-hosted-agents-private-dependent": (
+            "samples/python/hosted-agents/example/sample.yaml"
+        ),
+        "csharp-hosted-agents-private-dependent": (
+            "samples/csharp/hosted-agents/example/sample.yaml"
+        ),
+        "bicep-private-dependent": (
+            "infrastructure/infrastructure-setup-bicep/main.bicep"
+        ),
+        "samples-public-ready": "samples/python/example/sample.yaml",
+        "samples-classic-public-ready": "samples-classic/python/example.py",
+        "samples-mistral-public-ready": "samples-mistral/python/example.py",
+        "infrastructure-public-ready": "infrastructure/terraform/main.tf",
+        "migration-public-ready": "migration/tool.py",
+        "infra-public-ready": ".infra/pytest_plugins/plugin.py",
+        "gitattributes-public-ready": ".gitattributes",
+        "gitignore-public-ready": ".gitignore",
+        "pre-commit-config-public-ready": ".pre-commit-config.yaml",
+        "code-of-conduct-public-ready": "CODE_OF_CONDUCT.md",
+        "license-public-ready": "LICENSE",
+        "security-public-ready": "SECURITY.md",
+        "support-public-ready": "SUPPORT.md",
+        "conftest-public-ready": "conftest.py",
+        "dev-requirements-public-ready": "dev-requirements.txt",
+        "package-lock-public-ready": "package-lock.json",
+        "tox-public-ready": "tox.ini",
+    }
+    assert set(representative_paths) == {item["id"] for item in manifest["rules"]}
+    for expected_rule_id, path in representative_paths.items():
+        assert MATCHER.classify_path(manifest, path)["rule_id"] == expected_rule_id
+
+
+def test_all_current_repository_paths_follow_locked_rules(manifest):
+    completed = subprocess.run(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    tracked_paths = completed.stdout.splitlines()
+    output = MATCHER.classify_paths(manifest, tracked_paths)
+    unresolved = [
+        result["path"]
+        for result in output["results"]
+        if result["classification"] == "unresolved"
+    ]
+    assert unresolved == []
+
+
+def test_unknown_paths_use_explicit_unresolved_defaults(manifest):
+    assert MATCHER.classify_path(manifest, "new-root/file.txt") == {
+        "path": "new-root/file.txt",
+        "rule_id": None,
+        "glob": None,
+        "classification": "unresolved",
+        "check_class": "none",
+        "disposition": "unresolved",
+    }
+
+
+def test_classify_paths_rejects_duplicate_and_empty_inputs(manifest):
+    with pytest.raises(MATCHER.ManifestError, match="unique"):
+        MATCHER.classify_paths(manifest, ["samples/a", "samples/a"])
+    with pytest.raises(MATCHER.ManifestError, match="at least one"):
+        MATCHER.classify_paths(manifest, [])
+
+
+def test_digest_and_result_order_are_deterministic():
+    first = make_manifest()
+    second = {key: copy.deepcopy(first[key]) for key in reversed(list(first))}
+    assert MATCHER.manifest_sha256(first) == MATCHER.manifest_sha256(second)
+
+    output = MATCHER.classify_paths(
+        first, ["samples/z/sample.yaml", "samples/a/sample.yaml"]
+    )
+    assert [result["path"] for result in output["results"]] == [
+        "samples/a/sample.yaml",
+        "samples/z/sample.yaml",
+    ]
+    assert len(output["manifest_sha256"]) == 64
+
+
+def test_importable_api_supports_golden_p4_consumer(manifest):
+    def golden_p4_consumer(paths):
+        classified = MATCHER.classify_paths(manifest, paths)["results"]
+        if any(item["classification"] == "unresolved" for item in classified):
+            raise ValueError("P4 fails closed on unresolved sample roots")
+        return [
+            {
+                "path": item["path"],
+                "classification": item["classification"],
+            }
+            for item in classified
+            if item["classification"] in {"public-ready", "private-workflow-dependent"}
+        ]
+
+    assert golden_p4_consumer(
+        [
+            "samples/python/quickstart/sample.yaml",
+            "samples/python/hosted-agents/example/sample.yaml",
+            ".github/private/sample.yaml",
+        ]
+    ) == [
+        {
+            "path": "samples/python/hosted-agents/example/sample.yaml",
+            "classification": "private-workflow-dependent",
+        },
+        {
+            "path": "samples/python/quickstart/sample.yaml",
+            "classification": "public-ready",
+        },
+    ]
+
+
+def run_cli(tmp_path, paths):
+    paths_file = tmp_path / "paths.txt"
+    paths_file.write_text("\n".join(paths) + "\n", encoding="utf-8")
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "classify",
+            "--manifest",
+            str(MANIFEST_PATH),
+            "--paths-file",
+            str(paths_file),
+            "--format",
+            "json",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_emits_deterministic_json_and_returns_zero(tmp_path):
+    completed = run_cli(
+        tmp_path,
+        ["samples/z/sample.yaml", "samples/python/hosted-agents/a/sample.yaml"],
+    )
+    assert completed.returncode == 0
+    assert completed.stderr == ""
+    assert completed.stdout == completed.stdout.strip() + "\n"
+    output = json.loads(completed.stdout)
+    assert output["schema_version"] == 1
+    assert len(output["manifest_sha256"]) == 64
+    assert [result["path"] for result in output["results"]] == [
+        "samples/python/hosted-agents/a/sample.yaml",
+        "samples/z/sample.yaml",
+    ]
+
+
+def test_cli_emits_unresolved_json_and_returns_nonzero(tmp_path):
+    completed = run_cli(tmp_path, ["new-root/file.txt", "samples/a/sample.yaml"])
+    assert completed.returncode == 1
+    assert completed.stderr == ""
+    output = json.loads(completed.stdout)
+    assert [result["path"] for result in output["results"]] == [
+        "new-root/file.txt",
+        "samples/a/sample.yaml",
+    ]
+    assert output["results"][0]["classification"] == "unresolved"
+
+
+def test_cli_rejects_duplicate_inputs_without_success_shaped_output(tmp_path):
+    completed = run_cli(tmp_path, ["samples/a", "samples/a"])
+    assert completed.returncode == 2
+    assert completed.stdout == ""
+    assert "unique" in completed.stderr

--- a/.github/tests/test_public_transition_manifest.py
+++ b/.github/tests/test_public_transition_manifest.py
@@ -117,6 +117,24 @@ def test_rejects_invalid_top_level_values(field, bad_value):
 @pytest.mark.parametrize(
     "field",
     [
+        "match_semantics",
+        "glob_dialect",
+        "default_classification",
+        "default_check_class",
+        "default_disposition",
+    ],
+)
+@pytest.mark.parametrize("bad_value", [[], {}, 7, None])
+def test_rejects_non_string_top_level_contract_values(field, bad_value):
+    candidate = make_manifest()
+    candidate[field] = bad_value
+    with pytest.raises(MATCHER.ManifestError):
+        MATCHER.validate_manifest(candidate)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
         "schema_version",
         "match_semantics",
         "glob_dialect",
@@ -160,6 +178,17 @@ def test_rejects_unexpected_top_level_and_rule_fields():
     ],
 )
 def test_rejects_invalid_rule_fields_and_enums(field, bad_value):
+    candidate = make_manifest()
+    candidate["rules"][0][field] = bad_value
+    with pytest.raises(MATCHER.ManifestError):
+        MATCHER.validate_manifest(candidate)
+
+
+@pytest.mark.parametrize(
+    "field", ["id", "glob", "classification", "check_class", "disposition"]
+)
+@pytest.mark.parametrize("bad_value", [[], {}, 7, None])
+def test_rejects_non_string_rule_contract_values(field, bad_value):
     candidate = make_manifest()
     candidate["rules"][0][field] = bad_value
     with pytest.raises(MATCHER.ManifestError):
@@ -239,6 +268,20 @@ def test_rejects_invalid_delegation_objects(delegation):
         "hosted-agents",
     )
     candidate_rule["delegation"] = delegation
+    with pytest.raises(MATCHER.ManifestError):
+        MATCHER.validate_manifest(make_manifest([candidate_rule]))
+
+
+@pytest.mark.parametrize("field", ["mode", "root"])
+@pytest.mark.parametrize("bad_value", [[], {}, 7, None])
+def test_rejects_non_string_delegation_values(field, bad_value):
+    candidate_rule = rule(
+        "private",
+        "samples/python/hosted-agents/**",
+        "private-workflow-dependent",
+        "hosted-agents",
+    )
+    candidate_rule["delegation"][field] = bad_value
     with pytest.raises(MATCHER.ManifestError):
         MATCHER.validate_manifest(make_manifest([candidate_rule]))
 
@@ -507,7 +550,7 @@ def test_importable_api_supports_golden_p4_consumer(manifest):
     ]
 
 
-def run_cli(tmp_path, paths):
+def run_cli(tmp_path, paths, manifest_path=MANIFEST_PATH):
     paths_file = tmp_path / "paths.txt"
     paths_file.write_text("\n".join(paths) + "\n", encoding="utf-8")
     return subprocess.run(
@@ -516,7 +559,7 @@ def run_cli(tmp_path, paths):
             str(SCRIPT_PATH),
             "classify",
             "--manifest",
-            str(MANIFEST_PATH),
+            str(manifest_path),
             "--paths-file",
             str(paths_file),
             "--format",
@@ -562,3 +605,16 @@ def test_cli_rejects_duplicate_inputs_without_success_shaped_output(tmp_path):
     assert completed.returncode == 2
     assert completed.stdout == ""
     assert "unique" in completed.stderr
+
+
+def test_cli_rejects_malformed_enum_without_traceback(tmp_path):
+    malformed = make_manifest()
+    malformed["rules"][0]["classification"] = []
+    malformed_path = tmp_path / "malformed.json"
+    malformed_path.write_text(json.dumps(malformed), encoding="utf-8")
+
+    completed = run_cli(tmp_path, ["samples/a"], malformed_path)
+    assert completed.returncode == 2
+    assert completed.stdout == ""
+    assert completed.stderr.startswith("error: ")
+    assert "Traceback" not in completed.stderr


### PR DESCRIPTION
## Summary

- Add the P5-owned canonical v1 path-classification manifest with locked first-match rule ordering.
- Add the sole production schema validator and `p5-posix-v1` matcher as importable functions plus the deterministic `classify` JSON CLI.
- Add required path-derived delegation metadata to every `private-workflow-dependent` rule; stable rule IDs, not array indexes, identify each target contract.
- Add contract coverage for schema/enums, all rules and current repository paths, glob semantics and rejection, path normalization, duplicates, precedence, delegation, malformed value types, digest/order determinism, unresolved output/exit status, import use, and the golden P4 consumer.

## Contract

- Defaults are `unresolved` / `none` / `unresolved`; unresolved paths are emitted and return exit 1.
- Malformed schemas, including unhashable enum values, produce controlled stderr without a traceback and return exit 2.
- Matching is full-path, case-sensitive, repository-relative POSIX with explicit `*`, `?`, `**`, and zero-segment `**/` behavior.
- Delegation modes are `tracked-sample-yaml-roots` and `rule-root`; roots must be normalized, non-glob paths covered by their owning rule.
- Hosted Agents delegation discovers tracked `sample.yaml` roots under the declared language root. Current public proof is 4 Python roots and 0 C# roots.
- Bicep delegates one rule-root target: `infrastructure/infrastructure-setup-bicep`.
- The manifest contains no volatile per-target inventory.
- `.github/**` intentionally classifies the canonical manifest and matcher as internal-only for private promotion.
- Unknown or newly introduced roots remain unresolved until the canonical manifest is deliberately updated.

## Validation

- `python -m pytest .github/tests/test_public_transition_manifest.py -q` — 128 passed.
- Repository Black environment — clean.
- Ruff 0.9.10 `check` — clean (the existing tox command uses the retired pre-0.1 CLI form, so the installed tox environment executable was invoked with `check`).
- Production-shaped classification — all 2,907 current repository paths resolved; canonical manifest SHA-256 `24602504243488913565121fb51a4978ddcbefafeecf45bf901160565935bd99`.

## Dependency and sequencing

P4/private helper production wiring remains fail-closed until this PR lands. This PR does not modify P4-owned readiness fields or consumers, workflows, settings, or environments.

## ADO

[ADO 5449714](https://msdata.visualstudio.com/Vienna/_workitems/edit/5449714)

## Documentation impact

- **Current behavior:** unchanged. This draft establishes target contract surfaces only and makes no docs-current claim.
- **Target contract paths:** `.github/public-transition-manifest.json` and `.github/scripts/public_transition_manifest.py`.
- **PR/SHA proof:** this draft PR at head commit `94fe10eb86bf7ec7a77b4f334fdf61e387a2b5f9`; tests are `.github/tests/test_public_transition_manifest.py`.
- **Ownership:** P5 owns classification, delegation metadata, and matching; P4 owns readiness fields, live target enumeration, and consumer behavior.