### PR TITLE
Establish representative public validation run pilot

### DIFF
--- a/.github/scripts/run-validation-pilot.py
+++ b/.github/scripts/run-validation-pilot.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Run one curated sample and write its canonical normalized result."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+OUTCOMES = {
+    0: "passed",
+    1: "sample failure",
+    2: "infrastructure/error",
+}
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sample-id", required=True)
+    parser.add_argument("--language", required=True)
+    parser.add_argument("--shape", required=True)
+    parser.add_argument("--sample-path", required=True)
+    parser.add_argument("--validator", default=".github/scripts/validate-sample.sh")
+    parser.add_argument("--bash", default="bash")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--diagnostic", type=Path, required=True)
+    parser.add_argument("--run-id", default=os.environ.get("GITHUB_RUN_ID", "local"))
+    parser.add_argument("--run-attempt", default=os.environ.get("GITHUB_RUN_ATTEMPT", "1"))
+    parser.add_argument("--sha", default=os.environ.get("GITHUB_SHA", "local"))
+    parser.add_argument("--ref", default=os.environ.get("GITHUB_REF", "local"))
+    parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", "local"))
+    parser.add_argument("--workflow", default=os.environ.get("GITHUB_WORKFLOW", "validation pilot"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    started_at = utc_now()
+    started = time.monotonic()
+    command = [
+        args.bash,
+        args.validator,
+        "--level",
+        "3",
+        "--language",
+        args.language,
+        "--sample-dir",
+        args.sample_path,
+    ]
+    try:
+        completed = subprocess.run(command, capture_output=True, text=True)
+        diagnostic = (
+            "$ " + " ".join(command) + "\n"
+            + completed.stdout
+            + completed.stderr
+        )
+        outcome = OUTCOMES.get(completed.returncode, "infrastructure/error")
+        stage = "L3 validation" if completed.returncode in OUTCOMES else "L3 validation invocation"
+    except (OSError, subprocess.SubprocessError) as exc:
+        completed = None
+        diagnostic = "$ " + " ".join(command) + f"\nrunner error: {exc}\n"
+        outcome = "infrastructure/error"
+        stage = "L3 validation invocation"
+
+    completed_at = utc_now()
+    result = {
+        "schema_version": 1,
+        "sample": {
+            "id": args.sample_id,
+            "path": args.sample_path,
+            "language": args.language,
+            "shape": args.shape,
+        },
+        "outcome": outcome,
+        "completed_stage": stage,
+        "duration_seconds": round(time.monotonic() - started, 3),
+        "diagnostic_reference": args.diagnostic.name,
+        "artifact_reference": args.output.name,
+        "completed_at": completed_at,
+        "run": {
+            "repository": args.repository,
+            "workflow": args.workflow,
+            "run_id": args.run_id,
+            "run_attempt": args.run_attempt,
+            "sha": args.sha,
+            "ref": args.ref,
+            "started_at": started_at,
+        },
+    }
+    args.diagnostic.parent.mkdir(parents=True, exist_ok=True)
+    args.diagnostic.write_text(diagnostic, encoding="utf-8")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"{args.sample_id}: {outcome} ({result['duration_seconds']}s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Focused contract tests for the representative validation pilot producer."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RUNNER = ROOT / "scripts" / "run-validation-pilot.py"
+COMPLETENESS = ROOT / "scripts" / "validate-validation-pilot-results.py"
+MANIFEST = ROOT / "validation-pilot-matrix.json"
+
+
+class ValidationPilotTests(unittest.TestCase):
+    def test_manifest_is_curated_and_supported(self) -> None:
+        manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        self.assertEqual(manifest["schema_version"], 1)
+        self.assertEqual(len(manifest["samples"]), 4)
+        self.assertEqual(
+            {sample["language"] for sample in manifest["samples"]},
+            {"csharp", "java", "python", "typescript"},
+        )
+        for sample in manifest["samples"]:
+            self.assertTrue((ROOT.parent / sample["path"]).is_dir(), sample["path"])
+
+    def test_sample_failure_is_a_complete_valid_result(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            validator = root / "validator.sh"
+            validator.write_text("import sys\nsys.exit(1)\n", encoding="utf-8")
+            output = root / "sample-result.json"
+            diagnostic = root / "diagnostics.log"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUNNER),
+                    "--sample-id",
+                    "fixture",
+                    "--language",
+                    "python",
+                    "--shape",
+                    "fixture",
+                    "--sample-path",
+                    "samples/python/fixture",
+                    "--validator",
+                    str(validator),
+                    "--bash",
+                    sys.executable,
+                    "--output",
+                    str(output),
+                    "--diagnostic",
+                    str(diagnostic),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            result = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(result["outcome"], "sample failure")
+            self.assertEqual(result["completed_stage"], "L3 validation")
+            self.assertTrue(diagnostic.is_file())
+
+    def test_completeness_rejects_missing_matrix_member(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            manifest = root / "manifest.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "samples": [
+                            {"id": "one", "path": "samples/python/one", "language": "python", "shape": "fixture"},
+                            {"id": "two", "path": "samples/java/two", "language": "java", "shape": "fixture"},
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            artifacts = root / "artifacts" / "validation-pilot-one"
+            artifacts.mkdir(parents=True)
+            (artifacts / "diagnostics.log").write_text("diagnostic\n", encoding="utf-8")
+            (artifacts / "sample-result.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "sample": {"id": "one", "path": "samples/python/one", "language": "python", "shape": "fixture"},
+                        "outcome": "passed",
+                        "completed_stage": "L3 validation",
+                        "duration_seconds": 1,
+                        "diagnostic_reference": "diagnostics.log",
+                        "artifact_reference": "sample-result.json",
+                        "completed_at": "2026-08-10T00:00:00Z",
+                        "run": {"run_id": "1"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(COMPLETENESS),
+                    "--manifest",
+                    str(manifest),
+                    "--artifacts",
+                    str(root / "artifacts"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn("missing result artifacts: two", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/validate-validation-pilot-results.py
+++ b/.github/scripts/validate-validation-pilot-results.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Fail closed when a pilot run did not persist one complete result per attempt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_OUTCOMES = {"passed", "sample failure", "infrastructure/error", "skipped/not-completed"}
+REQUIRED_FIELDS = {
+    "schema_version", "sample", "outcome", "completed_stage", "duration_seconds",
+    "diagnostic_reference", "artifact_reference", "completed_at", "run",
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--artifacts", type=Path, required=True)
+    args = parser.parse_args()
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    expected = {sample["id"]: sample for sample in manifest["samples"]}
+    found = {}
+    errors = []
+    for result_path in sorted(args.artifacts.glob("*/sample-result.json")):
+        try:
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+            missing = REQUIRED_FIELDS - result.keys()
+            sample = result["sample"]
+            if missing or result["schema_version"] != 1 or result["outcome"] not in REQUIRED_OUTCOMES:
+                raise ValueError(f"invalid schema or outcome (missing={sorted(missing)})")
+            sample_id = sample["id"]
+            if sample_id not in expected or sample_id in found:
+                raise ValueError(f"unexpected or duplicate sample id: {sample_id}")
+            if sample != expected[sample_id] and any(
+                sample.get(key) != expected[sample_id].get(key)
+                for key in ("id", "path", "language", "shape")
+            ):
+                raise ValueError("sample identity does not match manifest")
+            diagnostic = result_path.parent / result["diagnostic_reference"]
+            if not diagnostic.is_file():
+                raise ValueError(f"missing diagnostic: {diagnostic}")
+            found[sample_id] = result
+        except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            errors.append(f"{result_path}: {exc}")
+    missing_ids = sorted(set(expected) - set(found))
+    if missing_ids:
+        errors.append("missing result artifacts: " + ", ".join(missing_ids))
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    output = args.artifacts / "run-summary.json"
+    output.write_text(json.dumps({"schema_version": 1, "results": found}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"validated {len(found)} complete sample results")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/validation-pilot-matrix.json
+++ b/.github/validation-pilot-matrix.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "repository": "microsoft-foundry/foundry-samples",
+  "samples": [
+    {
+      "id": "csharp-chat-with-agent",
+      "language": "csharp",
+      "shape": "quickstart",
+      "path": "samples/csharp/quickstart/chat-with-agent"
+    },
+    {
+      "id": "java-create-agent",
+      "language": "java",
+      "shape": "quickstart",
+      "path": "samples/java/quickstart/create-agent"
+    },
+    {
+      "id": "python-chat-with-agent",
+      "language": "python",
+      "shape": "quickstart-with-dependencies",
+      "path": "samples/python/quickstart/chat-with-agent"
+    },
+    {
+      "id": "typescript-chat-with-agent",
+      "language": "typescript",
+      "shape": "quickstart-declared-command",
+      "path": "samples/typescript/quickstart/chat-with-agent"
+    }
+  ]
+}

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -1,0 +1,21 @@
+# Representative public validation pilot
+
+`validation-pilot.yml` is a manual-only, non-gating workflow. It runs the
+versioned matrix in `validation-pilot-matrix.json` with `fail-fast: false`:
+
+| Sample | Language | Shape |
+| --- | --- | --- |
+| `csharp/quickstart/chat-with-agent` | C# | quickstart |
+| `java/quickstart/create-agent` | Java | quickstart |
+| `python/quickstart/chat-with-agent` | Python | quickstart with dependencies |
+| `typescript/quickstart/chat-with-agent` | TypeScript | declared-command quickstart |
+
+Each matrix leg persists `sample-result.json` and `diagnostics.log` in a
+versioned artifact. The result schema is owned by the producer and includes
+sample identity, one of `passed`, `sample failure`, `infrastructure/error`, or
+`skipped/not-completed`, the completed stage, duration, references to the
+diagnostic and result artifacts, completion time, and GitHub run metadata.
+
+The completeness job fails the run if any matrix member is missing, duplicated,
+malformed, or missing its diagnostic. Individual sample failures remain valid
+result records and do not prevent later matrix legs from running.

--- a/.github/workflows/scripts-selftest.yml
+++ b/.github/workflows/scripts-selftest.yml
@@ -22,6 +22,8 @@ on:
       - '.github/scripts/**'
       - '.github/workflows/validate.yml'
       - '.github/workflows/scripts-selftest.yml'
+      - '.github/workflows/validation-pilot.yml'
+      - '.github/validation-pilot-matrix.json'
 
 permissions:
   contents: read
@@ -99,6 +101,13 @@ jobs:
 
       - name: Phase-1 exit gate — all 5 languages, pass(0)/fail(1)/error(2)
         run: bash .github/scripts/test/run-tests.sh
+
+  validation-pilot-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Producer contract tests
+        run: python -m unittest discover -s .github/scripts/test -p 'test_validation_pilot.py'
 
   # --- Plumbing isolation proof: detector outputs cross a REAL job boundary via needs.*.outputs ---
   # Proves the $GITHUB_OUTPUT -> steps.*.outputs -> job.outputs -> downstream needs.*.outputs chain

--- a/.github/workflows/validation-pilot.yml
+++ b/.github/workflows/validation-pilot.yml
@@ -1,0 +1,102 @@
+name: Representative public validation pilot
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - id: csharp-chat-with-agent
+            language: csharp
+            shape: quickstart
+            path: samples/csharp/quickstart/chat-with-agent
+          - id: java-create-agent
+            language: java
+            shape: quickstart
+            path: samples/java/quickstart/create-agent
+          - id: python-chat-with-agent
+            language: python
+            shape: quickstart-with-dependencies
+            path: samples/python/quickstart/chat-with-agent
+          - id: typescript-chat-with-agent
+            language: typescript
+            shape: quickstart-declared-command
+            path: samples/typescript/quickstart/chat-with-agent
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        if: matrix.language == 'csharp'
+        with:
+          dotnet-version: 8.0.x
+      - uses: actions/setup-python@v5
+        if: matrix.language == 'python'
+        with:
+          python-version: '3.12'
+      - uses: actions/setup-node@v4
+        if: matrix.language == 'typescript'
+        with:
+          node-version: '20'
+      - uses: actions/setup-java@v4
+        if: matrix.language == 'java'
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+      - name: Run sample validation
+        run: |
+          mkdir -p "$RUNNER_TEMP/pilot-result"
+          python .github/scripts/run-validation-pilot.py \
+            --sample-id "${{ matrix.id }}" \
+            --language "${{ matrix.language }}" \
+            --shape "${{ matrix.shape }}" \
+            --sample-path "${{ matrix.path }}" \
+            --output "$RUNNER_TEMP/pilot-result/sample-result.json" \
+            --diagnostic "$RUNNER_TEMP/pilot-result/diagnostics.log"
+      - name: Persist sample result and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-pilot-${{ matrix.id }}
+          path: ${{ runner.temp }}/pilot-result
+          if-no-files-found: error
+          retention-days: 30
+
+  completeness:
+    if: always()
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: validation-pilot-*
+          path: ${{ runner.temp }}/pilot-artifacts
+      - name: Validate complete normalized result set
+        run: |
+          python .github/scripts/validate-validation-pilot-results.py \
+            --manifest .github/validation-pilot-matrix.json \
+            --artifacts "$RUNNER_TEMP/pilot-artifacts"
+      - name: Persist run metadata and normalized summary
+        if: always()
+        run: |
+          python -c 'import json,os; from pathlib import Path; p=Path(os.environ["RUNNER_TEMP"])/"pilot-artifacts"/"run-metadata.json"; p.write_text(json.dumps({"schema_version":1,"repository":os.environ["GITHUB_REPOSITORY"],"workflow":os.environ["GITHUB_WORKFLOW"],"run_id":os.environ["GITHUB_RUN_ID"],"run_attempt":os.environ["GITHUB_RUN_ATTEMPT"],"sha":os.environ["GITHUB_SHA"],"ref":os.environ["GITHUB_REF"],"completed_at":__import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat().replace("+00:00","Z")},indent=2)+"\n")'
+        continue-on-error: true
+      - name: Upload normalized pilot run
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-pilot-run-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/pilot-artifacts
+          if-no-files-found: error
+          retention-days: 90


### PR DESCRIPTION
## Summary

- add a manual-only representative public validation pilot with `fail-fast: false`
- validate a documented four-sample matrix across C#, Java, Python, and TypeScript sample shapes
- persist one schema-versioned normalized result and diagnostic log per matrix attempt
- fail closed on missing, duplicate, malformed, or incomplete result artifacts while preserving sample failures as valid results

## Producer contract

Each result includes schema version, sample identity/path, normalized outcome, completed stage, duration, diagnostic and artifact references, completion timestamp, and GitHub run metadata. Outcomes are `passed`, `sample failure`, `infrastructure/error`, and `skipped/not-completed`.

The workflow is `workflow_dispatch` only. It is not PR gating and does not introduce a scheduled full-fleet cadence; ADO 5449701 remains the separate scale-up task.

Tracking: ADO 5510709 https://msdata.visualstudio.com/Vienna/_workitems/edit/5510709