### PR TITLE
Clarify L3 and L4 validation sequencing

### DIFF
--- a/.github/scripts/validate-sample.README.md
+++ b/.github/scripts/validate-sample.README.md
@@ -18,6 +18,12 @@ SKIP_PROVISION=true bash .github/scripts/validate-sample.sh \
   --sample-dir samples/python/quickstart/responses
 ```
 
+These commands invoke individual validation levels; calling `--level 4` directly
+does not implicitly run L3 first. The repository validation pilot provides the
+end-to-end sequence: every supported sample runs L3, and a sample with an `l4`
+declaration proceeds to L4 only after its L3 check passes. Declaring L4 therefore
+does not opt a sample out of L3.
+
 Both modes use the same exit and verdict contract:
 
 | Exit | Verdict | Meaning |

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -6,14 +6,17 @@ generates a deterministic manifest and matrix, and runs with `fail-fast: false`.
 The first full-fleet run should be manually reviewed before the first scheduled
 occurrence.
 
-All supported samples run L3. JavaScript uses the existing TypeScript/node
-validator mapping. Rust samples remain in the manifest and emit
+All supported samples run L3. Declared-L4 samples use a separate credentialed
+matrix leg to avoid duplicate validation and unnecessary environment deployment
+records, but that leg still runs L3 first and proceeds to L4 only when L3 passes.
+Declaring L4 never opts a sample out of L3. JavaScript uses the existing
+TypeScript/node validator mapping. Rust samples remain in the manifest and emit
 `skipped/not-completed` with an explicit unsupported-language reason.
 
 Each matrix leg persists `sample-result.json` and `diagnostics.log` in a
-versioned artifact. Declared `sample.yaml` L4 commands run after L3 through the
-existing `L4-validation` OIDC environment and warm-project seam. P4.1 does not
-provision resources and does not set a cold-provisioning default.
+versioned artifact. Declared `sample.yaml` L4 commands run through the existing
+`L4-validation` OIDC environment and warm-project seam. P4.1 does not provision
+resources and does not set a cold-provisioning default.
 
 The result schema remains owned by the producer and includes
 sample identity, one of `passed`, `sample failure`, `infrastructure/error`, or


### PR DESCRIPTION
## Summary
- clarify that declaring L4 does not remove a sample from L3 validation
- document that validation-pilot runs L3 first and only proceeds to L4 after L3 passes
- distinguish direct single-level validator usage from pilot orchestration

Documentation follow-up to [ADO 5511477](https://msdata.visualstudio.com/Vienna/_workitems/edit/5511477) and merged PR #905.