### PR TITLE
Replace numbered validation terminology

### DIFF
--- a/.github/scripts/CLASSIFICATION.md
+++ b/.github/scripts/CLASSIFICATION.md
@@ -9,9 +9,9 @@ consumes its verdict.
 
 | Exit | Verdict | Meaning | Downstream action |
 |------|---------|---------|-------------------|
-| `0`  | `pass`  | The requested level passed: L3 builds/compiles, or the declared L4 command exited 0. L4 with no declaration is also a successful no-op. | none |
+| `0`  | `pass`  | The requested mode passed: build readiness builds/compiles, or the declared live-service command exited 0. Live-service validation with no declaration is also a successful no-op. | none |
 | `1`  | `fail`  | **The SAMPLE is broken**, or a runtime failure we cannot positively attribute to our infra. | P4.4 may count a strike / quarantine (advisory-first). |
-| `2`  | `error` | **OUR INFRA is sick** — a precondition error, a dedicated dependency install with positively-identified transport failure, or an L4 command explicitly reporting caller/cloud infrastructure failure with exit 2. | Page us. **P4.4 must NEVER count or quarantine on `error`.** |
+| `2`  | `error` | **OUR INFRA is sick** — a precondition error, a dedicated dependency install with positively-identified transport failure, or a live-service command explicitly reporting caller/cloud infrastructure failure with exit 2. | Page us. **P4.4 must NEVER count or quarantine on `error`.** |
 
 The split is a safety interlock. A real breakage mislabeled `error` hides broken code forever
 (there is no counter behind `error`). A transient infra blip mislabeled `failure` risks
@@ -22,7 +22,7 @@ quarantining a healthy sample. Both directions are dangerous; keep the split hon
 **Precondition errors (validator can't even run the check):**
 - bad / missing CLI args; unknown or missing `--language`; missing or nonexistent `--sample-dir`
 - `sample.yaml` unreadable or malformed (`yq` read fails)
-- a declared `l4` block has an invalid shape, a required L4 environment variable is missing,
+- a declared `live_service_validation` block has an invalid shape, a required live-service environment variable is missing,
   or the caller did not set `SKIP_PROVISION` to exactly `true` or `false`
 - a required toolchain binary missing from `PATH` (`require_tool`)
 - `yq` unavailable when a `sample.yaml` must be read
@@ -31,20 +31,20 @@ quarantining a healthy sample. Both directions are dangerous; keep the split hon
 **Runtime infrastructure failures:**
 - a `pip install` or `npm install` that failed with **positive transport evidence**:
   DNS failure, connection refused/reset, connect/read timeout, or a registry `5xx`.
-- a declared L4 command that explicitly exits `2` after identifying a known caller/cloud
+- a declared live-service command that explicitly exits `2` after identifying a known caller/cloud
   infrastructure failure (for example credential, endpoint, or cloud transport failure).
 - Pip/npm detection lives in `dep_infra_signature()` — a **narrow allow-list of tool-specific
   transport strings** (e.g. `ECONNREFUSED`, `ENOTFOUND`, `Temporary failure in name
   resolution`, `Max retries exceeded`, `503 Server Error`). It is the authoritative signature
-  list for those dedicated install logs only; arbitrary L4 output never enters it.
+  list for those dedicated install logs only; arbitrary live-service output never enters it.
 
 ## What is `failure` (exit 1)
 
 - any `sample.yaml` build/validate/test command exits non-zero
-- a declared `sample.yaml` L4 command exits `1`
-- a declared L4 command exits with any unexpected nonzero status other than explicit error `2`
-- an L4 command exits `1` after printing transport-like application text such as
-  `503 Service Unavailable`; text alone never upgrades L4 to infrastructure error
+- a declared `sample.yaml` live-service command exits `1`
+- a declared live-service command exits with any unexpected nonzero status other than explicit error `2`
+- a live-service command exits `1` after printing transport-like application text such as
+  `503 Service Unavailable`; text alone never upgrades it to infrastructure error
 - a compile/build step fails: `dotnet build`, `mvn compile`, `gradle build`, `go build`,
   `npm run build`, `node --check`, `py_compile`
 - a dependency install (`pip install` / `npm install`) fails **without** transport evidence —
@@ -54,7 +54,7 @@ quarantining a healthy sample. Both directions are dangerous; keep the split hon
 ## Ambiguity-bias rule
 
 When a dependency-install failure shows **no** positive transport evidence, it is classified
-`failure`, **never** `pass`. L4 commands must normalize a known infrastructure condition to
+`failure`, **never** `pass`. Live-service commands must normalize a known infrastructure condition to
 exit `2`; output text is not interpreted. When we genuinely cannot tell an infra blip from a
 sample break, we bias to **`failure`**.
 
@@ -95,8 +95,8 @@ never fails **open** to `pass`.
 
 The contract is exercised end-to-end on a real GitHub Actions runner by
 `.github/scripts/test/run-tests.sh` (invoked from the `validate-harness` job in
-`.github/workflows/scripts-selftest.yml`). It covers declared L4 pass, undeclared no-op,
-explicit L4 fail/error exits, unexpected nonzero failure, transport-like text that remains a
+`.github/workflows/scripts-selftest.yml`). It covers declared live-service pass, undeclared no-op,
+explicit live-service fail/error exits, unexpected nonzero failure, transport-like text that remains a
 failure, invalid declarations, missing caller environment, `GITHUB_OUTPUT`, and results files.
 The dependency checks separately prove that a forced-unreachable registry
 (`127.0.0.1:1` blackhole) classifies as `error` (exit 2), while an unaccompanied resolution

--- a/.github/scripts/discover-validation-samples.py
+++ b/.github/scripts/discover-validation-samples.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Discover the full sample inventory and emit a deterministic Actions matrix."""
+"""Discover the full sample inventory and emit deterministic validation matrices."""
 
 from __future__ import annotations
 
@@ -21,10 +21,17 @@ def sample_id(path: str) -> str:
     return path.removeprefix("samples/").replace("/", "-")
 
 
-def declares_l4(metadata: Path) -> bool:
+def declares_live_service_validation(metadata: Path) -> bool:
     for line in metadata.read_text(encoding="utf-8").splitlines():
         without_comment = line.split("#", 1)[0].rstrip()
         if re.match(r"^[ \t]*l4[ \t]*:", without_comment):
+            raise ValueError(
+                f"{metadata}: legacy top-level key 'l4' is unsupported; "
+                "rename it to 'live_service_validation'"
+            )
+        if re.match(
+            r"^[ \t]*live_service_validation[ \t]*:", without_comment
+        ):
             return True
     return False
 
@@ -35,7 +42,7 @@ def discover(root: Path) -> dict:
         path = metadata.parent.relative_to(root).as_posix()
         language = path.split("/")[1]
         validator_language = SUPPORTED_LANGUAGES.get(language)
-        declared_l4 = declares_l4(metadata)
+        live_service_validation_declared = declares_live_service_validation(metadata)
         sample = {
             "id": sample_id(path),
             "path": path,
@@ -46,21 +53,26 @@ def discover(root: Path) -> dict:
         sample["validator_language"] = validator_language or ""
         sample["eligible"] = validator_language is not None
         sample["skip_reason"] = (
-            "" if validator_language else f"language '{language}' is not supported by L3 validation"
+            "" if validator_language else f"language '{language}' is not supported by build readiness"
         )
-        sample["l4_declared"] = declared_l4
+        sample["live_service_validation_declared"] = live_service_validation_declared
 
     identities = [
         {key: sample[key] for key in ("id", "path", "language", "shape")}
         for sample in samples
     ]
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "samples": identities,
         "validation": {
             sample["id"]: {
                 key: sample[key]
-                for key in ("validator_language", "eligible", "skip_reason", "l4_declared")
+                for key in (
+                    "validator_language",
+                    "eligible",
+                    "skip_reason",
+                    "live_service_validation_declared",
+                )
             }
             for sample in samples
         },
@@ -80,8 +92,8 @@ def main() -> int:
     parser.add_argument("--root", type=Path, default=Path("."))
     parser.add_argument("--manifest", type=Path, required=True)
     parser.add_argument("--matrix", type=Path, required=True)
-    parser.add_argument("--l3-matrix", type=Path)
-    parser.add_argument("--l4-matrix", type=Path)
+    parser.add_argument("--build-readiness-matrix", type=Path)
+    parser.add_argument("--live-service-matrix", type=Path)
     args = parser.parse_args()
 
     payload = discover(args.root.resolve())
@@ -95,15 +107,23 @@ def main() -> int:
         encoding="utf-8",
     )
     write_matrix(args.matrix, payload["matrix"])
-    if args.l3_matrix:
+    if args.build_readiness_matrix:
         write_matrix(
-            args.l3_matrix,
-            [sample for sample in payload["matrix"] if not sample["l4_declared"]],
+            args.build_readiness_matrix,
+            [
+                sample
+                for sample in payload["matrix"]
+                if not sample["live_service_validation_declared"]
+            ],
         )
-    if args.l4_matrix:
+    if args.live_service_matrix:
         write_matrix(
-            args.l4_matrix,
-            [sample for sample in payload["matrix"] if sample["l4_declared"]],
+            args.live_service_matrix,
+            [
+                sample
+                for sample in payload["matrix"]
+                if sample["live_service_validation_declared"]
+            ],
         )
     print(json.dumps({"count": len(payload["matrix"]), "matrix": payload["matrix"]}, separators=(",", ":")))
     return 0

--- a/.github/scripts/render-validation-report.py
+++ b/.github/scripts/render-validation-report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Render a run-scoped summary from validation-pilot v1 result artifacts."""
+"""Render a run-scoped summary from validation-pilot result artifacts."""
 
 from __future__ import annotations
 
@@ -30,6 +30,13 @@ SECTION_LABELS = {
     "skipped/not-completed": "Skipped/not-completed",
 }
 DIAGNOSTIC_LIMIT = 240
+SUPPORTED_SCHEMA_VERSIONS = {1, 2}
+LEGACY_COMPLETED_STAGES = {
+    "L3 validation": "build readiness validation",
+    "L3 validation invocation": "build readiness invocation",
+    "L4 validation": "live-service validation",
+    "L4 validation invocation": "live-service validation invocation",
+}
 DIAGNOSTIC_PATTERNS = (
     re.compile(r"(?:\berror\b|^FAIL:|^ERROR:|^SKIP:|^runner error:|^verdict=)", re.IGNORECASE),
 )
@@ -77,7 +84,7 @@ def load_expected(path: Path) -> list[dict[str, str]]:
     payload = load_json(path, "sample manifest")
     if (
         not isinstance(payload, dict)
-        or payload.get("schema_version") != 1
+        or payload.get("schema_version") not in SUPPORTED_SCHEMA_VERSIONS
         or not isinstance(payload.get("samples"), list)
         or not payload["samples"]
     ):
@@ -91,8 +98,12 @@ def load_expected(path: Path) -> list[dict[str, str]]:
 
 def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
     value = load_json(path, f"result artifact {path}")
-    if not isinstance(value, dict) or set(value) != REQUIRED or value.get("schema_version") != 1:
-        raise ContractError("result must be a schema_version 1 object")
+    if (
+        not isinstance(value, dict)
+        or set(value) != REQUIRED
+        or value.get("schema_version") not in SUPPORTED_SCHEMA_VERSIONS
+    ):
+        raise ContractError("result must be a supported schema object")
     missing = REQUIRED - value.keys()
     if missing:
         raise ContractError(f"result is missing fields: {sorted(missing)}")
@@ -123,8 +134,12 @@ def load_record(path: Path, expected: dict[str, str]) -> dict[str, Any]:
     diagnostic = path.parent / value["diagnostic_reference"]
     if not diagnostic.is_file():
         raise ContractError(f"missing diagnostic: {diagnostic}")
+    completed_stage = LEGACY_COMPLETED_STAGES.get(
+        value["completed_stage"], value["completed_stage"]
+    )
     return {
         **value,
+        "completed_stage": completed_stage,
         "completed_at": timestamp(value["completed_at"], "completed_at"),
         "diagnostic_path": diagnostic,
     }

--- a/.github/scripts/run-validation-pilot.py
+++ b/.github/scripts/run-validation-pilot.py
@@ -40,7 +40,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--ref", default=os.environ.get("GITHUB_REF", "local"))
     parser.add_argument("--repository", default=os.environ.get("GITHUB_REPOSITORY", "local"))
     parser.add_argument("--workflow", default=os.environ.get("GITHUB_WORKFLOW", "validation pilot"))
-    parser.add_argument("--run-l4", action="store_true")
+    parser.add_argument("--run-live-service", action="store_true")
     parser.add_argument("--skip-reason")
     return parser.parse_args()
 
@@ -58,8 +58,8 @@ def main() -> int:
         command = [
             args.bash,
             args.validator,
-            "--level",
-            "3",
+            "--mode",
+            "build-readiness",
             "--language",
             validator_language,
             "--sample-dir",
@@ -69,21 +69,46 @@ def main() -> int:
             completed = subprocess.run(command, capture_output=True, text=True)
             diagnostic = "$ " + " ".join(command) + "\n" + completed.stdout + completed.stderr
             outcome = OUTCOMES.get(completed.returncode, "infrastructure/error")
-            stage = "L3 validation" if completed.returncode in OUTCOMES else "L3 validation invocation"
-            if outcome == "passed" and args.run_l4:
-                l4_command = [args.bash, args.validator, "--level", "4", "--sample-dir", args.sample_path]
-                l4 = subprocess.run(l4_command, capture_output=True, text=True)
-                diagnostic += "\n$ " + " ".join(l4_command) + "\n" + l4.stdout + l4.stderr
-                outcome = OUTCOMES.get(l4.returncode, "infrastructure/error")
-                stage = "L4 validation" if l4.returncode in OUTCOMES else "L4 validation invocation"
+            stage = (
+                "build readiness validation"
+                if completed.returncode in OUTCOMES
+                else "build readiness invocation"
+            )
+            if outcome == "passed" and args.run_live_service:
+                live_service_command = [
+                    args.bash,
+                    args.validator,
+                    "--mode",
+                    "live-service",
+                    "--sample-dir",
+                    args.sample_path,
+                ]
+                live_service = subprocess.run(
+                    live_service_command, capture_output=True, text=True
+                )
+                diagnostic += (
+                    "\n$ "
+                    + " ".join(live_service_command)
+                    + "\n"
+                    + live_service.stdout
+                    + live_service.stderr
+                )
+                outcome = OUTCOMES.get(
+                    live_service.returncode, "infrastructure/error"
+                )
+                stage = (
+                    "live-service validation"
+                    if live_service.returncode in OUTCOMES
+                    else "live-service validation invocation"
+                )
         except (OSError, subprocess.SubprocessError) as exc:
             diagnostic = "$ " + " ".join(command) + f"\nrunner error: {exc}\n"
             outcome = "infrastructure/error"
-            stage = "L3 validation invocation"
+            stage = "build readiness invocation"
 
     completed_at = utc_now()
     result = {
-        "schema_version": 1,
+        "schema_version": 2,
         "sample": {
             "id": args.sample_id,
             "path": args.sample_path,

--- a/.github/scripts/test/fixtures/l4-cold/sample.yaml
+++ b/.github/scripts/test/fixtures/l4-cold/sample.yaml
@@ -1,4 +1,0 @@
-name: l4-cold
-description: Hermetic L4 fixture proving the validator preserves cold-cadence semantics.
-l4:
-  command: 'test "$SKIP_PROVISION" = "false"'

--- a/.github/scripts/test/fixtures/l4-fail/sample.yaml
+++ b/.github/scripts/test/fixtures/l4-fail/sample.yaml
@@ -1,4 +1,0 @@
-name: l4-fail
-description: Hermetic L4 fixture whose sample assertion explicitly reports failure.
-l4:
-  command: "echo 'sample assertion failed'; exit 1"

--- a/.github/scripts/test/fixtures/l4-good/sample.yaml
+++ b/.github/scripts/test/fixtures/l4-good/sample.yaml
@@ -1,6 +1,0 @@
-name: l4-good
-description: Hermetic L4 fixture proving caller environment and SKIP_PROVISION are inherited.
-l4:
-  command: 'test "$L4_TEST_ENDPOINT" = "https://stub.invalid" && test "$SKIP_PROVISION" = "true"'
-  required_env:
-    - L4_TEST_ENDPOINT

--- a/.github/scripts/test/fixtures/l4-infra/sample.yaml
+++ b/.github/scripts/test/fixtures/l4-infra/sample.yaml
@@ -1,4 +1,0 @@
-name: l4-infra
-description: Hermetic L4 fixture whose command normalizes known caller infrastructure failure.
-l4:
-  command: "echo 'known caller infrastructure failure' >&2; exit 2"

--- a/.github/scripts/test/fixtures/l4-invalid-env/sample.yaml
+++ b/.github/scripts/test/fixtures/l4-invalid-env/sample.yaml
@@ -1,5 +1,0 @@
-name: l4-invalid-env
-description: Hermetic L4 fixture whose required_env field is not a string list.
-l4:
-  command: "true"
-  required_env: L4_TEST_ENDPOINT

--- a/.github/scripts/test/fixtures/l4-invalid/sample.yaml
+++ b/.github/scripts/test/fixtures/l4-invalid/sample.yaml
@@ -1,3 +1,0 @@
-name: l4-invalid
-description: Hermetic L4 fixture with an invalid scalar declaration.
-l4: "true"

--- a/.github/scripts/test/fixtures/l4-malformed/sample.yaml
+++ b/.github/scripts/test/fixtures/l4-malformed/sample.yaml
@@ -1,3 +1,0 @@
-name: l4-malformed
-l4:
-  command: "unterminated

--- a/.github/scripts/test/fixtures/l4-missing-command/sample.yaml
+++ b/.github/scripts/test/fixtures/l4-missing-command/sample.yaml
@@ -1,4 +1,0 @@
-name: l4-missing-command
-description: Hermetic L4 fixture with a mapping that omits the required command.
-l4:
-  required_env: []

--- a/.github/scripts/test/fixtures/l4-unexpected/sample.yaml
+++ b/.github/scripts/test/fixtures/l4-unexpected/sample.yaml
@@ -1,4 +1,0 @@
-name: l4-unexpected
-description: Unexpected nonzero L4 statuses conservatively classify as sample failure.
-l4:
-  command: "echo 'unexpected sample command status' >&2; exit 7"

--- a/.github/scripts/test/fixtures/legacy-l4/sample.yaml
+++ b/.github/scripts/test/fixtures/legacy-l4/sample.yaml
@@ -1,0 +1,4 @@
+name: legacy-l4
+description: Legacy metadata must fail with an actionable migration message.
+l4:
+  command: "true"

--- a/.github/scripts/test/fixtures/live-service-cold/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-cold/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-cold
+description: Hermetic live-service fixture proving the validator preserves cold-cadence semantics.
+live_service_validation:
+  command: 'test "$SKIP_PROVISION" = "false"'

--- a/.github/scripts/test/fixtures/live-service-fail/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-fail/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-fail
+description: Hermetic live-service fixture whose sample assertion explicitly reports failure.
+live_service_validation:
+  command: "echo 'sample assertion failed'; exit 1"

--- a/.github/scripts/test/fixtures/live-service-good/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-good/sample.yaml
@@ -1,0 +1,6 @@
+name: live-service-good
+description: Hermetic live-service fixture proving caller environment and SKIP_PROVISION are inherited.
+live_service_validation:
+  command: 'test "$LIVE_SERVICE_TEST_ENDPOINT" = "https://stub.invalid" && test "$SKIP_PROVISION" = "true"'
+  required_env:
+    - LIVE_SERVICE_TEST_ENDPOINT

--- a/.github/scripts/test/fixtures/live-service-infra/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-infra/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-infra
+description: Hermetic live-service fixture whose command normalizes known caller infrastructure failure.
+live_service_validation:
+  command: "echo 'known caller infrastructure failure' >&2; exit 2"

--- a/.github/scripts/test/fixtures/live-service-invalid-env/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-invalid-env/sample.yaml
@@ -1,0 +1,5 @@
+name: live-service-invalid-env
+description: Hermetic live-service fixture whose required_env field is not a string list.
+live_service_validation:
+  command: "true"
+  required_env: LIVE_SERVICE_TEST_ENDPOINT

--- a/.github/scripts/test/fixtures/live-service-invalid/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-invalid/sample.yaml
@@ -1,0 +1,3 @@
+name: live-service-invalid
+description: Hermetic live-service fixture with an invalid scalar declaration.
+live_service_validation: "true"

--- a/.github/scripts/test/fixtures/live-service-malformed/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-malformed/sample.yaml
@@ -1,0 +1,3 @@
+name: live-service-malformed
+live_service_validation:
+  command: "unterminated

--- a/.github/scripts/test/fixtures/live-service-missing-command/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-missing-command/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-missing-command
+description: Hermetic live-service fixture with a mapping that omits the required command.
+live_service_validation:
+  required_env: []

--- a/.github/scripts/test/fixtures/live-service-transport-like/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-transport-like/sample.yaml
@@ -1,4 +1,4 @@
-name: l4-transport-like
+name: live-service-transport-like
 description: Transport-like application output must not override an explicit sample failure.
-l4:
+live_service_validation:
   command: "echo '503 Service Unavailable: sample response assertion failed' >&2; exit 1"

--- a/.github/scripts/test/fixtures/live-service-unexpected/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-unexpected/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-unexpected
+description: Unexpected nonzero live-service statuses conservatively classify as sample failure.
+live_service_validation:
+  command: "echo 'unexpected sample command status' >&2; exit 7"

--- a/.github/scripts/test/run-tests.sh
+++ b/.github/scripts/test/run-tests.sh
@@ -9,7 +9,7 @@
 #
 # Plus, toolchain-free proofs:
 #   - shared run_sample_yaml path: sample.yaml validate:true => pass, :false => fail (needs yq)
-#   - L4 contract: declared pass/fail/error, required environment, and undeclared no-op
+#   - live-service contract: declared pass/fail/error, required environment, and undeclared no-op
 #   - guardrails: unknown language, missing --sample-dir, missing --language => error
 #   - --results-dir plumbing lands each sample path in passed/failed/errored.txt
 #
@@ -93,8 +93,8 @@ check() {
     fi
 }
 
-# check_l4 <desc> <expected_exit> <expected_verdict> <expected_declared> -- <command...>
-check_l4() {
+# check_live_service <desc> <expected_exit> <expected_verdict> <expected_declared> -- <command...>
+check_live_service() {
     local desc="$1" exp_code="$2" exp_verdict="$3" exp_declared="$4"
     shift 4
     [ "$1" = "--" ] && shift
@@ -102,12 +102,12 @@ check_l4() {
     out="$("$@" 2>&1)"
     code=$?
     verdict="$(printf '%s\n' "$out" | sed -n 's/^verdict=\(pass\|fail\|error\)$/\1/p' | tail -1)"
-    declared="$(printf '%s\n' "$out" | sed -n 's/^l4_declared=\(true\|false\)$/\1/p' | tail -1)"
+    declared="$(printf '%s\n' "$out" | sed -n 's/^live_service_validation_declared=\(true\|false\)$/\1/p' | tail -1)"
     if [ "$code" = "$exp_code" ] && [ "$verdict" = "$exp_verdict" ] && [ "$declared" = "$exp_declared" ]; then
-        echo "  PASS  $desc  (exit=$code verdict=$verdict l4_declared=$declared)"
+        echo "  PASS  $desc  (exit=$code verdict=$verdict live_service_validation_declared=$declared)"
         PASS_N=$((PASS_N + 1))
     else
-        echo "  FAIL  $desc  expected exit=$exp_code verdict=$exp_verdict l4_declared=$exp_declared, got exit=$code verdict=${verdict:-<none>} l4_declared=${declared:-<none>}"
+        echo "  FAIL  $desc  expected exit=$exp_code verdict=$exp_verdict live_service_validation_declared=$exp_declared, got exit=$code verdict=${verdict:-<none>} live_service_validation_declared=${declared:-<none>}"
         printf '%s\n' "$out" | sed 's/^/        | /'
         FAIL_N=$((FAIL_N + 1))
     fi
@@ -174,43 +174,45 @@ fi
 
 echo ""
 echo "=============================================================="
-echo " Per-sample L4 declaration contract (toolchain-free; needs yq)"
+echo " Per-sample live-service declaration contract (toolchain-free; needs yq)"
 echo "=============================================================="
 if [ "$YQ_OK" = true ]; then
-    check_l4 "L4 declared command + inherited env -> pass" 0 pass true -- \
-        env "GITHUB_OUTPUT=$OUTPUTS" "SKIP_PROVISION=true" "L4_TEST_ENDPOINT=https://stub.invalid" \
-            bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-good" --results-dir "$RESULTS"
-    check_l4 "L4 cold caller keeps SKIP_PROVISION=false -> pass" 0 pass true -- \
+    check_live_service "live-service declared command + inherited env -> pass" 0 pass true -- \
+        env "GITHUB_OUTPUT=$OUTPUTS" "SKIP_PROVISION=true" "LIVE_SERVICE_TEST_ENDPOINT=https://stub.invalid" \
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-good" --results-dir "$RESULTS"
+    check_live_service "live-service cold caller keeps SKIP_PROVISION=false -> pass" 0 pass true -- \
         env "SKIP_PROVISION=false" \
-            bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-cold" --results-dir "$RESULTS"
-    check_l4 "L4 undeclared -> clean no-op" 0 pass false -- \
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-cold" --results-dir "$RESULTS"
+    check_live_service "live-service undeclared -> clean no-op" 0 pass false -- \
         env "GITHUB_OUTPUT=$OUTPUTS" \
-            bash "$SCRIPT" --level 4 --sample-dir "$FIX/csharp-yaml-good" --results-dir "$RESULTS"
-    check_l4 "L4 explicit exit 1 -> fail" 1 fail true -- \
-        env "SKIP_PROVISION=true" bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-fail" --results-dir "$RESULTS"
-    check_l4 "L4 explicit exit 2 -> error" 2 error true -- \
-        env "SKIP_PROVISION=true" bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-infra" --results-dir "$RESULTS"
-    check_l4 "L4 exit 1 with transport-like text -> fail" 1 fail true -- \
-        env "SKIP_PROVISION=true" bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-transport-like" --results-dir "$RESULTS"
-    check_l4 "L4 unexpected exit 7 -> fail" 1 fail true -- \
-        env "SKIP_PROVISION=true" bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-unexpected" --results-dir "$RESULTS"
-    check_l4 "L4 missing required env -> error" 2 error true -- \
-        env -u L4_TEST_ENDPOINT "SKIP_PROVISION=true" \
-            bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-good" --results-dir "$RESULTS"
-    check_l4 "L4 missing SKIP_PROVISION -> error" 2 error true -- \
-        env -u SKIP_PROVISION "L4_TEST_ENDPOINT=https://stub.invalid" \
-            bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-good" --results-dir "$RESULTS"
-    check_l4 "L4 invalid declaration shape -> error" 2 error true -- \
-        env "SKIP_PROVISION=true" bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-invalid" --results-dir "$RESULTS"
-    check_l4 "L4 missing command -> error" 2 error true -- \
-        env "SKIP_PROVISION=true" bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-missing-command" --results-dir "$RESULTS"
-    check_l4 "L4 invalid required_env -> error" 2 error true -- \
-        env "SKIP_PROVISION=true" bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-invalid-env" --results-dir "$RESULTS"
-    check "L4 malformed sample.yaml -> error" 2 error -- \
-        env "SKIP_PROVISION=true" bash "$SCRIPT" --level 4 --sample-dir "$FIX/l4-malformed" --results-dir "$RESULTS"
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/csharp-yaml-good" --results-dir "$RESULTS"
+    check_live_service "live-service explicit exit 1 -> fail" 1 fail true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-fail" --results-dir "$RESULTS"
+    check_live_service "live-service explicit exit 2 -> error" 2 error true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-infra" --results-dir "$RESULTS"
+    check_live_service "live-service exit 1 with transport-like text -> fail" 1 fail true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-transport-like" --results-dir "$RESULTS"
+    check_live_service "live-service unexpected exit 7 -> fail" 1 fail true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-unexpected" --results-dir "$RESULTS"
+    check_live_service "live-service missing required env -> error" 2 error true -- \
+        env -u LIVE_SERVICE_TEST_ENDPOINT "SKIP_PROVISION=true" \
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-good" --results-dir "$RESULTS"
+    check_live_service "live-service missing SKIP_PROVISION -> error" 2 error true -- \
+        env -u SKIP_PROVISION "LIVE_SERVICE_TEST_ENDPOINT=https://stub.invalid" \
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-good" --results-dir "$RESULTS"
+    check_live_service "live-service invalid declaration shape -> error" 2 error true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-invalid" --results-dir "$RESULTS"
+    check_live_service "live-service missing command -> error" 2 error true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-missing-command" --results-dir "$RESULTS"
+    check_live_service "live-service invalid required_env -> error" 2 error true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-invalid-env" --results-dir "$RESULTS"
+    check "live-service malformed sample.yaml -> error" 2 error -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-malformed" --results-dir "$RESULTS"
+    check "legacy l4 declaration -> actionable error" 2 error -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/legacy-l4" --results-dir "$RESULTS"
 else
-    echo "  SKIP  L4 contract cases — yq unavailable (BLOCKED-on-env)"
-    SKIP_N=$((SKIP_N + 13))
+    echo "  SKIP  live-service contract cases — yq unavailable (BLOCKED-on-env)"
+    SKIP_N=$((SKIP_N + 14))
 fi
 
 echo ""
@@ -220,9 +222,9 @@ echo "=============================================================="
 check "unknown language -> error"   2 error -- bash "$SCRIPT" --language rust   --sample-dir "$FIX/csharp-good"
 check "missing sample-dir -> error" 2 error -- bash "$SCRIPT" --language csharp --sample-dir "$FIX/does-not-exist"
 check "missing --language -> error" 2 error -- bash "$SCRIPT" --sample-dir "$FIX/csharp-good"
-check "unknown --level -> error" 2 error -- bash "$SCRIPT" --level 5 --sample-dir "$FIX/csharp-good"
-check_l4 "L4 absent sample.yaml -> no-op without yq" 0 pass false -- \
-    env "PATH=$SCRUB_BIN" "$BASH_BIN" "$SCRIPT" --level 4 --sample-dir "$FIX/csharp-good"
+check "unknown --mode -> error" 2 error -- bash "$SCRIPT" --mode unknown --sample-dir "$FIX/csharp-good"
+check_live_service "live-service absent sample.yaml -> no-op without yq" 0 pass false -- \
+    env "PATH=$SCRUB_BIN" "$BASH_BIN" "$SCRIPT" --mode live-service --sample-dir "$FIX/csharp-good"
 
 echo ""
 echo "=============================================================="
@@ -234,16 +236,16 @@ assert_file_has "$RESULTS/errored.txt" "$FIX/csharp-good"
 if [ "$YQ_OK" = true ]; then
     # The yq sample.yaml cases above already appended to passed/failed.txt.
     assert_file_has "$RESULTS/passed.txt" "$FIX/csharp-yaml-good"
-    assert_file_has "$RESULTS/passed.txt" "$FIX/l4-good"
-    assert_file_has "$RESULTS/passed.txt" "$FIX/l4-cold"
-    assert_file_has "$RESULTS/failed.txt" "$FIX/l4-fail"
-    assert_file_has "$RESULTS/errored.txt" "$FIX/l4-infra"
-    assert_file_has "$RESULTS/errored.txt" "$FIX/l4-malformed"
-    assert_file_has "$RESULTS/failed.txt" "$FIX/l4-transport-like"
-    assert_file_has "$RESULTS/failed.txt" "$FIX/l4-unexpected"
+    assert_file_has "$RESULTS/passed.txt" "$FIX/live-service-good"
+    assert_file_has "$RESULTS/passed.txt" "$FIX/live-service-cold"
+    assert_file_has "$RESULTS/failed.txt" "$FIX/live-service-fail"
+    assert_file_has "$RESULTS/errored.txt" "$FIX/live-service-infra"
+    assert_file_has "$RESULTS/errored.txt" "$FIX/live-service-malformed"
+    assert_file_has "$RESULTS/failed.txt" "$FIX/live-service-transport-like"
+    assert_file_has "$RESULTS/failed.txt" "$FIX/live-service-unexpected"
     assert_file_has "$RESULTS/failed.txt" "$FIX/csharp-yaml-broken"
-    assert_file_has "$OUTPUTS" "l4_declared=true"
-    assert_file_has "$OUTPUTS" "l4_declared=false"
+    assert_file_has "$OUTPUTS" "live_service_validation_declared=true"
+    assert_file_has "$OUTPUTS" "live_service_validation_declared=false"
 fi
 
 echo ""

--- a/.github/scripts/test/run-workflow-structure-tests.sh
+++ b/.github/scripts/test/run-workflow-structure-tests.sh
@@ -2,7 +2,7 @@
 # Structural regression gate for the single required `trusted` job.
 #
 # Root cause pinned here: a job-level `if:` skip concludes `skipped`, and GitHub treats a
-# skipped required check as satisfied. The job must run and fail forks explicitly after L3.
+# skipped required check as satisfied. The job must run and fail forks explicitly after build readiness.
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -97,7 +97,7 @@ expect_count "exactly one trusted job exists" '^  trusted:$' 1
 expect_count "trusted has exactly one job-level condition" '^    if:' 1 "$TMP/trusted-job.yml"
 expect_count "trusted job runs after dependency failure unless cancelled" '^    if: \$\{\{ !cancelled\(\) \}\}$' 1 "$TMP/trusted-job.yml"
 expect_not_has "trusted job has no matrix" '^    (strategy:|matrix:)' "$TRUSTED"
-expect_has "trusted job keeps L4-validation environment" '^    environment: L4-validation$' "$TRUSTED"
+expect_has "trusted job keeps legacy L4-validation environment" '^    environment: L4-validation$' "$TRUSTED"
 expect_not_has "job-level fork skip is absent" 'head\.repo\.fork != true' "$TMP/trusted-job.yml"
 expect_not_has "job-level draft skip is absent" 'pull_request\.draft' "$TMP/trusted-job.yml"
 
@@ -164,23 +164,23 @@ run_contract_case "count mismatch fails closed" 1 success true 2 '["samples/pyth
 extract_step "Short-circuit docs-only PRs before secrets" "$TMP/docs-only.yml"
 expect_has "docs-only success is same-repo guarded" 'head\.repo\.fork != true' "$TMP/docs-only.yml"
 
-extract_step "Validate changed samples to L3 (in-job parallel)" "$TMP/l3.yml"
+extract_step "Validate changed sample build readiness (in-job parallel)" "$TMP/build-readiness.yml"
 extract_step "Reject fork until maintainer promotion" "$TMP/fork-reject.yml"
 expect_has "fork rejection is fork-only" 'head\.repo\.fork == true' "$TMP/fork-reject.yml"
-expect_has "fork rejection runs after an L3 failure" '!cancelled\(\)' "$TMP/fork-reject.yml"
+expect_has "fork rejection runs after a readiness failure" '!cancelled\(\)' "$TMP/fork-reject.yml"
 expect_has "fork rejection checks OIDC request surface" 'ACTIONS_ID_TOKEN_REQUEST_(URL|TOKEN)' "$TMP/fork-reject.yml"
 expect_has "fork rejection emits promotion error" '::error::.*promot' "$TMP/fork-reject.yml"
 expect_has "fork rejection exits non-zero" '^[[:space:]]*exit 1$' "$TMP/fork-reject.yml"
 
-l3_line="$(grep -nF -- '- name: Validate changed samples to L3 (in-job parallel)' "$TRUSTED" | cut -d: -f1)"
+readiness_line="$(grep -nF -- '- name: Validate changed sample build readiness (in-job parallel)' "$TRUSTED" | cut -d: -f1)"
 fork_line="$(grep -nF -- '- name: Reject fork until maintainer promotion' "$TRUSTED" | cut -d: -f1)"
-if [ -n "$l3_line" ] && [ -n "$fork_line" ] && [ "$l3_line" -lt "$fork_line" ]; then
-    pass "credential-free L3 runs before fork rejection"
+if [ -n "$readiness_line" ] && [ -n "$fork_line" ] && [ "$readiness_line" -lt "$fork_line" ]; then
+    pass "credential-free build readiness runs before fork rejection"
 else
-    fail "credential-free L3 must run before fork rejection"
+    fail "credential-free build readiness must run before fork rejection"
 fi
 
-# Any step containing a current credential/L4 marker must carry an explicit same-repo guard.
+# Any step containing a current credential/live-service marker must carry an explicit same-repo guard.
 if awk '
     function flush() {
         if (active && credentialed && !same_repo) {
@@ -195,7 +195,7 @@ if awk '
         credentialed=0
         same_repo=0
     }
-    active && /azure\/login|vars\.AZURE_|az account|get-access-token|L4 smoke/ {
+    active && /azure\/login|vars\.AZURE_|az account|get-access-token|Live-service smoke/ {
         credentialed=1
     }
     active && /head\.repo\.fork != true/ {
@@ -206,9 +206,9 @@ if awk '
         exit bad
     }
 ' "$TRUSTED"; then
-    pass "every credentialed/L4 step has a same-repo guard"
+    pass "every credentialed/live-service step has a same-repo guard"
 else
-    fail "every credentialed/L4 step must have a same-repo guard"
+    fail "every credentialed/live-service step must have a same-repo guard"
 fi
 
 extract_step "Trusted verdict" "$TMP/verdict.yml"

--- a/.github/scripts/test/test-render-validation-report.py
+++ b/.github/scripts/test/test-render-validation-report.py
@@ -24,7 +24,7 @@ class ReportTests(unittest.TestCase):
         self.expected.write_text(
             json.dumps(
                 {
-                    "schema_version": 1,
+                    "schema_version": 2,
                     "samples": [
                         {"id": "a", "path": SAMPLE_A, "language": "python", "shape": "quickstart"},
                         {"id": "b", "path": SAMPLE_B, "language": "csharp", "shape": "quickstart"},
@@ -61,6 +61,7 @@ class ReportTests(unittest.TestCase):
         sample: str,
         outcome: str = "passed",
         diagnostic_text: str = "diagnostic\n",
+        completed_stage: str = "build readiness validation",
     ) -> None:
         manifest = json.loads(self.expected.read_text(encoding="utf-8"))
         sample_definition = next(
@@ -73,10 +74,10 @@ class ReportTests(unittest.TestCase):
         (sample_dir / "sample-result.json").write_text(
             json.dumps(
                 {
-                    "schema_version": 1,
+                    "schema_version": manifest["schema_version"],
                     "sample": sample_definition,
                     "outcome": outcome,
-                    "completed_stage": "L3 validation",
+                    "completed_stage": completed_stage,
                     "duration_seconds": 12.5,
                     "diagnostic_reference": "diagnostics.log",
                     "artifact_reference": f"validation-pilot-{sample_id}",
@@ -146,6 +147,20 @@ class ReportTests(unittest.TestCase):
         body = self.output.read_text(encoding="utf-8")
         self.assertIn("expected result artifact is missing", body)
         self.assertIn("⚠️ Infrastructure/error", body)
+
+    def test_schema_one_stage_names_are_normalized_for_historical_artifacts(self) -> None:
+        manifest = json.loads(self.expected.read_text(encoding="utf-8"))
+        manifest["schema_version"] = 1
+        self.expected.write_text(json.dumps(manifest), encoding="utf-8")
+        self.write_result(SAMPLE_A, completed_stage="L3 validation")
+        self.write_result(SAMPLE_B, completed_stage="L4 validation")
+        completed = self.run_report()
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        body = self.output.read_text(encoding="utf-8")
+        self.assertIn("build readiness validation", body)
+        self.assertIn("live-service validation", body)
+        self.assertNotIn("L3 validation", body)
+        self.assertNotIn("L4 validation", body)
 
     def test_malformed_artifact_publishes_error_row_and_fails(self) -> None:
         bad = self.results / "bad"

--- a/.github/scripts/test/test_validation_pilot.py
+++ b/.github/scripts/test/test_validation_pilot.py
@@ -36,8 +36,8 @@ class ValidationPilotTests(unittest.TestCase):
             root = Path(directory)
             manifest = root / "manifest.json"
             matrix = root / "matrix.json"
-            l3_matrix = root / "l3-matrix.json"
-            l4_matrix = root / "l4-matrix.json"
+            build_readiness_matrix = root / "build-readiness-matrix.json"
+            live_service_matrix = root / "live-service-matrix.json"
             completed = subprocess.run(
                 [
                     sys.executable,
@@ -48,17 +48,17 @@ class ValidationPilotTests(unittest.TestCase):
                     str(manifest),
                     "--matrix",
                     str(matrix),
-                    "--l3-matrix",
-                    str(l3_matrix),
-                    "--l4-matrix",
-                    str(l4_matrix),
+                    "--build-readiness-matrix",
+                    str(build_readiness_matrix),
+                    "--live-service-matrix",
+                    str(live_service_matrix),
                 ],
                 capture_output=True,
                 text=True,
             )
             self.assertEqual(completed.returncode, 0, completed.stderr)
             payload = json.loads(manifest.read_text(encoding="utf-8"))
-            self.assertEqual(payload["schema_version"], 1)
+            self.assertEqual(payload["schema_version"], 2)
             sample_metadata = list((ROOT.parent / "samples").glob("**/sample.yaml"))
             expected_unsupported = sum(
                 path.relative_to(ROOT.parent / "samples").parts[0]
@@ -75,13 +75,15 @@ class ValidationPilotTests(unittest.TestCase):
                 {"csharp", "java", "python", "typescript"},
             )
             self.assertTrue(all(sample["shape"] == "full-fleet" for sample in payload["samples"]))
-            declared_l4_paths = {
+            declared_live_service_paths = {
                 sample["path"]
                 for sample in payload["samples"]
-                if payload["validation"][sample["id"]]["l4_declared"]
+                if payload["validation"][sample["id"]][
+                    "live_service_validation_declared"
+                ]
             }
             self.assertEqual(
-                declared_l4_paths,
+                declared_live_service_paths,
                 {
                     "samples/csharp/quickstart/responses",
                     "samples/python/quickstart/responses",
@@ -91,18 +93,34 @@ class ValidationPilotTests(unittest.TestCase):
                 {**sample, **payload["validation"][sample["id"]]} for sample in payload["samples"]
             ])
             self.assertTrue(
-                all(not sample["l4_declared"] for sample in json.loads(l3_matrix.read_text())["include"])
+                all(
+                    not sample["live_service_validation_declared"]
+                    for sample in json.loads(
+                        build_readiness_matrix.read_text()
+                    )["include"]
+                )
             )
             self.assertEqual(
-                {sample["path"] for sample in json.loads(l4_matrix.read_text())["include"]},
-                declared_l4_paths,
+                {
+                    sample["path"]
+                    for sample in json.loads(live_service_matrix.read_text())[
+                        "include"
+                    ]
+                },
+                declared_live_service_paths,
             )
 
-    def test_workflow_isolates_declared_l4_warm_project_jobs(self) -> None:
+    def test_workflow_isolates_declared_live_service_warm_project_jobs(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertEqual(workflow.count("environment: L4-validation"), 1)
-        self.assertIn("matrix: ${{ fromJSON(needs.discover.outputs.l3_matrix) }}", workflow)
-        self.assertIn("matrix: ${{ fromJSON(needs.discover.outputs.l4_matrix) }}", workflow)
+        self.assertIn(
+            "matrix: ${{ fromJSON(needs.discover.outputs.build_readiness_matrix) }}",
+            workflow,
+        )
+        self.assertIn(
+            "matrix: ${{ fromJSON(needs.discover.outputs.live_service_matrix) }}",
+            workflow,
+        )
         self.assertIn(
             "AZURE_AI_PROJECT_ENDPOINT: ${{ vars.AZURE_AI_PROJECT_ENDPOINT }}",
             workflow,
@@ -113,6 +131,69 @@ class ValidationPilotTests(unittest.TestCase):
         )
         self.assertIn('SKIP_PROVISION: "true"', workflow)
         self.assertIn('python -m pip install -r "${{ matrix.path }}/requirements.txt"', workflow)
+
+    def test_discovery_rejects_legacy_l4_metadata_with_migration_message(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sample = root / "samples" / "python" / "legacy"
+            sample.mkdir(parents=True)
+            (sample / "sample.yaml").write_text(
+                "name: legacy\nl4:\n  command: \"true\"\n",
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(DISCOVERY),
+                    "--root",
+                    str(root),
+                    "--manifest",
+                    str(root / "manifest.json"),
+                    "--matrix",
+                    str(root / "matrix.json"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn(
+                "rename it to 'live_service_validation'", completed.stderr
+            )
+
+    def test_discovery_recognizes_indented_live_service_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sample = root / "samples" / "python" / "indented"
+            sample.mkdir(parents=True)
+            (sample / "sample.yaml").write_text(
+                "  name: indented\n"
+                "  live_service_validation:\n"
+                "    command: \"true\"\n",
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(DISCOVERY),
+                    "--root",
+                    str(root),
+                    "--manifest",
+                    str(root / "manifest.json"),
+                    "--matrix",
+                    str(root / "matrix.json"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            manifest = json.loads(
+                (root / "manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertTrue(
+                manifest["validation"]["python-indented"][
+                    "live_service_validation_declared"
+                ]
+            )
 
     def test_sample_failure_is_a_complete_valid_result(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -148,7 +229,7 @@ class ValidationPilotTests(unittest.TestCase):
             self.assertEqual(completed.returncode, 0, completed.stderr)
             result = json.loads(output.read_text(encoding="utf-8"))
             self.assertEqual(result["outcome"], "sample failure")
-            self.assertEqual(result["completed_stage"], "L3 validation")
+            self.assertEqual(result["completed_stage"], "build readiness validation")
             self.assertTrue(diagnostic.is_file())
 
     def test_completeness_rejects_missing_matrix_member(self) -> None:
@@ -158,7 +239,7 @@ class ValidationPilotTests(unittest.TestCase):
             manifest.write_text(
                 json.dumps(
                     {
-                        "schema_version": 1,
+                        "schema_version": 2,
                         "samples": [
                             {"id": "one", "path": "samples/python/one", "language": "python", "shape": "fixture"},
                             {"id": "two", "path": "samples/java/two", "language": "java", "shape": "fixture"},
@@ -173,10 +254,10 @@ class ValidationPilotTests(unittest.TestCase):
             (artifacts / "sample-result.json").write_text(
                 json.dumps(
                     {
-                        "schema_version": 1,
+                        "schema_version": 2,
                         "sample": {"id": "one", "path": "samples/python/one", "language": "python", "shape": "fixture"},
                         "outcome": "passed",
-                        "completed_stage": "L3 validation",
+                        "completed_stage": "build readiness validation",
                         "duration_seconds": 1,
                         "diagnostic_reference": "diagnostics.log",
                         "artifact_reference": "sample-result.json",
@@ -200,6 +281,61 @@ class ValidationPilotTests(unittest.TestCase):
             )
             self.assertNotEqual(completed.returncode, 0)
             self.assertIn("missing result artifacts: two", completed.stderr)
+
+    def test_completeness_accepts_historical_schema_one_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            sample = {
+                "id": "one",
+                "path": "samples/python/one",
+                "language": "python",
+                "shape": "fixture",
+            }
+            manifest = root / "manifest.json"
+            manifest.write_text(
+                json.dumps({"schema_version": 1, "samples": [sample]}),
+                encoding="utf-8",
+            )
+            artifact = root / "artifacts" / "validation-pilot-one"
+            artifact.mkdir(parents=True)
+            (artifact / "diagnostics.log").write_text(
+                "diagnostic\n", encoding="utf-8"
+            )
+            (artifact / "sample-result.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "sample": sample,
+                        "outcome": "passed",
+                        "completed_stage": "L3 validation",
+                        "duration_seconds": 1,
+                        "diagnostic_reference": "diagnostics.log",
+                        "artifact_reference": "sample-result.json",
+                        "completed_at": "2026-08-10T00:00:00Z",
+                        "run": {"run_id": "1"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(COMPLETENESS),
+                    "--manifest",
+                    str(manifest),
+                    "--artifacts",
+                    str(root / "artifacts"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            summary = json.loads(
+                (root / "artifacts" / "run-summary.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertEqual(summary["schema_version"], 1)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/validate-sample.README.md
+++ b/.github/scripts/validate-sample.README.md
@@ -1,45 +1,46 @@
 # Per-sample validation contract
 
-`.github/scripts/validate-sample.sh` validates one sample at either L3 (load/build)
-or L4 (credentialed execution). The default remains L3, so existing callers do not
-need to change.
+`.github/scripts/validate-sample.sh` validates one sample for either build readiness
+or live-service behavior. Build readiness is the default.
 
 ## CLI
 
 ```bash
-# Existing L3 behavior
+# Build readiness (default)
 bash .github/scripts/validate-sample.sh \
   --language python \
   --sample-dir samples/python/quickstart/responses
 
-# Opt-in L4 behavior
+# Opt-in live-service validation
 SKIP_PROVISION=true bash .github/scripts/validate-sample.sh \
-  --level 4 \
+  --mode live-service \
   --sample-dir samples/python/quickstart/responses
 ```
 
-These commands invoke individual validation levels; calling `--level 4` directly
-does not implicitly run L3 first. The repository validation pilot provides the
-end-to-end sequence: every supported sample runs L3, and a sample with an `l4`
-declaration proceeds to L4 only after its L3 check passes. Declaring L4 therefore
-does not opt a sample out of L3.
+These commands invoke individual validation modes; calling `--mode live-service`
+directly does not implicitly run build readiness first. The repository validation
+pilot provides the end-to-end sequence: every supported sample runs build readiness,
+and a sample with a `live_service_validation` declaration proceeds to live-service
+validation only after readiness passes. Declaring live-service validation therefore
+does not opt a sample out of build readiness.
 
 Both modes use the same exit and verdict contract:
 
 | Exit | Verdict | Meaning |
 |---|---|---|
-| `0` | `pass` | The requested check passed. In L4 mode, no declaration is also a clean no-op. |
+| `0` | `pass` | The requested check passed. In live-service mode, no declaration is also a clean no-op. |
 | `1` | `fail` | The sample command/assertion failed. |
-| `2` | `error` | The validator precondition or caller environment is invalid, or an L4 command explicitly reported caller/cloud infrastructure failure. |
+| `2` | `error` | The validator precondition or caller environment is invalid, or a live-service command explicitly reported caller/cloud infrastructure failure. |
 
 See `CLASSIFICATION.md` for the authoritative failure-versus-error rules.
 
-## `sample.yaml` L4 declaration
+## `sample.yaml` live-service declaration
 
-L4 is opt-in. A sample declares it with a top-level `l4` mapping:
+Live-service validation is opt-in. A sample declares it with a top-level
+`live_service_validation` mapping:
 
 ```yaml
-l4:
+live_service_validation:
   command: >-
     python run_sample.py --assert-response
   required_env:
@@ -49,13 +50,13 @@ l4:
 
 The contract is:
 
-- `l4.command` is a required, non-empty shell string. The validator runs it from
+- `live_service_validation.command` is a required, non-empty shell string. The validator runs it from
   the sample directory with Bash and captures/preserves its output.
 - The command owns a strict three-way result: exit `0` means pass, exit `1`
   means the sample/assertion failed, and exit `2` means a known caller/cloud
   infrastructure failure. Any other nonzero exit is conservatively classified
   as sample failure.
-- The validator never infers L4 infrastructure failure from stdout/stderr text.
+- The validator never infers live-service infrastructure failure from stdout/stderr text.
   A broken sample can legitimately print `503 Service Unavailable`, `Bad
   Gateway`, or similar application responses. If a command can distinguish a
   known credential, endpoint, or cloud transport failure, it must normalize
@@ -65,23 +66,27 @@ The contract is:
   interrupted tests, or usage errors. Wrap those commands so only a known
   caller/cloud infrastructure failure exits `2`; normalize other nonzero
   statuses to `1`.
-- `l4.required_env` is optional. When present, it must be a list of valid
+- `live_service_validation.required_env` is optional. When present, it must be a list of valid
   environment-variable names. Every listed variable must be non-empty or the
   validator returns infrastructure error (`2`) before executing sample code.
 - `SKIP_PROVISION` is a reserved caller input and must be set to exactly `true`
-  or `false` whenever L4 is declared. The validator does not override it:
+  or `false` whenever live-service validation is declared. The validator does not override it:
   trusted PR callers can use the warm project with `true`, while the cold
   cadence can use `false`.
 - Authentication and cloud configuration are caller-owned. The command inherits
   the caller's environment and existing CLI/OIDC login. Do not put credentials,
   secrets, resource provisioning, or production mutations in `sample.yaml`.
-- If `l4` is omitted (or `sample.yaml` itself is absent), `--level 4` exits `0`
+- If `live_service_validation` is omitted (or `sample.yaml` itself is absent),
+  `--mode live-service` exits `0`
   without requiring credentials or `SKIP_PROVISION`. It emits
-  `l4_declared=false`; a declared check emits `l4_declared=true`.
-- If `$GITHUB_OUTPUT` is set, `verdict` and `l4_declared` are appended there.
+  `live_service_validation_declared=false`; a declared check emits
+  `live_service_validation_declared=true`.
+- If `$GITHUB_OUTPUT` is set, `verdict` and `live_service_validation_declared`
+  are appended there.
   `--results-dir` continues to write the sample path to
   `passed.txt`, `failed.txt`, or `errored.txt`.
 
-The validator rejects a scalar `l4`, a missing/non-string/empty `command`, a
-non-list `required_env`, invalid variable names, malformed YAML, and missing
-declared environment inputs as infrastructure errors.
+The validator rejects the legacy `l4` key with a migration message. It also rejects
+a scalar `live_service_validation`, a missing/non-string/empty `command`, a non-list
+`required_env`, invalid variable names, malformed YAML, and missing declared
+environment inputs as infrastructure errors.

--- a/.github/scripts/validate-sample.sh
+++ b/.github/scripts/validate-sample.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# validate-sample.sh — reusable single-sample validator (L3 Load or declared L4 execution).
+# validate-sample.sh — reusable single-sample build-readiness or live-service validator.
 #
 # Ported from .azure-pipelines/validation.yml Stage 2, which duplicated the same
 # per-sample body across five per-language jobs (C#, Python, TypeScript, Java, Go).
@@ -12,28 +12,28 @@
 # This script assumes the required toolchain is already on PATH and reports ERROR if not.
 #
 # Usage:
-#   validate-sample.sh [--level 3] --language <csharp|python|typescript|java|go> \
+#   validate-sample.sh [--mode build-readiness] --language <csharp|python|typescript|java|go> \
 #                      --sample-dir <path> [--results-dir <dir>]
-#   validate-sample.sh --level 4 --sample-dir <path> [--results-dir <dir>]
+#   validate-sample.sh --mode live-service --sample-dir <path> [--results-dir <dir>]
 #
 # Verdict / exit codes — the classifier. This split is load-bearing: downstream lanes
 # and the sync gate trust it, and ERROR must NEVER be treated as a sample failure
 # (that is what protects good samples from being quarantined when our infra breaks).
 #
 #   0  PASS   the requested level passed
-#             (L3 commands/default pass; or L4 command passes/none is declared)
+#             (build-readiness commands/default pass; or live-service command passes/none is declared)
 #   1  FAIL   the SAMPLE is broken
-#             (an L3/L4 sample command exits non-zero; or the language default's
+#             (a build-readiness/live-service sample command exits non-zero; or the language default's
 #              compile/build/py_compile exits non-zero, without positive infra evidence)
 #   2  ERROR  OUR INFRA is sick — page us, do not quarantine
 #             PRECONDITION errors (bad/missing args, unknown language, missing sample dir,
 #             unreadable or malformed sample.yaml, a required toolchain binary missing from
 #             PATH, yq unavailable when a sample.yaml must be read), OR a dedicated `pip install` /
-#             `npm install` failure with positive transport evidence, OR an L4 command that
+#             `npm install` failure with positive transport evidence, OR a live-service command that
 #             explicitly reports caller/cloud infrastructure failure with exit 2.
 #
 # failure-vs-error at runtime (honest v1): the two DEDICATED install steps (`pip install`,
-# `npm install`) are inspected for positive transport evidence. Arbitrary L4 output is NEVER
+# `npm install`) are inspected for positive transport evidence. Arbitrary live-service output is NEVER
 # inferred: its command owns normalization to 0=PASS, 1=FAIL, or 2=ERROR; every other nonzero
 # remains FAIL (bias ambiguous->fail, never fail-open). The merged resolve+compile tools
 # (dotnet build, mvn compile, gradle build, go build, npm run build) are NOT inspected in v1.
@@ -41,7 +41,7 @@
 #
 # Outputs:
 #   - prints `verdict=pass|fail|error` on stdout (also appended to $GITHUB_OUTPUT if set)
-#   - in L4 mode, also prints/appends `l4_declared=true|false`
+#   - in live-service mode, also prints/appends `live_service_validation_declared=true|false`
 #   - if --results-dir is given, appends the sample path to
 #     passed.txt | failed.txt | errored.txt in that directory.
 #
@@ -53,20 +53,20 @@ set -uo pipefail
 LANGUAGE=""
 SAMPLE_DIR=""
 RESULTS_DIR=""
-LEVEL="3"
-L4_DECLARED=""
+MODE="build-readiness"
+LIVE_SERVICE_VALIDATION_DECLARED=""
 SAMPLE_YAML_FAIL_STEP=""
 PYTHON_VENV_DIR=""
 
 usage() {
     cat <<'EOF'
 Usage:
-  validate-sample.sh [--level 3] --language <lang> --sample-dir <path> [--results-dir <dir>]
-  validate-sample.sh --level 4 --sample-dir <path> [--results-dir <dir>]
+  validate-sample.sh [--mode build-readiness] --language <lang> --sample-dir <path> [--results-dir <dir>]
+  validate-sample.sh --mode live-service --sample-dir <path> [--results-dir <dir>]
 
-  --level        Validation level: 3 (default) or 4.
+  --mode         Validation mode: build-readiness (default) or live-service.
   --language     One of: csharp | python | typescript | java | go (frozen set).
-                 Required for L3; optional for L4.
+                 Required for build readiness; optional for live-service validation.
   --sample-dir   Path to the single sample directory to validate.
   --results-dir  Optional. Directory to append passed.txt/failed.txt/errored.txt.
 
@@ -81,13 +81,13 @@ EOF
 emit_verdict() {
     # $1 = pass|fail|error, $2 = exit code
     local verdict="$1" code="$2"
-    if [ "$LEVEL" = "4" ] && [ -n "$L4_DECLARED" ]; then
-        echo "l4_declared=${L4_DECLARED}"
+    if [ "$MODE" = "live-service" ] && [ -n "$LIVE_SERVICE_VALIDATION_DECLARED" ]; then
+        echo "live_service_validation_declared=${LIVE_SERVICE_VALIDATION_DECLARED}"
     fi
     echo "verdict=${verdict}"
     if [ -n "${GITHUB_OUTPUT:-}" ]; then
-        if [ "$LEVEL" = "4" ] && [ -n "$L4_DECLARED" ]; then
-            echo "l4_declared=${L4_DECLARED}" >> "$GITHUB_OUTPUT"
+        if [ "$MODE" = "live-service" ] && [ -n "$LIVE_SERVICE_VALIDATION_DECLARED" ]; then
+            echo "live_service_validation_declared=${LIVE_SERVICE_VALIDATION_DECLARED}" >> "$GITHUB_OUTPUT"
         fi
         echo "verdict=${verdict}" >> "$GITHUB_OUTPUT"
     fi
@@ -137,7 +137,7 @@ ensure_yq() {
 #   - a positive match wins even when pip later prints a generic "No matching distribution"
 #     line (pip emits that AFTER exhausting retries against an unreachable index);
 #   - it is scoped to direct `pip install` and `npm install` logs only;
-#   - arbitrary sample/L4 output MUST NOT be passed here;
+#   - arbitrary sample/live-service output MUST NOT be passed here;
 #   - anything unmatched stays FAIL (bias ambiguous->fail, never fail-open to pass);
 #   - EXPECT maintenance as runner pip/npm versions drift their error strings.
 # The full captured log is printed by the caller before classifying, so diagnosis is preserved.
@@ -194,6 +194,9 @@ run_sample_yaml() {
 
     if ! yq eval '.' "$yaml" >/dev/null 2>&1; then
         error "sample.yaml is unreadable or malformed: $yaml"
+    fi
+    if [ "$(yq eval 'has("l4")' "$yaml" 2>/dev/null)" = "true" ]; then
+        error "legacy sample.yaml key 'l4' is unsupported; rename it to 'live_service_validation'"
     fi
 
     local had_cmd=false cmd cmd_type
@@ -364,20 +367,20 @@ cleanup_python_venv() {
     rm -rf "$PYTHON_VENV_DIR"
 }
 
-# --- Part 3: opt-in L4 execution ---------------------------------------------
+# --- Part 3: opt-in live-service validation ---------------------------------
 # Contract:
-#   l4:
+#   live_service_validation:
 #     command: "<credentialed runtime assertion>"
 #     required_env: [OPTIONAL_ENV_NAME, ...]  # optional
 #
 # The caller owns authentication and configuration. This script never provisions, logs in,
 # or invents defaults: it inherits the caller environment and requires the caller to set
 # SKIP_PROVISION to exactly true or false. A missing declaration is a successful no-op.
-run_l4() {
+run_live_service_validation() {
     local yaml="$SAMPLE_DIR/sample.yaml"
     if [ ! -f "$yaml" ]; then
-        L4_DECLARED=false
-        echo "No sample.yaml L4 declaration; nothing owes L4."
+        LIVE_SERVICE_VALIDATION_DECLARED=false
+        echo "No sample.yaml live-service declaration; nothing owes live-service validation."
         pass
     fi
 
@@ -386,71 +389,74 @@ run_l4() {
         error "sample.yaml is unreadable or malformed: $yaml"
     fi
 
-    if [ "$(yq eval 'has("l4")' "$yaml" 2>/dev/null)" != "true" ]; then
-        L4_DECLARED=false
-        echo "No sample.yaml L4 declaration; nothing owes L4."
+    if [ "$(yq eval 'has("l4")' "$yaml" 2>/dev/null)" = "true" ]; then
+        error "legacy sample.yaml key 'l4' is unsupported; rename it to 'live_service_validation'"
+    fi
+    if [ "$(yq eval 'has("live_service_validation")' "$yaml" 2>/dev/null)" != "true" ]; then
+        LIVE_SERVICE_VALIDATION_DECLARED=false
+        echo "No sample.yaml live-service declaration; nothing owes live-service validation."
         pass
     fi
-    L4_DECLARED=true
+    LIVE_SERVICE_VALIDATION_DECLARED=true
 
-    local l4_kind command_tag cmd
-    l4_kind="$(yq eval '.l4 | kind' "$yaml" 2>/dev/null)" ||
-        error "failed to read sample.yaml l4 declaration: $yaml"
-    [ "$l4_kind" = "map" ] ||
-        error "sample.yaml l4 must be a mapping with a string command"
+    local declaration_kind command_tag cmd
+    declaration_kind="$(yq eval '.live_service_validation | kind' "$yaml" 2>/dev/null)" ||
+        error "failed to read sample.yaml live_service_validation declaration: $yaml"
+    [ "$declaration_kind" = "map" ] ||
+        error "sample.yaml live_service_validation must be a mapping with a string command"
 
-    command_tag="$(yq eval '.l4.command | tag' "$yaml" 2>/dev/null)" ||
-        error "failed to read sample.yaml l4.command: $yaml"
+    command_tag="$(yq eval '.live_service_validation.command | tag' "$yaml" 2>/dev/null)" ||
+        error "failed to read sample.yaml live_service_validation.command: $yaml"
     [ "$command_tag" = "!!str" ] ||
-        error "sample.yaml l4.command must be a non-empty string"
-    cmd="$(yq eval '.l4.command' "$yaml" 2>/dev/null)" ||
-        error "failed to read sample.yaml l4.command: $yaml"
+        error "sample.yaml live_service_validation.command must be a non-empty string"
+    cmd="$(yq eval '.live_service_validation.command' "$yaml" 2>/dev/null)" ||
+        error "failed to read sample.yaml live_service_validation.command: $yaml"
     printf '%s' "$cmd" | grep -q '[^[:space:]]' ||
-        error "sample.yaml l4.command must be a non-empty string"
+        error "sample.yaml live_service_validation.command must be a non-empty string"
 
-    if [ "$(yq eval '.l4 | has("required_env")' "$yaml" 2>/dev/null)" = "true" ]; then
+    if [ "$(yq eval '.live_service_validation | has("required_env")' "$yaml" 2>/dev/null)" = "true" ]; then
         local required_env_kind env_count i env_name env_tag
-        required_env_kind="$(yq eval '.l4.required_env | kind' "$yaml" 2>/dev/null)" ||
-            error "failed to read sample.yaml l4.required_env: $yaml"
+        required_env_kind="$(yq eval '.live_service_validation.required_env | kind' "$yaml" 2>/dev/null)" ||
+            error "failed to read sample.yaml live_service_validation.required_env: $yaml"
         [ "$required_env_kind" = "seq" ] ||
-            error "sample.yaml l4.required_env must be a list of environment-variable names"
-        env_count="$(yq eval '.l4.required_env | length' "$yaml" 2>/dev/null)" ||
-            error "failed to read sample.yaml l4.required_env: $yaml"
+            error "sample.yaml live_service_validation.required_env must be a list of environment-variable names"
+        env_count="$(yq eval '.live_service_validation.required_env | length' "$yaml" 2>/dev/null)" ||
+            error "failed to read sample.yaml live_service_validation.required_env: $yaml"
         i=0
         while [ "$i" -lt "$env_count" ]; do
-            env_tag="$(yq eval ".l4.required_env[$i] | tag" "$yaml" 2>/dev/null)" ||
-                error "failed to read sample.yaml l4.required_env[$i]: $yaml"
+            env_tag="$(yq eval ".live_service_validation.required_env[$i] | tag" "$yaml" 2>/dev/null)" ||
+                error "failed to read sample.yaml live_service_validation.required_env[$i]: $yaml"
             [ "$env_tag" = "!!str" ] ||
-                error "sample.yaml l4.required_env[$i] must be a string"
-            env_name="$(yq eval ".l4.required_env[$i]" "$yaml" 2>/dev/null)" ||
-                error "failed to read sample.yaml l4.required_env[$i]: $yaml"
+                error "sample.yaml live_service_validation.required_env[$i] must be a string"
+            env_name="$(yq eval ".live_service_validation.required_env[$i]" "$yaml" 2>/dev/null)" ||
+                error "failed to read sample.yaml live_service_validation.required_env[$i]: $yaml"
             [[ "$env_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] ||
-                error "sample.yaml l4.required_env[$i] is not a valid environment-variable name: $env_name"
+                error "sample.yaml live_service_validation.required_env[$i] is not a valid environment-variable name: $env_name"
             [ -n "${!env_name:-}" ] ||
-                error "required L4 environment variable is missing or empty: $env_name"
+                error "required live-service environment variable is missing or empty: $env_name"
             i=$((i + 1))
         done
     fi
 
     case "${SKIP_PROVISION:-}" in
         true|false) ;;
-        "") error "SKIP_PROVISION must be set by the L4 caller to true or false" ;;
+        "") error "SKIP_PROVISION must be set by the live-service caller to true or false" ;;
         *) error "SKIP_PROVISION must be exactly true or false (got: $SKIP_PROVISION)" ;;
     esac
 
-    echo "Running L4 command (SKIP_PROVISION=$SKIP_PROVISION): $cmd"
-    local l4log
-    l4log="$(mktemp)" || error "failed to create temporary L4 command log"
-    local l4_rc
-    ( cd "$SAMPLE_DIR" && eval "$cmd" ) >"$l4log" 2>&1
-    l4_rc=$?
-    cat "$l4log"
-    rm -f "$l4log"
-    case "$l4_rc" in
+    echo "Running live-service command (SKIP_PROVISION=$SKIP_PROVISION): $cmd"
+    local live_service_log
+    live_service_log="$(mktemp)" || error "failed to create temporary live-service command log"
+    local live_service_rc
+    ( cd "$SAMPLE_DIR" && eval "$cmd" ) >"$live_service_log" 2>&1
+    live_service_rc=$?
+    cat "$live_service_log"
+    rm -f "$live_service_log"
+    case "$live_service_rc" in
         0) pass ;;
-        1) fail "sample.yaml l4.command reported sample failure (exit 1)" ;;
-        2) error "sample.yaml l4.command reported caller/cloud infrastructure error (exit 2)" ;;
-        *) fail "sample.yaml l4.command exited with unexpected status $l4_rc (classified fail)" ;;
+        1) fail "sample.yaml live_service_validation.command reported sample failure (exit 1)" ;;
+        2) error "sample.yaml live_service_validation.command reported caller/cloud infrastructure error (exit 2)" ;;
+        *) fail "sample.yaml live_service_validation.command exited with unexpected status $live_service_rc (classified fail)" ;;
     esac
 }
 
@@ -468,7 +474,7 @@ python_setup_venv() {
 # --- Argument parsing --------------------------------------------------------
 while [ $# -gt 0 ]; do
     case "$1" in
-        --level)       LEVEL="${2:-}";       shift $(( $# > 1 ? 2 : 1 )) ;;
+        --mode)        MODE="${2:-}";        shift $(( $# > 1 ? 2 : 1 )) ;;
         --language)    LANGUAGE="${2:-}";    shift $(( $# > 1 ? 2 : 1 )) ;;
         --sample-dir)  SAMPLE_DIR="${2:-}";  shift $(( $# > 1 ? 2 : 1 )) ;;
         --results-dir) RESULTS_DIR="${2:-}"; shift $(( $# > 1 ? 2 : 1 )) ;;
@@ -478,29 +484,29 @@ while [ $# -gt 0 ]; do
 done
 
 # --- Guards (ordered so the ERROR tier is provable without any toolchain) -----
-case "$LEVEL" in
-    3|4) ;;
-    "") error "missing value for --level (expected 3 or 4)" ;;
-    *)  error "unsupported validation level '$LEVEL' (expected 3 or 4)" ;;
+case "$MODE" in
+    build-readiness|live-service) ;;
+    "") error "missing value for --mode (expected build-readiness or live-service)" ;;
+    *)  error "unsupported validation mode '$MODE' (expected build-readiness or live-service)" ;;
 esac
 
 [ -n "$SAMPLE_DIR" ] || error "missing required --sample-dir"
 [ -d "$SAMPLE_DIR" ] || error "sample directory not found: $SAMPLE_DIR"
 SAMPLE_DIR="${SAMPLE_DIR%/}"
 
-if [ "$LEVEL" = "3" ] || [ -n "$LANGUAGE" ]; then
+if [ "$MODE" = "build-readiness" ] || [ -n "$LANGUAGE" ]; then
     case "$LANGUAGE" in
         csharp|python|typescript|java|go) ;;
-        "") error "missing required --language for L3" ;;
+        "") error "missing required --language for build readiness" ;;
         *)  error "unsupported language '$LANGUAGE' (frozen set: csharp|python|typescript|java|go)" ;;
     esac
 fi
 
-echo "=== validate-sample: level=L$LEVEL language=${LANGUAGE:-n/a} dir=$SAMPLE_DIR ==="
+echo "=== validate-sample: mode=$MODE language=${LANGUAGE:-n/a} dir=$SAMPLE_DIR ==="
 
-if [ "$LEVEL" = "4" ]; then
-    run_l4
-    error "internal: no L4 verdict emitted"
+if [ "$MODE" = "live-service" ]; then
+    run_live_service_validation
+    error "internal: no live-service verdict emitted"
 fi
 
 # Python creates its isolated venv before the sample.yaml/default branch (ADO parity),

--- a/.github/scripts/validate-validation-pilot-results.py
+++ b/.github/scripts/validate-validation-pilot-results.py
@@ -13,6 +13,7 @@ REQUIRED_FIELDS = {
     "schema_version", "sample", "outcome", "completed_stage", "duration_seconds",
     "diagnostic_reference", "artifact_reference", "completed_at", "run",
 }
+SUPPORTED_SCHEMA_VERSIONS = {1, 2}
 
 
 def main() -> int:
@@ -21,6 +22,13 @@ def main() -> int:
     parser.add_argument("--artifacts", type=Path, required=True)
     args = parser.parse_args()
     manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    schema_version = manifest.get("schema_version")
+    if schema_version not in SUPPORTED_SCHEMA_VERSIONS:
+        print(
+            f"ERROR: unsupported manifest schema_version: {schema_version!r}",
+            file=sys.stderr,
+        )
+        return 1
     expected = {sample["id"]: sample for sample in manifest["samples"]}
     found = {}
     errors = []
@@ -29,7 +37,11 @@ def main() -> int:
             result = json.loads(result_path.read_text(encoding="utf-8"))
             missing = REQUIRED_FIELDS - result.keys()
             sample = result["sample"]
-            if missing or result["schema_version"] != 1 or result["outcome"] not in REQUIRED_OUTCOMES:
+            if (
+                missing
+                or result["schema_version"] != schema_version
+                or result["outcome"] not in REQUIRED_OUTCOMES
+            ):
                 raise ValueError(f"invalid schema or outcome (missing={sorted(missing)})")
             sample_id = sample["id"]
             if sample_id not in expected or sample_id in found:
@@ -53,7 +65,15 @@ def main() -> int:
             print(f"ERROR: {error}", file=sys.stderr)
         return 1
     output = args.artifacts / "run-summary.json"
-    output.write_text(json.dumps({"schema_version": 1, "results": found}, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    output.write_text(
+        json.dumps(
+            {"schema_version": schema_version, "results": found},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
     print(f"validated {len(found)} complete sample results")
     return 0
 

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -6,16 +6,19 @@ generates a deterministic manifest and matrix, and runs with `fail-fast: false`.
 The first full-fleet run should be manually reviewed before the first scheduled
 occurrence.
 
-All supported samples run L3. Declared-L4 samples use a separate credentialed
+All supported samples run build readiness. Samples declaring live-service validation use a separate credentialed
 matrix leg to avoid duplicate validation and unnecessary environment deployment
-records, but that leg still runs L3 first and proceeds to L4 only when L3 passes.
-Declaring L4 never opts a sample out of L3. JavaScript uses the existing
+records, but that leg still runs build readiness first and proceeds to live-service
+validation only when readiness passes. Declaring live-service validation never opts
+a sample out of build readiness. JavaScript uses the existing
 TypeScript/node validator mapping. Rust samples remain in the manifest and emit
 `skipped/not-completed` with an explicit unsupported-language reason.
 
 Each matrix leg persists `sample-result.json` and `diagnostics.log` in a
-versioned artifact. Declared `sample.yaml` L4 commands run through the existing
-`L4-validation` OIDC environment and warm-project seam. P4.1 does not provision
+versioned artifact. Declared `sample.yaml` live-service commands run through the
+existing `L4-validation` OIDC environment and warm-project seam. That environment
+name is a legacy external GitHub/Entra identifier and is not the validation mode
+name. P4.1 does not provision
 resources and does not set a cold-provisioning default.
 
 The result schema remains owned by the producer and includes

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,18 +1,18 @@
 name: validate
 
-# The REAL PR-triggered L3 "floor" lane (P2.1, ADO 5449695) — distinct from the inert
+# The REAL PR-triggered build-readiness floor lane (P2.1, ADO 5449695) — distinct from the inert
 # scripts-selftest.yml dev harness. It validates every changed sample to Build Readiness
-# Level 3 (Load) using the shared scripts ported in Phase 1.
+# using the shared scripts ported in Phase 1.
 #
 # FORK-SAFE BY CONSTRUCTION (this is the headline property):
 #   - on: pull_request  (NEVER pull_request_target) — so PRs from forks run this with a
 #     read-only GITHUB_TOKEN and NO access to secrets, per GitHub's documented behavior.
-#   - The required `trusted` job ALWAYS runs. Forks execute its credential-free L3 path, then
+#   - The required `trusted` job ALWAYS runs. Forks execute its credential-free readiness path, then
 #     fail explicitly with a promotion-required error. A job-level fork skip is forbidden:
 #     GitHub treats a required check that concludes `skipped` as satisfied.
 #   - `trusted` uses the status-function condition `!cancelled()` so a failed/malformed `detect`
 #     dependency starts the job and fails its first contract-check step instead of skipping open.
-#   - Every credentialed setup/L4 step has an explicit same-repo guard. Fork isolation remains
+#   - Every credentialed live-service step has an explicit same-repo guard. Fork isolation remains
 #     layered: read-only fork token/no secrets/no OIDC issuance + step-level guards.
 #   - The job checks out and EXECUTES untrusted fork code (dotnet build, npm install,
 #     pip install, mvn compile, ...). That is intentional and safe *because* the runner is
@@ -21,7 +21,7 @@ name: validate
 # Frozen constraints honored: no pull_request_target, no trust-scoring, no org-membership
 # API calls, no aggregator/gate-shim job, no `on: paths:` trigger filter. "What changed" is
 # decided IN-JOB by detect-changed-samples.sh and fanned out via needs.*.outputs. The
-# trusted L4 lane (secrets, fork-gated) is the `trusted` job at the BOTTOM of THIS workflow
+# trusted live-service lane (secrets, fork-gated) is the `trusted` job at the BOTTOM of THIS workflow
 # (P2.2, ADO 5449696) — a SINGLE job (never a matrix), so its required-check context is exactly
 # `trusted` (displayed by Actions as `validate / trusted`).
 
@@ -55,7 +55,7 @@ jobs:
         # loud (exit 1) if the git diff itself errors — never a fake empty set.
         run: bash .github/scripts/detect-changed-samples.sh
 
-  # --- Validate each changed sample to L3, one runner per sample ---------------
+  # --- Validate each changed sample for build readiness, one runner per sample -
   validate:
     needs: detect
     if: needs.detect.outputs.has_changes == 'true'   # docs-only PRs skip this job entirely
@@ -134,9 +134,9 @@ jobs:
         if: steps.lang.outputs.language == 'unsupported'
         env:
           SAMPLE: ${{ matrix.sample }}
-        run: echo "::notice::Skipping ${SAMPLE} — language not covered by the L3 floor lane."
+        run: echo "::notice::Skipping ${SAMPLE} — language not covered by build readiness."
 
-      - name: Validate sample (L3 / Load)
+      - name: Validate sample build readiness
         if: steps.lang.outputs.language != 'unsupported'
         env:
           SAMPLE: ${{ matrix.sample }}
@@ -146,33 +146,34 @@ jobs:
         # green on an unresolved run — while the script's log distinguishes them.
         run: bash .github/scripts/validate-sample.sh --language "$LANGUAGE" --sample-dir "$SAMPLE"
 
-  # === P2.2 · ADO 5449696 · the TRUSTED L4 lane ================================
+  # === P2.2 · ADO 5449696 · trusted live-service validation ===================
   # The credentialed counterpart to the floor `validate` job above. It produces the
   # required-merge-gate check context `validate / trusted` (workflow name `validate` + job name
   # `trusted`). FROZEN, non-negotiable properties (violating any is a defect):
   #   - SINGLE JOB, no per-language matrix. A matrix of required checks reinstates the rejected
-  #     aggregator/gate-shim. Speed comes from IN-JOB parallelism (the L3 step backgrounds
+  #     aggregator/gate-shim. Speed comes from IN-JOB parallelism (the readiness step backgrounds
   #     validate-sample.sh per changed sample), never from fan-out into multiple checks.
-  #   - ALWAYS RUNS for every triggered PR. Forks run credential-free L3, then fail in-job with
+  #   - ALWAYS RUNS for every triggered PR. Forks run credential-free readiness, then fail in-job with
   #     a promotion-required error. Never restore a job-level fork/draft `if:`: P3.3 proved that
   #     GitHub treats a required job that concludes `skipped` as satisfying the merge gate.
   #   - FAILS CLOSED when `detect` fails or emits malformed outputs. The exact job-level
   #     `!cancelled()` status condition starts trusted after dependency failure; the FIRST step
   #     validates the dependency result/output contract before checkout or docs-only handling.
   #   - Docs-only PRs SHORT-CIRCUIT before any Azure/secret step (has_changes gate). A docs-only
-  #     same-repo PR yields a PRESENT, PASSING check (correct "no sample owes L4"); every fork
+  #     same-repo PR yields a PRESENT, PASSING check (correct "no sample owes live-service validation"); every fork
   #     yields a PRESENT, FAILING check and requires maintainer promotion.
   #   - Concurrency cancels superseded runs.
-  #   - L4 = the pre-provisioned WARM validation project via SKIP_PROVISION=true (never provisions
+  #   - Live-service validation uses the pre-provisioned WARM project via SKIP_PROVISION=true (never provisions
   #     per PR — cold provisioning is the cadence lane's sole job). OIDC federated login, no stored
-  #     secret. Env L4-validation MUST carry zero protection_rules: because this always-running job
+  #     secret. The legacy external environment identifier L4-validation MUST carry zero
+  #     protection_rules: because this always-running job
   #     binds the environment, an environment reviewer rule would stall a fork instead of failing it.
   trusted:
     needs: detect
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    # Binds the OIDC subject to environment:L4-validation (matches the Azure federated credential)
-    # and scopes vars.AZURE_* to that environment.
+    # Legacy external identifier: renaming it also requires an Entra OIDC subject migration.
+    # It scopes vars.AZURE_* and binds the matching Azure federated credential.
     environment: L4-validation
     # Job-level permissions REPLACE the workflow default for this job: add id-token for OIDC.
     permissions:
@@ -238,12 +239,12 @@ jobs:
       - uses: actions/checkout@v4
 
       # --- Docs-only short-circuit (BEFORE any secret/Azure step) ---------------
-      # If detect found no changed sample, nothing owes L4 → the trusted gate is satisfied. Log and
+      # If detect found no changed sample, nothing owes live-service validation, so the trusted gate is satisfied. Log and
       # let a SAME-REPO job end green WITHOUT touching OIDC/secrets. Forks never short-circuit to
       # success; they reach the explicit promotion failure below.
       - name: Short-circuit docs-only PRs before secrets
         if: needs.detect.outputs.has_changes != 'true' && github.event.pull_request.head.repo.fork != true
-        run: echo "No changed samples (docs-only) -> no sample owes L4 -> trusted gate satisfied. Skipping L3+L4 without touching secrets."
+        run: echo "No changed samples (docs-only) -> no sample owes live-service validation -> trusted gate satisfied. Skipping build readiness and live-service validation without touching secrets."
 
       # --- Derive which toolchains the changed samples actually need ------------
       - name: Derive languages from changed samples
@@ -309,18 +310,18 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
           yq --version
 
-      # --- L3 (Load) for EVERY changed sample, IN-JOB PARALLEL (no matrix) ------
+      # --- Build readiness for EVERY changed sample, IN-JOB PARALLEL (no matrix)
       # Single job; concurrency comes from backgrounding validate-sample.sh per sample. GITHUB_OUTPUT
       # is blanked per-invocation so the parallel legs don't race on the shared output file; each
       # leg's verdict is its exit code (0 pass / 1 fail / 2 error). Any fail OR error → job red, and
-      # the default success() gating means L4 below never runs on a red L3.
-      - name: Validate changed samples to L3 (in-job parallel)
+      # the default success() gating means live-service validation never runs after a red result.
+      - name: Validate changed sample build readiness (in-job parallel)
         if: needs.detect.outputs.has_changes == 'true'
         env:
           SAMPLES: ${{ needs.detect.outputs.samples }}
         run: |
           set -uo pipefail
-          mkdir -p _l3
+          mkdir -p _build_readiness
           map_lang() {
             case "$1" in
               csharp)                echo csharp ;;
@@ -339,39 +340,39 @@ jobs:
             safe="$(printf '%s' "$sample" | tr '/ ' '__')"
             n=$((n+1))
             if [ "$lang" = unsupported ]; then
-              echo "::notice::Skipping $sample — language '$dir' not in the frozen L3 set."
-              echo 0 > "_l3/$safe.rc"
-              : > "_l3/$safe.log"
+              echo "::notice::Skipping $sample — language '$dir' not in the build-readiness set."
+              echo 0 > "_build_readiness/$safe.rc"
+              : > "_build_readiness/$safe.log"
               continue
             fi
             (
-              GITHUB_OUTPUT= bash .github/scripts/validate-sample.sh --language "$lang" --sample-dir "$sample" > "_l3/$safe.log" 2>&1
-              echo $? > "_l3/$safe.rc"
+              GITHUB_OUTPUT= bash .github/scripts/validate-sample.sh --language "$lang" --sample-dir "$sample" > "_build_readiness/$safe.log" 2>&1
+              echo $? > "_build_readiness/$safe.rc"
             ) &
           done < <(printf '%s' "$SAMPLES" | jq -r '.[]')
           wait
           pass=0; failed=0; errored=0
-          for rcf in _l3/*.rc; do
+          for rcf in _build_readiness/*.rc; do
             rc="$(cat "$rcf")"
             base="$(basename "$rcf" .rc)"
             echo "----- $base (rc=$rc) -----"
-            cat "_l3/$base.log" 2>/dev/null || true
+            cat "_build_readiness/$base.log" 2>/dev/null || true
             case "$rc" in
               0) pass=$((pass+1)) ;;
-              1) failed=$((failed+1));  echo "::error::L3 FAIL ($base)" ;;
-              2) errored=$((errored+1)); echo "::error::L3 ERROR/infra ($base)" ;;
-              *) errored=$((errored+1)); echo "::error::L3 unexpected rc=$rc ($base)" ;;
+              1) failed=$((failed+1));  echo "::error::BUILD READINESS FAIL ($base)" ;;
+              2) errored=$((errored+1)); echo "::error::BUILD READINESS ERROR/infra ($base)" ;;
+              *) errored=$((errored+1)); echo "::error::BUILD READINESS unexpected rc=$rc ($base)" ;;
             esac
           done
-          echo "L3 summary: total=$n pass=$pass fail=$failed error=$errored"
+          echo "Build-readiness summary: total=$n pass=$pass fail=$failed error=$errored"
           if [ "$failed" -gt 0 ] || [ "$errored" -gt 0 ]; then
-            echo "L3 not green -> trusted gate red; not proceeding to L4."
+            echo "Build readiness not green -> trusted gate red; not proceeding to live-service validation."
             exit 1
           fi
-          echo "L3 green for all $pass changed sample(s)."
+          echo "Build readiness green for all $pass changed sample(s)."
 
       # A fork must produce a terminal FAILURE, never a skipped required check. This step uses a
-      # status function so it still emits the promotion instruction after a broken fork's L3 fails.
+      # status function so it still emits the promotion instruction after a fork's readiness fails.
       - name: Reject fork until maintainer promotion
         if: ${{ !cancelled() && github.event.pull_request.head.repo.fork == true }}
         run: |
@@ -380,11 +381,11 @@ jobs:
             echo "::error::Fork runner unexpectedly received an OIDC request surface; refusing to continue."
             exit 1
           fi
-          echo "::error::Fork PRs cannot satisfy the trusted gate directly. A maintainer must promote this commit to a same-repo branch, where the credentialed L4 path can run."
+          echo "::error::Fork PRs cannot satisfy the trusted gate directly. A maintainer must promote this commit to a same-repo branch, where live-service validation can run."
           exit 1
 
-      # --- L4: reach the WARM project via OIDC (only after L3 green) ------------
-      # Reached only when real samples changed AND L3 passed (default step success() gating). This
+      # --- Reach the warm project via OIDC (only after build readiness is green) -
+      # Reached only when real samples changed and readiness passed. This
       # is the trusted secret boundary: federated OIDC login, no stored secret.
       - name: Azure login via OIDC (no secret)
         if: needs.detect.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork != true
@@ -394,7 +395,7 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-      - name: L4 smoke against the warm project (SKIP_PROVISION)
+      - name: Live-service smoke against the warm project (SKIP_PROVISION)
         if: needs.detect.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork != true
         env:
           AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
@@ -412,8 +413,8 @@ jobs:
           echo "HTTP ${HTTP}"
           cat resp.json; echo
           test "${HTTP}" = "200"
-          echo "L4 OK: OIDC + SKIP_PROVISION warm-project reach + least-priv inference all green."
+          echo "LIVE-SERVICE OK: OIDC + SKIP_PROVISION warm-project reach + least-priv inference all green."
 
       - name: Trusted verdict
         if: needs.detect.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork != true
-        run: echo "validate / trusted GREEN — L3 passed for all changed samples AND the L4 warm-project smoke passed."
+        run: echo "validate / trusted GREEN — build readiness passed for all changed samples AND the live-service warm-project smoke passed."

--- a/.github/workflows/validation-pilot.yml
+++ b/.github/workflows/validation-pilot.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      l3_matrix: ${{ steps.discovery.outputs.l3_matrix }}
-      l4_matrix: ${{ steps.discovery.outputs.l4_matrix }}
+      build_readiness_matrix: ${{ steps.discovery.outputs.build_readiness_matrix }}
+      live_service_matrix: ${{ steps.discovery.outputs.live_service_matrix }}
     steps:
       - uses: actions/checkout@v4
       - name: Discover full sample inventory
@@ -28,10 +28,10 @@ jobs:
           python .github/scripts/discover-validation-samples.py \
             --manifest "$RUNNER_TEMP/validation-manifest.json" \
             --matrix "$RUNNER_TEMP/validation-matrix.json" \
-            --l3-matrix "$RUNNER_TEMP/validation-l3-matrix.json" \
-            --l4-matrix "$RUNNER_TEMP/validation-l4-matrix.json" > "$RUNNER_TEMP/discovery.json"
-          printf 'l3_matrix=%s\n' "$(cat "$RUNNER_TEMP/validation-l3-matrix.json")" >> "$GITHUB_OUTPUT"
-          printf 'l4_matrix=%s\n' "$(cat "$RUNNER_TEMP/validation-l4-matrix.json")" >> "$GITHUB_OUTPUT"
+            --build-readiness-matrix "$RUNNER_TEMP/validation-build-readiness-matrix.json" \
+            --live-service-matrix "$RUNNER_TEMP/validation-live-service-matrix.json" > "$RUNNER_TEMP/discovery.json"
+          printf 'build_readiness_matrix=%s\n' "$(cat "$RUNNER_TEMP/validation-build-readiness-matrix.json")" >> "$GITHUB_OUTPUT"
+          printf 'live_service_matrix=%s\n' "$(cat "$RUNNER_TEMP/validation-live-service-matrix.json")" >> "$GITHUB_OUTPUT"
           cat "$RUNNER_TEMP/discovery.json"
       - name: Persist discovered manifest
         uses: actions/upload-artifact@v4
@@ -41,7 +41,7 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-  validate:
+  build-readiness:
     needs: discover
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 32
-      matrix: ${{ fromJSON(needs.discover.outputs.l3_matrix) }}
+      matrix: ${{ fromJSON(needs.discover.outputs.build_readiness_matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
@@ -75,7 +75,7 @@ jobs:
         run: |
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
-      - name: Run normalized sample validation
+      - name: Run normalized build-readiness validation
         if: always()
         run: |
           set -uo pipefail
@@ -102,10 +102,11 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-  validate-l4:
+  live-service:
     needs: discover
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Legacy external identifier: renaming it also requires an Entra OIDC subject migration.
     environment: L4-validation
     permissions:
       contents: read
@@ -118,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 4
-      matrix: ${{ fromJSON(needs.discover.outputs.l4_matrix) }}
+      matrix: ${{ fromJSON(needs.discover.outputs.live_service_matrix) }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
@@ -133,7 +134,7 @@ jobs:
         run: |
           sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
-      - name: Install declared L4 Python runtime dependencies
+      - name: Install declared live-service Python runtime dependencies
         if: matrix.validator_language == 'python'
         run: python -m pip install -r "${{ matrix.path }}/requirements.txt"
       - name: Azure login
@@ -142,7 +143,7 @@ jobs:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-      - name: Run normalized L4 sample validation
+      - name: Run normalized live-service validation
         if: always()
         run: |
           set -uo pipefail
@@ -155,7 +156,7 @@ jobs:
             --sample-path "${{ matrix.path }}" \
             --output "$RUNNER_TEMP/pilot-result/sample-result.json" \
             --diagnostic "$RUNNER_TEMP/pilot-result/diagnostics.log" \
-            --run-l4
+            --run-live-service
       - name: Persist sample result and diagnostics
         if: always()
         uses: actions/upload-artifact@v4
@@ -167,7 +168,7 @@ jobs:
 
   completeness:
     if: always()
-    needs: [discover, validate, validate-l4]
+    needs: [discover, build-readiness, live-service]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -192,7 +193,7 @@ jobs:
       - name: Persist run metadata and normalized summary
         if: always()
         run: |
-          python -c 'import json,os; from pathlib import Path; p=Path(os.environ["RUNNER_TEMP"])/"pilot-artifacts"/"run-metadata.json"; p.write_text(json.dumps({"schema_version":1,"repository":os.environ["GITHUB_REPOSITORY"],"workflow":os.environ["GITHUB_WORKFLOW"],"run_id":os.environ["GITHUB_RUN_ID"],"run_attempt":os.environ["GITHUB_RUN_ATTEMPT"],"sha":os.environ["GITHUB_SHA"],"ref":os.environ["GITHUB_REF"],"completed_at":__import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat().replace("+00:00","Z")},indent=2)+"\n")'
+          python -c 'import json,os; from pathlib import Path; p=Path(os.environ["RUNNER_TEMP"])/"pilot-artifacts"/"run-metadata.json"; p.write_text(json.dumps({"schema_version":2,"repository":os.environ["GITHUB_REPOSITORY"],"workflow":os.environ["GITHUB_WORKFLOW"],"run_id":os.environ["GITHUB_RUN_ID"],"run_attempt":os.environ["GITHUB_RUN_ATTEMPT"],"sha":os.environ["GITHUB_SHA"],"ref":os.environ["GITHUB_REF"],"completed_at":__import__("datetime").datetime.now(__import__("datetime").timezone.utc).isoformat().replace("+00:00","Z")},indent=2)+"\n")'
         continue-on-error: true
       - name: Upload normalized run
         if: always()

--- a/.github/workflows/validation-report.yml
+++ b/.github/workflows/validation-report.yml
@@ -1,6 +1,6 @@
 name: validation report
 
-# Reusable consumer job for validation-pilot v1. The producer owns the schema and
+# Reusable consumer job for validation-pilot schemas 1 and 2. The producer owns the schema and
 # artifact completeness; this workflow only consumes normalized results and diagnostics.
 on:
   workflow_call:

--- a/samples/csharp/quickstart/responses/sample.yaml
+++ b/samples/csharp/quickstart/responses/sample.yaml
@@ -1,7 +1,7 @@
 name: Quickstart Responses
 description: Basic quickstart sample demonstrating Microsoft Foundry responses.
 build: "dotnet restore --source https://api.nuget.org/v3/index.json && dotnet build --no-restore --verbosity minimal"
-l4:
+live_service_validation:
   command: "dotnet run --no-build"
   required_env:
     - AZURE_AI_PROJECT_ENDPOINT

--- a/samples/python/quickstart/responses/sample.yaml
+++ b/samples/python/quickstart/responses/sample.yaml
@@ -3,7 +3,7 @@ description: Basic quickstart sample demonstrating Microsoft Foundry responses.
 
 build: "pip install -r requirements.txt"
 validate: "python -m py_compile *.py"
-l4:
+live_service_validation:
   command: "python quickstart-responses.py"
   required_env:
     - AZURE_AI_PROJECT_ENDPOINT


### PR DESCRIPTION
## Summary

- replace `L3`/`L4` user-facing terminology with **Build readiness** and **Live-service validation**
- move producer interfaces to `live_service_validation`, `--mode build-readiness|live-service`, descriptive workflow/matrix names, and schema v2
- retain schema-v1 historical artifact readers and the externally configured `L4-validation` GitHub environment/Entra subject
- preserve validation order, classifier outcomes, credentials, provisioning policy, and required-check behavior

## Validation

- Python pilot/report suites: 13 passed
- workflow structure suite: 39 passed
- Bash contract suite: all 14 renamed live-service and legacy-migration cases passed; local full suite reported 39 passed, 1 failed, 11 skipped because this host could not resolve NuGet/package endpoints
- final read-only code review: no findings

ADO 5517139: https://msdata.visualstudio.com/Vienna/_workitems/edit/5517139