### PR TITLE
Improve run-scoped validation report triage UX

### DIFF
--- a/.github/scripts/render-validation-report.py
+++ b/.github/scripts/render-validation-report.py
@@ -33,6 +33,8 @@ DIAGNOSTIC_LIMIT = 240
 DIAGNOSTIC_PATTERNS = (
     re.compile(r"(?:\berror\b|^FAIL:|^ERROR:|^SKIP:|^runner error:|^verdict=)", re.IGNORECASE),
 )
+REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+SHA_PATTERN = re.compile(r"^[0-9a-f]{7,40}$")
 
 
 class ContractError(ValueError):
@@ -184,8 +186,9 @@ def sample_url(record: dict[str, Any]) -> str | None:
     path = record["sample"]["path"]
     if (
         not isinstance(repository, str)
+        or not REPOSITORY_PATTERN.fullmatch(repository)
         or not isinstance(sha, str)
-        or not re.fullmatch(r"[0-9a-f]{7,40}", sha)
+        or not SHA_PATTERN.fullmatch(sha)
     ):
         return None
     return f"https://github.com/{repository}/tree/{sha}/{quote(path, safe='/')}"
@@ -260,11 +263,17 @@ def render(records: list[dict[str, Any]], run_url: str | None, complete: bool) -
     run = next((record.get("run") for record in records if record.get("run")), {})
     if run:
         metadata = f"Run {run.get('run_id')} · attempt {run.get('run_attempt')}"
+        repository = run.get("repository")
         sha = run.get("sha")
-        if isinstance(sha, str):
+        if (
+            isinstance(repository, str)
+            and REPOSITORY_PATTERN.fullmatch(repository)
+            and isinstance(sha, str)
+            and SHA_PATTERN.fullmatch(sha)
+        ):
             metadata += (
                 f" · validated SHA [`{sha[:12]}`]"
-                f"(https://github.com/{run.get('repository')}/commit/{sha})"
+                f"(https://github.com/{repository}/commit/{sha})"
             )
         if run_url:
             metadata += f" · [Workflow run]({run_url})"
@@ -318,8 +327,8 @@ def render(records: list[dict[str, Any]], run_url: str | None, complete: bool) -
         )
     lines.extend(
         [
-            "**Legend:** ✅ passed · ❌ sample failure · ⚠️ infrastructure/error · "
-            "⏭️ skipped/not-completed",
+            f"**Legend:** {OUTCOMES['passed']} · {OUTCOMES['sample failure']} · "
+            f"{OUTCOMES['infrastructure/error']} · {OUTCOMES['skipped/not-completed']}",
             "",
             "Diagnostics are summarized and sanitized. Full logs remain available from "
             "the workflow run, subject to GitHub Actions retention and authentication.",

--- a/.github/scripts/render-validation-report.py
+++ b/.github/scripts/render-validation-report.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 OUTCOMES = {
     "passed": "✅ Passed",
@@ -21,6 +23,16 @@ REQUIRED = {
     "diagnostic_reference", "artifact_reference", "completed_at", "run",
 }
 RUN_FIELDS = {"repository", "workflow", "run_id", "run_attempt", "sha", "ref", "started_at"}
+SECTION_ORDER = ("sample failure", "infrastructure/error", "skipped/not-completed", "passed")
+SECTION_LABELS = {
+    "sample failure": "Sample failures",
+    "infrastructure/error": "Infrastructure/errors",
+    "skipped/not-completed": "Skipped/not-completed",
+}
+DIAGNOSTIC_LIMIT = 240
+DIAGNOSTIC_PATTERNS = (
+    re.compile(r"(?:\berror\b|^FAIL:|^ERROR:|^SKIP:|^runner error:|^verdict=)", re.IGNORECASE),
+)
 
 
 class ContractError(ValueError):
@@ -109,7 +121,11 @@ def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
     diagnostic = path.parent / value["diagnostic_reference"]
     if not diagnostic.is_file():
         raise ContractError(f"missing diagnostic: {diagnostic}")
-    return {**value, "completed_at": timestamp(value["completed_at"], "completed_at")}
+    return {
+        **value,
+        "completed_at": timestamp(value["completed_at"], "completed_at"),
+        "diagnostic_path": diagnostic,
+    }
 
 
 def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dict[str, Any]], bool]:
@@ -150,23 +166,166 @@ def collect(results_dir: Path, expected: list[dict[str, str]]) -> tuple[list[dic
     return sorted(records.values(), key=lambda value: value["sample"]["path"]), incomplete
 
 
-def render(records: list[dict[str, Any]], run_url: str | None) -> str:
-    lines = [
-        "## Validation report", "",
-        "_Run-scoped summary; only attempted samples are listed._", "",
-        "| Sample | Outcome | Completed stage | Duration | Last run (UTC) | Diagnostic/artifact |",
-        "|---|---|---|---:|---|---|",
-    ]
+def markdown_cell(value: Any) -> str:
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("`", "'")
+        .replace("\r", " ")
+        .replace("\n", " ")
+    )
+
+
+def sample_url(record: dict[str, Any]) -> str | None:
+    run = record.get("run", {})
+    repository = run.get("repository")
+    sha = run.get("sha")
+    path = record["sample"]["path"]
+    if (
+        not isinstance(repository, str)
+        or not isinstance(sha, str)
+        or not re.fullmatch(r"[0-9a-f]{7,40}", sha)
+    ):
+        return None
+    return f"https://github.com/{repository}/tree/{sha}/{quote(path, safe='/')}"
+
+
+def diagnostic_excerpt(record: dict[str, Any]) -> str:
+    if record.get("error"):
+        value = record["error"]
+    else:
+        try:
+            lines = [
+                line.strip()
+                for line in record["diagnostic_path"]
+                .read_text(encoding="utf-8", errors="replace")
+                .splitlines()
+                if line.strip() and not line.lstrip().startswith("$ ")
+            ]
+        except OSError:
+            return "No diagnostic excerpt available"
+        value = next(
+            (
+                line
+                for line in lines
+                if any(pattern.search(line) for pattern in DIAGNOSTIC_PATTERNS)
+            ),
+            lines[0] if lines else "",
+        )
+    value = re.sub(
+        r"(?i)(token|secret|password|api[_ -]?key)(\s*[:=]\s*)\S+",
+        r"\1\2[redacted]",
+        value,
+    )
+    value = re.sub(r"[\x00-\x1f\x7f]", " ", value)
+    value = " ".join(value.split())
+    if len(value) > DIAGNOSTIC_LIMIT:
+        value = value[: DIAGNOSTIC_LIMIT - 1].rstrip() + "…"
+    return value or "No diagnostic excerpt available"
+
+
+def render_sample(record: dict[str, Any]) -> str:
+    path = markdown_cell(record["sample"]["path"])
+    url = sample_url(record)
+    return f"[`{path}`]({url})" if url else f"`{path}`"
+
+
+def render_rows(records: list[dict[str, Any]], outcome: str) -> list[str]:
+    rows = []
     for record in records:
-        completed = record["completed_at"].strftime("%Y-%m-%d %H:%M:%S UTC") if record["completed_at"] else "—"
-        sample = f"`{record['sample']['path']}`"
-        evidence = f"`{record['diagnostic_reference']}` / `{record['artifact_reference']}`"
-        lines.append(f"| {sample} | {OUTCOMES[record['outcome']]} | {record['completed_stage']} | {record['duration_seconds']}s | {completed} | {evidence} |")
-        if record.get("error"):
-            lines.append(f"| {sample} | ⚠️ Incomplete | reporting | — | — | {record['error']} |")
-    if run_url:
-        lines.extend(["", f"Run evidence: {run_url}"])
-    lines.extend(["", "**Legend:** ✅ passed · ❌ sample failure · ⚠️ infrastructure/error · ⏭️ skipped/not-completed", ""])
+        sample = render_sample(record)
+        stage = markdown_cell(record["completed_stage"])
+        if outcome == "passed":
+            rows.append(f"| {sample} | {stage} | {record['duration_seconds']}s |")
+            continue
+        reason = markdown_cell(diagnostic_excerpt(record))
+        if outcome == "skipped/not-completed":
+            next_action = "Add validator support or retain explicit skip"
+        elif outcome == "infrastructure/error":
+            next_action = "Inspect workflow job"
+        else:
+            next_action = "Inspect sample validation output"
+        rows.append(f"| {sample} | {stage} | `{reason}` | {next_action} |")
+    return rows
+
+
+def render(records: list[dict[str, Any]], run_url: str | None, complete: bool) -> str:
+    counts = {
+        outcome: sum(record["outcome"] == outcome for record in records)
+        for outcome in OUTCOMES
+    }
+    action_required = counts["sample failure"] + counts["infrastructure/error"]
+    lines = ["## Validation report", ""]
+    run = next((record.get("run") for record in records if record.get("run")), {})
+    if run:
+        metadata = f"Run {run.get('run_id')} · attempt {run.get('run_attempt')}"
+        sha = run.get("sha")
+        if isinstance(sha, str):
+            metadata += (
+                f" · validated SHA [`{sha[:12]}`]"
+                f"(https://github.com/{run.get('repository')}/commit/{sha})"
+            )
+        if run_url:
+            metadata += f" · [Workflow run]({run_url})"
+        lines.extend([f"_{metadata}_", ""])
+    lines.extend(
+        [
+            f"> **Action required:** {action_required} record(s) need maintainer attention",
+            f"> **Informational:** {counts['skipped/not-completed']} record(s) are intentionally skipped",
+            f"> **Fleet {'complete' if complete else 'incomplete'}:** {len(records)} result record(s) reported",
+            "",
+            f"**{len(records)} total · {counts['passed']} passed · "
+            f"{counts['sample failure']} sample failures · "
+            f"{counts['infrastructure/error']} infrastructure/errors · "
+            f"{counts['skipped/not-completed']} skipped/not-completed**",
+            "",
+        ]
+    )
+    for outcome in SECTION_ORDER[:3]:
+        section_records = sorted(
+            (record for record in records if record["outcome"] == outcome),
+            key=lambda record: (record["sample"]["language"], record["sample"]["path"]),
+        )
+        if not section_records:
+            continue
+        lines.extend(
+            [
+                f"### {OUTCOMES[outcome].split(' ', 1)[0]} {SECTION_LABELS[outcome]} ({len(section_records)})",
+                "",
+                "| Sample | Stage | Reason | Next action |",
+                "|---|---|---|---|",
+                *render_rows(section_records, outcome),
+                "",
+            ]
+        )
+    passed = sorted(
+        (record for record in records if record["outcome"] == "passed"),
+        key=lambda record: (record["sample"]["language"], record["sample"]["path"]),
+    )
+    if passed:
+        lines.extend(
+            [
+                f"<details><summary>{OUTCOMES['passed']} ({len(passed)})</summary>",
+                "",
+                "| Sample | Stage | Duration |",
+                "|---|---|---:|",
+                *render_rows(passed, "passed"),
+                "",
+                "</details>",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "**Legend:** ✅ passed · ❌ sample failure · ⚠️ infrastructure/error · "
+            "⏭️ skipped/not-completed",
+            "",
+            "Diagnostics are summarized and sanitized. Full logs remain available from "
+            "the workflow run, subject to GitHub Actions retention and authentication.",
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -180,7 +339,11 @@ def main() -> int:
     try:
         records, incomplete = collect(args.results_dir, load_expected(args.expected_samples))
         args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(render(records, args.run_url), encoding="utf-8", newline="\n")
+        args.output.write_text(
+            render(records, args.run_url, not incomplete),
+            encoding="utf-8",
+            newline="\n",
+        )
     except (ContractError, OSError) as exc:
         print(f"render-validation-report: {exc}", file=sys.stderr)
         return 1

--- a/.github/scripts/test/test-render-validation-report.py
+++ b/.github/scripts/test/test-render-validation-report.py
@@ -56,21 +56,25 @@ class ReportTests(unittest.TestCase):
             text=True,
         )
 
-    def write_result(self, sample: str, outcome: str = "passed") -> None:
-        sample_id = "a" if sample == SAMPLE_A else "b"
+    def write_result(
+        self,
+        sample: str,
+        outcome: str = "passed",
+        diagnostic_text: str = "diagnostic\n",
+    ) -> None:
+        manifest = json.loads(self.expected.read_text(encoding="utf-8"))
+        sample_definition = next(
+            value for value in manifest["samples"] if value["path"] == sample
+        )
+        sample_id = sample_definition["id"]
         sample_dir = self.results / sample_id
         sample_dir.mkdir()
-        (sample_dir / "diagnostics.log").write_text("diagnostic\n", encoding="utf-8")
+        (sample_dir / "diagnostics.log").write_text(diagnostic_text, encoding="utf-8")
         (sample_dir / "sample-result.json").write_text(
             json.dumps(
                 {
                     "schema_version": 1,
-                    "sample": {
-                        "id": sample_id,
-                        "path": sample,
-                        "language": "python" if sample_id == "a" else "csharp",
-                        "shape": "quickstart",
-                    },
+                    "sample": sample_definition,
                     "outcome": outcome,
                     "completed_stage": "L3 validation",
                     "duration_seconds": 12.5,
@@ -82,7 +86,7 @@ class ReportTests(unittest.TestCase):
                         "workflow": "validation pilot",
                         "run_id": "42",
                         "run_attempt": "1",
-                        "sha": "abc",
+                        "sha": "abcdef0",
                         "ref": "refs/heads/main",
                         "started_at": "2026-08-10T19:22:00Z",
                     },
@@ -99,9 +103,41 @@ class ReportTests(unittest.TestCase):
         body = self.output.read_text(encoding="utf-8")
         self.assertIn("✅ Passed", body)
         self.assertIn("❌ Sample failure", body)
-        self.assertIn("2026-08-10 19:22:33 UTC", body)
-        self.assertIn("Run evidence:", body)
+        self.assertIn("Workflow run", body)
+        self.assertIn("Sample failures (1)", body)
+        self.assertIn("Passed (1)", body)
+        self.assertIn("https://github.com/example/repo/tree/abcdef0", body)
         self.assertEqual(body.count("`samples/"), 2)
+
+    def test_renders_skip_reason_and_sanitized_truncated_excerpt(self) -> None:
+        self.expected.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "samples": [
+                        {"id": "a", "path": SAMPLE_A, "language": "python", "shape": "quickstart"},
+                        {"id": "b", "path": SAMPLE_B, "language": "csharp", "shape": "quickstart"},
+                        {"id": "c", "path": "samples/rust/quickstart/c", "language": "rust", "shape": "quickstart"},
+                        {"id": "d", "path": "samples/typescript/quickstart/d", "language": "typescript", "shape": "quickstart"},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.write_result(SAMPLE_A, "passed")
+        self.write_result(SAMPLE_B, "sample failure", "FAIL: password=secret " + ("x" * 300))
+        self.write_result("samples/rust/quickstart/c", "skipped/not-completed", "skipped: unsupported language: rust\n")
+        self.write_result("samples/typescript/quickstart/d", "infrastructure/error", "runner error: validator unavailable\n")
+        completed = self.run_report()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("Sample failures (1)", body)
+        self.assertIn("Infrastructure/errors (1)", body)
+        self.assertIn("Skipped/not-completed (1)", body)
+        self.assertIn("unsupported language: rust", body)
+        self.assertIn("password=[redacted]", body)
+        self.assertNotIn("password=secret", body)
+        self.assertIn("…", body)
 
     def test_missing_expected_artifact_publishes_partial_summary_and_fails(self) -> None:
         self.write_result(SAMPLE_A)


### PR DESCRIPTION
## Summary

- replace the flat run-scoped validation table with action-first outcome sections
- add fleet counts, completeness status, SHA-pinned sample links, and next actions
- surface bounded, sanitized diagnostic excerpts and skipped reasons
- keep producer/result schema v1 and reusable workflow wiring unchanged

## Validation

- Focused renderer tests pass
- Previewed against the 72-record normalized artifact from workflow run 31469044031
- Manual full-fleet preview run: https://github.com/microsoft-foundry/foundry-samples/actions/runs/31545068510

ADO 5514556: https://msdata.visualstudio.com/Vienna/_workitems/edit/5514556