### PR TITLE
Onboard Responses quickstarts to L4 validation

### DIFF
--- a/.github/scripts/discover-validation-samples.py
+++ b/.github/scripts/discover-validation-samples.py
@@ -68,11 +68,20 @@ def discover(root: Path) -> dict:
     }
 
 
+def write_matrix(path: Path, samples: list[dict]) -> None:
+    path.write_text(
+        json.dumps({"include": samples}, separators=(",", ":")),
+        encoding="utf-8",
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--root", type=Path, default=Path("."))
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--matrix", type=Path, required=True)
+    parser.add_argument("--l3-matrix", type=Path)
+    parser.add_argument("--l4-matrix", type=Path)
     args = parser.parse_args()
 
     payload = discover(args.root.resolve())
@@ -85,10 +94,17 @@ def main() -> int:
         + "\n",
         encoding="utf-8",
     )
-    args.matrix.write_text(
-        json.dumps({"include": payload["matrix"]}, separators=(",", ":")),
-        encoding="utf-8",
-    )
+    write_matrix(args.matrix, payload["matrix"])
+    if args.l3_matrix:
+        write_matrix(
+            args.l3_matrix,
+            [sample for sample in payload["matrix"] if not sample["l4_declared"]],
+        )
+    if args.l4_matrix:
+        write_matrix(
+            args.l4_matrix,
+            [sample for sample in payload["matrix"] if sample["l4_declared"]],
+        )
     print(json.dumps({"count": len(payload["matrix"]), "matrix": payload["matrix"]}, separators=(",", ":")))
     return 0
 

--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -36,6 +36,8 @@ class ValidationPilotTests(unittest.TestCase):
             root = Path(directory)
             manifest = root / "manifest.json"
             matrix = root / "matrix.json"
+            l3_matrix = root / "l3-matrix.json"
+            l4_matrix = root / "l4-matrix.json"
             completed = subprocess.run(
                 [
                     sys.executable,
@@ -46,6 +48,10 @@ class ValidationPilotTests(unittest.TestCase):
                     str(manifest),
                     "--matrix",
                     str(matrix),
+                    "--l3-matrix",
+                    str(l3_matrix),
+                    "--l4-matrix",
+                    str(l4_matrix),
                 ],
                 capture_output=True,
                 text=True,
@@ -84,17 +90,29 @@ class ValidationPilotTests(unittest.TestCase):
             self.assertEqual(json.loads(matrix.read_text(encoding="utf-8"))["include"], [
                 {**sample, **payload["validation"][sample["id"]]} for sample in payload["samples"]
             ])
+            self.assertTrue(
+                all(not sample["l4_declared"] for sample in json.loads(l3_matrix.read_text())["include"])
+            )
+            self.assertEqual(
+                {sample["path"] for sample in json.loads(l4_matrix.read_text())["include"]},
+                declared_l4_paths,
+            )
 
-    def test_workflow_supplies_declared_l4_warm_project_inputs(self) -> None:
+    def test_workflow_isolates_declared_l4_warm_project_jobs(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertEqual(workflow.count("environment: L4-validation"), 1)
+        self.assertIn("matrix: ${{ fromJSON(needs.discover.outputs.l3_matrix) }}", workflow)
+        self.assertIn("matrix: ${{ fromJSON(needs.discover.outputs.l4_matrix) }}", workflow)
         self.assertIn(
-            "AZURE_AI_PROJECT_ENDPOINT: ${{ matrix.l4_declared && vars.AZURE_AI_PROJECT_ENDPOINT || '' }}",
+            "AZURE_AI_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_PROJECT_ENDPOINT }}",
             workflow,
         )
         self.assertIn(
-            "MODEL_DEPLOYMENT: ${{ matrix.l4_declared && vars.MODEL_DEPLOYMENT || '' }}",
+            "MODEL_DEPLOYMENT: ${{ vars.MODEL_DEPLOYMENT }}",
             workflow,
         )
+        self.assertIn('SKIP_PROVISION: "true"', workflow)
+        self.assertIn('python -m pip install -r "${{ matrix.path }}/requirements.txt"', workflow)
 
     def test_sample_failure_is_a_complete_valid_result(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -69,9 +69,33 @@ class ValidationPilotTests(unittest.TestCase):
                 {"csharp", "java", "python", "typescript"},
             )
             self.assertTrue(all(sample["shape"] == "full-fleet" for sample in payload["samples"]))
+            declared_l4_paths = {
+                sample["path"]
+                for sample in payload["samples"]
+                if payload["validation"][sample["id"]]["l4_declared"]
+            }
+            self.assertEqual(
+                declared_l4_paths,
+                {
+                    "samples/csharp/quickstart/responses",
+                    "samples/python/quickstart/responses",
+                },
+            )
             self.assertEqual(json.loads(matrix.read_text(encoding="utf-8"))["include"], [
                 {**sample, **payload["validation"][sample["id"]]} for sample in payload["samples"]
             ])
+
+    def test_workflow_supplies_declared_l4_warm_project_inputs(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "AZURE_AI_PROJECT_ENDPOINT: ${{ matrix.l4_declared && vars.AZURE_AI_PROJECT_ENDPOINT || '' }}",
+            workflow,
+        )
+        self.assertIn(
+            "MODEL_DEPLOYMENT: ${{ matrix.l4_declared && vars.MODEL_DEPLOYMENT || '' }}",
+            workflow,
+        )
+
     def test_sample_failure_is_a_complete_valid_result(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/.github/workflows/validation-pilot.yml
+++ b/.github/workflows/validation-pilot.yml
@@ -17,7 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      matrix: ${{ steps.discovery.outputs.matrix }}
+      l3_matrix: ${{ steps.discovery.outputs.l3_matrix }}
+      l4_matrix: ${{ steps.discovery.outputs.l4_matrix }}
     steps:
       - uses: actions/checkout@v4
       - name: Discover full sample inventory
@@ -26,8 +27,11 @@ jobs:
           set -euo pipefail
           python .github/scripts/discover-validation-samples.py \
             --manifest "$RUNNER_TEMP/validation-manifest.json" \
-            --matrix "$RUNNER_TEMP/validation-matrix.json" > "$RUNNER_TEMP/discovery.json"
-          printf 'matrix=%s\n' "$(cat "$RUNNER_TEMP/validation-matrix.json")" >> "$GITHUB_OUTPUT"
+            --matrix "$RUNNER_TEMP/validation-matrix.json" \
+            --l3-matrix "$RUNNER_TEMP/validation-l3-matrix.json" \
+            --l4-matrix "$RUNNER_TEMP/validation-l4-matrix.json" > "$RUNNER_TEMP/discovery.json"
+          printf 'l3_matrix=%s\n' "$(cat "$RUNNER_TEMP/validation-l3-matrix.json")" >> "$GITHUB_OUTPUT"
+          printf 'l4_matrix=%s\n' "$(cat "$RUNNER_TEMP/validation-l4-matrix.json")" >> "$GITHUB_OUTPUT"
           cat "$RUNNER_TEMP/discovery.json"
       - name: Persist discovered manifest
         uses: actions/upload-artifact@v4
@@ -41,20 +45,12 @@ jobs:
     needs: discover
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    environment: L4-validation
     permissions:
       contents: read
-      id-token: write
-    env:
-      # P4.1 never provisions. Declared L4 checks use the existing warm-project seam;
-      # P4.2 owns any future cold-provisioning caller.
-      SKIP_PROVISION: ${{ matrix.l4_declared && 'true' || '' }}
-      AZURE_AI_PROJECT_ENDPOINT: ${{ matrix.l4_declared && vars.AZURE_AI_PROJECT_ENDPOINT || '' }}
-      MODEL_DEPLOYMENT: ${{ matrix.l4_declared && vars.MODEL_DEPLOYMENT || '' }}
     strategy:
       fail-fast: false
       max-parallel: 32
-      matrix: ${{ fromJSON(needs.discover.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.discover.outputs.l3_matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
@@ -79,13 +75,6 @@ jobs:
         run: |
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
-      - name: Azure login for declared L4
-        if: matrix.l4_declared
-        uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
       - name: Run normalized sample validation
         if: always()
         run: |
@@ -102,8 +91,6 @@ jobs:
           )
           if [ "${{ matrix.eligible }}" != "true" ]; then
             args+=(--skip-reason "${{ matrix.skip_reason }}")
-          elif [ "${{ matrix.l4_declared }}" = "true" ]; then
-            args+=(--run-l4)
           fi
           python .github/scripts/run-validation-pilot.py "${args[@]}"
       - name: Persist sample result and diagnostics
@@ -115,9 +102,72 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
+  validate-l4:
+    needs: discover
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: L4-validation
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      # P4.1 never provisions. P4.2 owns any future cold-provisioning caller.
+      SKIP_PROVISION: "true"
+      AZURE_AI_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_PROJECT_ENDPOINT }}
+      MODEL_DEPLOYMENT: ${{ vars.MODEL_DEPLOYMENT }}
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix: ${{ fromJSON(needs.discover.outputs.l4_matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        if: matrix.validator_language == 'csharp'
+        with:
+          dotnet-version: 8.0.x
+      - uses: actions/setup-python@v5
+        if: matrix.validator_language == 'python'
+        with:
+          python-version: '3.12'
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+      - name: Install declared L4 Python runtime dependencies
+        if: matrix.validator_language == 'python'
+        run: python -m pip install -r "${{ matrix.path }}/requirements.txt"
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+      - name: Run normalized L4 sample validation
+        if: always()
+        run: |
+          set -uo pipefail
+          mkdir -p "$RUNNER_TEMP/pilot-result"
+          python .github/scripts/run-validation-pilot.py \
+            --sample-id "${{ matrix.id }}" \
+            --language "${{ matrix.language }}" \
+            --validator-language "${{ matrix.validator_language }}" \
+            --shape "${{ matrix.shape }}" \
+            --sample-path "${{ matrix.path }}" \
+            --output "$RUNNER_TEMP/pilot-result/sample-result.json" \
+            --diagnostic "$RUNNER_TEMP/pilot-result/diagnostics.log" \
+            --run-l4
+      - name: Persist sample result and diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-pilot-${{ matrix.id }}
+          path: ${{ runner.temp }}/pilot-result
+          if-no-files-found: error
+          retention-days: 30
+
   completeness:
     if: always()
-    needs: [discover, validate]
+    needs: [discover, validate, validate-l4]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/validation-pilot.yml
+++ b/.github/workflows/validation-pilot.yml
@@ -49,6 +49,8 @@ jobs:
       # P4.1 never provisions. Declared L4 checks use the existing warm-project seam;
       # P4.2 owns any future cold-provisioning caller.
       SKIP_PROVISION: ${{ matrix.l4_declared && 'true' || '' }}
+      AZURE_AI_PROJECT_ENDPOINT: ${{ matrix.l4_declared && vars.AZURE_AI_PROJECT_ENDPOINT || '' }}
+      MODEL_DEPLOYMENT: ${{ matrix.l4_declared && vars.MODEL_DEPLOYMENT || '' }}
     strategy:
       fail-fast: false
       max-parallel: 32

--- a/samples/csharp/quickstart/responses/quickstart-responses.cs
+++ b/samples/csharp/quickstart/responses/quickstart-responses.cs
@@ -6,15 +6,22 @@ using OpenAI.Responses;
 #pragma warning disable OPENAI001
 
 // Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-var ProjectEndpoint = "your_project_endpoint";
+var projectEndpoint = Environment.GetEnvironmentVariable("AZURE_AI_PROJECT_ENDPOINT") ?? "your_project_endpoint";
+var modelDeployment = Environment.GetEnvironmentVariable("MODEL_DEPLOYMENT") ?? "gpt-5-mini";
 
 // Create project client to call Foundry API
 AIProjectClient projectClient = new(
-    endpoint: new Uri(ProjectEndpoint),
+    endpoint: new Uri(projectEndpoint),
     tokenProvider: new DefaultAzureCredential());
 
 // Run a responses API call
-ProjectResponsesClient responseClient = projectClient.ProjectOpenAIClient.GetProjectResponsesClientForModel("gpt-5-mini"); 
+ProjectResponsesClient responseClient = projectClient.ProjectOpenAIClient.GetProjectResponsesClientForModel(modelDeployment);
 ResponseResult response = await responseClient.CreateResponseAsync(
     "What is the size of France in square miles?");
-Console.WriteLine(response.GetOutputText());
+string outputText = response.GetOutputText();
+if (string.IsNullOrWhiteSpace(outputText))
+{
+    throw new InvalidOperationException("Response output text was empty.");
+}
+
+Console.WriteLine(outputText);

--- a/samples/csharp/quickstart/responses/sample.yaml
+++ b/samples/csharp/quickstart/responses/sample.yaml
@@ -1,3 +1,8 @@
 name: Quickstart Responses
 description: Basic quickstart sample demonstrating Microsoft Foundry responses.
 build: "dotnet restore --source https://api.nuget.org/v3/index.json && dotnet build --no-restore --verbosity minimal"
+l4:
+  command: "dotnet run --no-build"
+  required_env:
+    - AZURE_AI_PROJECT_ENDPOINT
+    - MODEL_DEPLOYMENT

--- a/samples/python/quickstart/responses/quickstart-responses.py
+++ b/samples/python/quickstart/responses/quickstart-responses.py
@@ -1,8 +1,11 @@
+import os
+
 from azure.identity import DefaultAzureCredential
 from azure.ai.projects import AIProjectClient
 
 # Format: "https://resource_name.ai.azure.com/api/projects/project_name"
-PROJECT_ENDPOINT = "your_project_endpoint"
+PROJECT_ENDPOINT = os.getenv("AZURE_AI_PROJECT_ENDPOINT", "your_project_endpoint")
+MODEL_DEPLOYMENT = os.getenv("MODEL_DEPLOYMENT", "gpt-5-mini")
 
 # Create project and openai clients to call Foundry API
 project = AIProjectClient(
@@ -13,7 +16,10 @@ openai = project.get_openai_client()
 
 # Run a responses API call
 response = openai.responses.create(
-    model="gpt-5-mini",
+    model=MODEL_DEPLOYMENT,
     input="What is the size of France in square miles?",
 )
+if not response.output_text or not response.output_text.strip():
+    raise RuntimeError("Response output text was empty.")
+
 print(f"Response output: {response.output_text}")

--- a/samples/python/quickstart/responses/sample.yaml
+++ b/samples/python/quickstart/responses/sample.yaml
@@ -3,3 +3,8 @@ description: Basic quickstart sample demonstrating Microsoft Foundry responses.
 
 build: "pip install -r requirements.txt"
 validate: "python -m py_compile *.py"
+l4:
+  command: "python quickstart-responses.py"
+  required_env:
+    - AZURE_AI_PROJECT_ENDPOINT
+    - MODEL_DEPLOYMENT


### PR DESCRIPTION
## Summary
- onboard the Python and C# Responses quickstarts as the first declared-L4 cohort
- accept warm project/model overrides while retaining instructional local defaults
- require warm inputs and execute already-built samples without provisioning
- export declared-L4 environment inputs in the pilot workflow and pin focused discovery coverage

## Validation
- focused validation-pilot tests: 5 passed
- L3 validator: Python and C# passed
- missing required L4 input: both classified infrastructure/error (exit 2)
- direct warm-project execution: both returned non-empty text with gpt-5.4-mini
- L4 validator with SKIP_PROVISION=true: Python and C# passed

Tracks incremental work under [ADO 5511477](https://msdata.visualstudio.com/Vienna/_workitems/edit/5511477). The broader task remains In Progress; full inventory rubric, additional shapes/cohorts, and cold provisioning are deferred.