### PR TITLE
Document daily public validation cadence

### DIFF
--- a/.github/scripts/validate-sample.README.md
+++ b/.github/scripts/validate-sample.README.md
@@ -24,6 +24,25 @@ and a sample with a `live_service_validation` declaration proceeds to live-servi
 validation only after readiness passes. Declaring live-service validation therefore
 does not opt a sample out of build readiness.
 
+## Build readiness by language
+
+If `sample.yaml` declares `build`, `validate`, or `test` commands, the validator
+runs those commands in that order instead of the language default below. The
+first nonzero command fails build readiness.
+
+| Sample language | Default build-readiness checks |
+|---|---|
+| C# | Run `dotnet build` for every `.csproj` in the sample directory. If none exists, report readiness as passed. |
+| Python | Create an isolated virtual environment, install `requirements.txt` when present, and run `python -m py_compile` on top-level `.py` files. |
+| TypeScript | If `package.json` exists, run `npm install` and `npm run build --if-present`. Otherwise, syntax-check top-level `.js` files with `node --check`; top-level `.ts` files have no default check without a package definition. |
+| JavaScript | Use the TypeScript/Node.js validation path described above. |
+| Java | Run `mvn compile` for Maven samples or a Gradle build for Gradle samples, preferring the sample's `gradlew` wrapper. If no supported build file exists, report readiness as passed. |
+| Go | Run `go build ./...` for a module, or build each top-level `.go` file when no `go.mod` exists. |
+| Rust | Not currently supported by build readiness. Discovered Rust samples produce explicit `skipped/not-completed` results. |
+
+These defaults are credential-free readiness checks; they do not assert that a
+sample can successfully call a live service.
+
 Both modes use the same exit and verdict contract:
 
 | Exit | Verdict | Meaning |

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -12,13 +12,13 @@ At the checked-out commit, the workflow deterministically discovers every
 that run. There is no static matrix to maintain: a new
 `samples/**/sample.yaml` file is discovered automatically.
 
-The current inventory contains 72 samples:
+The current inventory contains 74 samples:
 
-- 53 samples are executable in the current cadence.
-- 19 samples emit explicit `skipped/not-completed` records: 12 have malformed
-  metadata and 7 use unsupported Rust build readiness.
+- 55 samples are eligible for execution in the current cadence.
+- 19 samples emit explicit `skipped/not-completed` records: 12 have invalid
+  YAML metadata and 7 use unsupported Rust build readiness.
 - JavaScript samples use the existing TypeScript/node validator.
-- Two samples opt in to live-service validation with
+- Two eligible samples opt in to live-service validation with
   `live_service_validation` metadata.
 
 **Build readiness** is credential-free. It uses a sample's declared build,
@@ -81,9 +81,10 @@ diagnostic excerpts, and preserves visible skip reasons. Full logs remain in
 the run artifacts.
 
 The authoritative hardened-cadence evidence is
-[run 31649334462](https://github.com/microsoft-foundry/foundry-samples/actions/runs/31649334462):
-all 75 jobs succeeded and the run published 74 artifacts at commit
-`328833f9d39e8e0a80975950cc98dc00d9c63aff`.
+[run 32821260320](https://github.com/microsoft-foundry/foundry-samples/actions/runs/32821260320):
+all 77 jobs succeeded and the run published 76 artifacts at commit
+`b9b2cdd67efee6287e4b263f83ed45f18fe892be`: 74 per-sample
+artifacts, the generated manifest, and the consolidated run artifact.
 
 This is a current cadence snapshot, not a completed-workstream claim.
 Additional live-service onboarding, cold provisioning, quarantine automation,

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -33,14 +33,14 @@ warm-project policy. The GitHub environment remains named `L4-validation`
 because that legacy external identifier is part of the Entra OIDC subject; it
 is not a current validation mode name.
 
-Discovery textually detects the `live_service_validation` key and rejects the
-legacy `l4` key with migration guidance. Do not infer broader YAML integrity,
-duplicate-ID, or path-safety guarantees from discovery until those guardrails
-are implemented.
+Discovery validates sample metadata and fails closed for malformed metadata,
+duplicate identities, or unsafe sample paths. It also rejects the legacy `l4`
+key with migration guidance.
 
 See the [per-sample validation contract](scripts/validate-sample.README.md) for
-metadata and local command examples. The runner modes are
-`--mode build-readiness` and `--mode live-service`.
+the language-by-language build-readiness matrix, metadata contract, and local
+command examples. The runner modes are `--mode build-readiness` and
+`--mode live-service`.
 
 ## Results and artifacts
 

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -1,33 +1,82 @@
 # Daily public validation cadence
 
-`validation-pilot.yml` runs daily at 07:00 UTC and can also be dispatched
-manually. It discovers every `samples/**/sample.yaml` at the checked-out commit,
-generates a deterministic manifest and matrix, and runs with `fail-fast: false`.
-The first full-fleet run should be manually reviewed before the first scheduled
-occurrence.
+The [Daily public validation cadence](workflows/validation-pilot.yml) runs every
+day at 07:00 UTC. Superseded runs are cancelled through workflow concurrency.
+Maintainers can also run it from **Actions** > **Daily public validation
+cadence** > **Run workflow**.
 
-All supported samples run build readiness. Samples declaring live-service validation use a separate credentialed
-matrix leg to avoid duplicate validation and unnecessary environment deployment
-records, but that leg still runs build readiness first and proceeds to live-service
-validation only when readiness passes. Declaring live-service validation never opts
-a sample out of build readiness. JavaScript uses the existing
-TypeScript/node validator mapping. Rust samples remain in the manifest and emit
-`skipped/not-completed` with an explicit unsupported-language reason.
+## Inventory and validation modes
 
-Each matrix leg persists `sample-result.json` and `diagnostics.log` in a
-versioned artifact. Declared `sample.yaml` live-service commands run through the
-existing `L4-validation` OIDC environment and warm-project seam. That environment
-name is a legacy external GitHub/Entra identifier and is not the validation mode
-name. P4.1 does not provision
-resources and does not set a cold-provisioning default.
+At the checked-out commit, the workflow deterministically discovers every
+`samples/**/sample.yaml` and generates the manifest and job matrices used by
+that run. There is no static matrix to maintain: a new
+`samples/**/sample.yaml` file is discovered automatically.
 
-The result schema remains owned by the producer and includes
-sample identity, one of `passed`, `sample failure`, `infrastructure/error`, or
-`skipped/not-completed`, the completed stage, duration, references to the
-diagnostic and result artifacts, completion time, and GitHub run metadata.
+The current inventory contains 72 samples:
 
-The completeness job fails the run if any discovered sample is missing,
-duplicated, malformed, or missing its diagnostic. Individual sample failures
-remain valid result records and do not prevent later matrix legs from running.
-The generated manifest is included in the normalized run artifact so the
-same-run report consumes exactly the inventory that was executed.
+- 61 samples have supported build-readiness validators.
+- 11 Rust samples emit explicit `skipped/not-completed` records because build
+  readiness does not yet support Rust.
+- JavaScript samples use the existing TypeScript/node validator.
+- Two samples opt in to live-service validation with
+  `live_service_validation` metadata.
+
+**Build readiness** is credential-free. It uses a sample's declared build,
+validate, or test command when present; otherwise, it uses the language-default
+restore, build, compile, or syntax check.
+
+**Live-service validation** is an opt-in, sample-owned runtime assertion. The
+workflow runs build readiness first and proceeds to the declared live-service
+command only when readiness passes. Authentication and configuration come from
+the caller, and the workflow preserves the current `SKIP_PROVISION=true`
+warm-project policy. The GitHub environment remains named `L4-validation`
+because that legacy external identifier is part of the Entra OIDC subject; it
+is not a current validation mode name.
+
+Discovery textually detects the `live_service_validation` key and rejects the
+legacy `l4` key with migration guidance. Do not infer broader YAML integrity,
+duplicate-ID, or path-safety guarantees from discovery until those guardrails
+are implemented.
+
+See the [per-sample validation contract](scripts/validate-sample.README.md) for
+metadata and local command examples. The runner modes are
+`--mode build-readiness` and `--mode live-service`.
+
+## Results and artifacts
+
+Producers emit schema-v2 manifests and results. Completeness and reporting
+readers retain schema-v1 compatibility for historical artifacts. New results
+use descriptive completed stages such as `build readiness validation` and
+`live-service validation`.
+
+Every result uses one of these outcomes:
+
+- `passed`
+- `sample failure`
+- `infrastructure/error`
+- `skipped/not-completed`
+
+A `sample failure` is valid reported data. Missing, duplicate, malformed, or
+incomplete result artifacts violate the reporting contract and fail the run.
+
+Each run publishes:
+
+- One `validation-pilot-{sample-id}` artifact per discovered sample, containing
+  `sample-result.json` and `diagnostics.log`.
+- The generated manifest in `validation-pilot-manifest`.
+- The consolidated
+  `validation-pilot-run-{run_id}-{run_attempt}` artifact.
+- A same-run summary in the `report / report` job.
+
+Cadence evidence is available in the
+[corrected manual run](https://github.com/microsoft-foundry/foundry-samples/actions/runs/31447067783)
+and the
+[first scheduled run](https://github.com/microsoft-foundry/foundry-samples/actions/runs/31469044031).
+
+The implementation and reporting contract are defined in:
+
+- [`.github/scripts/discover-validation-samples.py`](scripts/discover-validation-samples.py)
+- [`.github/scripts/run-validation-pilot.py`](scripts/run-validation-pilot.py)
+- [`.github/scripts/validate-validation-pilot-results.py`](scripts/validate-validation-pilot-results.py)
+- [`.github/scripts/render-validation-report.py`](scripts/render-validation-report.py)
+- [`.github/workflows/validation-report.yml`](workflows/validation-report.yml)

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -14,9 +14,9 @@ that run. There is no static matrix to maintain: a new
 
 The current inventory contains 72 samples:
 
-- 61 samples have supported build-readiness validators.
-- 11 Rust samples emit explicit `skipped/not-completed` records because build
-  readiness does not yet support Rust.
+- 53 samples are executable in the current cadence.
+- 19 samples emit explicit `skipped/not-completed` records: 12 have malformed
+  metadata and 7 use unsupported Rust build readiness.
 - JavaScript samples use the existing TypeScript/node validator.
 - Two samples opt in to live-service validation with
   `live_service_validation` metadata.
@@ -33,9 +33,13 @@ warm-project policy. The GitHub environment remains named `L4-validation`
 because that legacy external identifier is part of the Entra OIDC subject; it
 is not a current validation mode name.
 
-Discovery validates sample metadata and fails closed for malformed metadata,
-duplicate identities, or unsafe sample paths. It also rejects the legacy `l4`
-key with migration guidance.
+Discovery uses the pinned
+[`PyYAML`](scripts/requirements.txt) parser for the metadata fields it consumes.
+Unreadable or malformed metadata stays in inventory as an explicit
+`skipped/not-completed` record with an actionable reason. Ambiguous duplicate
+derived IDs and metadata paths that do not resolve to regular files inside the
+repository fail discovery before outputs are constructed. Discovery also
+rejects the legacy `l4` key with migration guidance.
 
 See the [per-sample validation contract](scripts/validate-sample.README.md) for
 the language-by-language build-readiness matrix, metadata contract, and local
@@ -68,10 +72,22 @@ Each run publishes:
   `validation-pilot-run-{run_id}-{run_attempt}` artifact.
 - A same-run summary in the `report / report` job.
 
-Cadence evidence is available in the
-[corrected manual run](https://github.com/microsoft-foundry/foundry-samples/actions/runs/31447067783)
-and the
-[first scheduled run](https://github.com/microsoft-foundry/foundry-samples/actions/runs/31469044031).
+## Interpret the report
+
+The run-scoped report puts records requiring maintainer action first, followed
+by informational skips and a compact passed section. It includes fleet counts,
+links each sample to the validated commit, shows bounded and sanitized
+diagnostic excerpts, and preserves visible skip reasons. Full logs remain in
+the run artifacts.
+
+The authoritative hardened-cadence evidence is
+[run 31649334462](https://github.com/microsoft-foundry/foundry-samples/actions/runs/31649334462):
+all 75 jobs succeeded and the run published 74 artifacts at commit
+`328833f9d39e8e0a80975950cc98dc00d9c63aff`.
+
+This is a current cadence snapshot, not a completed-workstream claim.
+Additional live-service onboarding, cold provisioning, quarantine automation,
+and Rust build-readiness support remain pending.
 
 The implementation and reporting contract are defined in:
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,16 @@ This repository is entirely open source, guidance on how to contribute and links
 
 Use the samples in this repository to try out Microsoft Foundry scenarios on your local machine!
 
+## Daily public validation
+
+The daily validation cadence checks every metadata-bearing sample at 07:00 UTC
+and publishes a run-scoped report and diagnostic artifacts. Maintainers can also
+start it manually. See the
+[validation cadence guide](.github/validation-pilot.README.md) for coverage,
+outcomes, artifacts, and current L4 limitations.
+
 ## Contributing
 
 Found a bug or have a suggestion? [Open an issue](https://github.com/microsoft-foundry/foundry-samples/issues/new) — we welcome feedback from everyone!
 
 Sample contributions are submitted through a private staging repository. If you're a Microsoft employee or contractor, see the [contributing guidelines](CONTRIBUTING.md) for how to get started.
-

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The daily validation cadence checks every metadata-bearing sample at 07:00 UTC
 and publishes a run-scoped report and diagnostic artifacts. Maintainers can also
 start it manually. See the
 [validation cadence guide](.github/validation-pilot.README.md) for coverage,
-outcomes, artifacts, and current L4 limitations.
+outcomes, artifacts, and live-service behavior.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- expose the daily public validation cadence from the root README
- document deterministic inventory discovery, invalid-YAML quarantine, duplicate-ID rejection, and the verified 74 visible / 55 eligible / 19 skipped snapshot (12 invalid YAML and 7 unsupported Rust)
- record the two eligible samples that declare Live-service validation
- add a language-by-language build-readiness matrix, including declared-command precedence and unsupported Rust behavior
- document schema-v2 production, schema-v1 reader compatibility, outcomes, artifacts, and action-first same-run reporting
- preserve the legacy `L4-validation` environment name only as an external infrastructure identifier
- identify the remaining live-service onboarding, cold-provisioning, quarantine-automation, and Rust-readiness scope without presenting P4 as complete

## Validation

- producer and reporting contract suites (18 tests)
- `tox -e typos` for all changed Markdown files
- local documentation link checks
- language matrix consistency against validator routes and declared-command precedence
- live schema, inventory, terminology, schedule, concurrency, artifact, provisioning-policy, discovery, and report consistency checks
- authoritative run 32821260320: 77/77 jobs succeeded and 76 artifacts published (74 per-sample, manifest, and consolidated run artifact)

## Tracking

ADO 5510709 — https://msdata.visualstudio.com/Vienna/_workitems/edit/5510709