### PR TITLE
Add hello-world-jfrog sample for private registry pulls

### DIFF
--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/AGENTS.md
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/AGENTS.md
@@ -1,0 +1,50 @@
+# Coding Agent Instructions
+
+This project is a **Microsoft Foundry hosted agent** — a containerized AI agent that runs in [Foundry Agent Service](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/hosted-agents). The platform handles containerization, hosting, security, scaling, and observability so you can focus on agent logic.
+
+This variant deploys a **pre-built image from a private JFrog Artifactory registry**, pulled using Microsoft Entra workload identity federation. See [README.md](./README.md) for the full setup.
+
+## Key files
+
+- `Dockerfile` — container definition
+- `azure.yaml` — `project` and `language` are intentionally empty so azd uses the pre-built `image`
+- `deploy/create-registry-connection.ps1` — one-time Foundry registry connection setup
+- `deploy/create-agent-version.ps1` — creates the agent version with `registry_connection_id`
+
+## Development workflow
+
+The **Azure Developer CLI (`azd`)** manages most of the lifecycle:
+
+```bash
+azd ai agent run                           # Run locally on http://localhost:8088
+azd ai agent invoke --local "your message" # Test the local agent
+azd deploy                                 # Register the agent in Foundry
+azd ai agent invoke "your message"         # Invoke the deployed agent
+```
+
+> [!NOTE]
+> `azd` cannot yet attach the registry connection that authorizes the JFrog pull, so
+> `deploy/create-agent-version.ps1` must be run after `azd deploy`. The team is working
+> to make this completely deployable via `azd`; see "The temporary gap" in the README.
+
+## Microsoft Foundry Skill
+
+Install the **Microsoft Foundry Skill** for guided deployment, evaluation, and troubleshooting workflows.
+
+Direct install (preferred, works with any coding agent):
+
+```bash
+npx skills add https://github.com/microsoft/azure-skills --skill microsoft-foundry
+```
+
+Or install the Azure Skills Plugin:
+
+- **Copilot CLI**: `/plugin marketplace add microsoft/azure-skills` then `/plugin install azure@azure-skills`
+- **Claude Code**: `/plugin install azure@claude-plugins-official`
+
+Then ask naturally, e.g. `Use the Microsoft Foundry Skill to deploy this agent.`
+
+## References
+
+- [Hosted agents overview](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/hosted-agents)
+- [Microsoft Foundry Skill](https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/use-microsoft-foundry-skill)

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/CLAUDE.md
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This project uses [AGENTS.md](./AGENTS.md) as the single source of truth for coding agent instructions. The import below loads it into Claude Code's context.
+
+@AGENTS.md

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/CLAUDE.md
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/CLAUDE.md
@@ -1,5 +1,0 @@
-# CLAUDE.md
-
-This project uses [AGENTS.md](./AGENTS.md) as the single source of truth for coding agent instructions. The import below loads it into Claude Code's context.
-
-@AGENTS.md

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/README.md
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/README.md
@@ -19,6 +19,12 @@ It shows how Microsoft Foundry pulls a private image using **Microsoft Entra wor
 
 If you don't need a private third-party registry, start with [`hello-world`](../hello-world/) instead — it's simpler and deploys end-to-end with a single `azd deploy`.
 
+> [!NOTE]
+> **Two steps in this guide use the REST API instead of `azd`** — creating the registry connection
+> (Step 4) and creating the agent version that references it (Step 8). This is a **temporary gap in
+> the tooling, not in the service**, and the team is working to make this sample completely
+> deployable via `azd`. See [The temporary gap](#the-temporary-gap) for details.
+
 ## How it works
 
 ```
@@ -131,6 +137,12 @@ JFrog → **Administration** → **General Management** → **Manage Integration
 
 This creates a connection named `jfrog-oidc-registry` containing only non-secret OIDC settings.
 
+> [!NOTE]
+> **Creating the registry connection through the REST API is temporary.** `azd` cannot declare a
+> registry connection today, so this script calls the REST API on your behalf. The team is working
+> to make this completely deployable via `azd` — once that lands, the connection will be declared
+> in `azure.yaml` and this script will no longer be needed.
+
 ✅ Setup is complete and never needs repeating.
 
 ---
@@ -184,6 +196,12 @@ azd deploy
 
 This creates the agent version with `registry_connection_id` set, waits for it to become ready, and routes the endpoint to it.
 
+> [!NOTE]
+> **This REST API step is temporary.** It exists only because `azd deploy` cannot yet attach the
+> registry connection to the agent version. The team is working to make this completely deployable
+> via `azd`; when that ships, Steps 7 and 8 merge into a single `azd deploy` and this script is
+> deleted from the sample.
+
 ## Step 9. Invoke
 
 ```bash
@@ -201,9 +219,9 @@ azd ai agent monitor
 # The temporary gap
 
 > [!NOTE]
-> **The Foundry service fully supports pulling images from private registries such as JFrog.** The gap is only in the tooling: `azd` (and the `azure-ai-projects` SDK) cannot yet express the registry connection reference, so `azure.yaml` alone can't authorize the pull. That's why Step 8 is a separate script.
+> **The Foundry service fully supports pulling images from private registries such as JFrog.** The gap is only in the tooling: `azd` (and the `azure-ai-projects` SDK) cannot yet declare a registry connection or reference one from an agent version, so `azure.yaml` alone can't authorize the pull. That's why Steps 4 and 8 use the REST API.
 >
-> **The team is actively working to make this completely deployable via `azd`.** Once the field lands in the tooling, Steps 7–8 collapse into a single `azd deploy`, the helper script goes away, and `azure.yaml` will simply name the connection.
+> **The team is actively working to make this completely deployable via `azd`.** Once support lands, the connection will be declared in `azure.yaml`, Steps 7–8 collapse into a single `azd deploy`, and both helper scripts go away.
 
 **What's happening under the covers:** the agent version needs this field, which only the REST API accepts today:
 

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/README.md
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/README.md
@@ -1,0 +1,249 @@
+<!-- Begin standard disclaimer — do not modify -->
+**IMPORTANT!** All samples and other resources made available in this GitHub repository ("samples") are designed to assist in accelerating development of agents, solutions, and agent workflows for various scenarios. Review all provided resources and carefully test output behavior in the context of your use case. AI responses may be inaccurate and AI actions should be monitored with human oversight. Learn more in the transparency note for [Agent Service](https://learn.microsoft.com/en-us/azure/ai-foundry/responsible-ai/agents/transparency-note).
+
+Agents, solutions, or other output you create may be subject to legal and regulatory requirements, may require licenses, or may not be suitable for all industries, scenarios, or use cases. By using any sample, you are acknowledging that any output created using those samples are solely your responsibility, and that you will comply with all applicable laws, regulations, and relevant safety standards, terms of service, and codes of conduct.
+
+Third-party samples contained in this folder are subject to their own designated terms, and they have not been tested or verified by Microsoft or its affiliates.
+
+Microsoft has no responsibility to you or others with respect to any of these samples or any resulting output.
+<!-- End standard disclaimer -->
+
+# What this sample demonstrates
+
+The same minimal "hello world" hosted agent as [`hello-world`](../hello-world/), but deployed from a **private JFrog Artifactory registry** instead of Azure Container Registry.
+
+It shows how Microsoft Foundry pulls a private image using **Microsoft Entra workload identity federation** — your Foundry project's managed identity is exchanged for a short-lived JFrog access token at pull time.
+
+> [!IMPORTANT]
+> **No JFrog password, API key, reference token, or Docker `auth` value is ever stored in Azure.** Those credentials are only used from your own machine to *push* images. Foundry authenticates with a short-lived token obtained through OIDC token exchange.
+
+If you don't need a private third-party registry, start with [`hello-world`](../hello-world/) instead — it's simpler and deploys end-to-end with a single `azd deploy`.
+
+## How it works
+
+```
+                 ┌─────────────────────────┐
+                 │  Foundry project        │
+                 │  (system-assigned MI)   │
+                 └───────────┬─────────────┘
+                             │ 1. Entra token
+                             │    aud = <your Entra app>
+                             │    oid = <project MI object ID>
+                             ▼
+                 ┌─────────────────────────┐
+                 │  JFrog OIDC provider    │  2. validates issuer + audience,
+                 │  + identity mapping     │     matches the oid claim
+                 └───────────┬─────────────┘
+                             │ 3. short-lived JFrog access token
+                             ▼
+                 ┌─────────────────────────┐
+                 │  JFrog Docker repo      │  4. Foundry pulls the image
+                 └─────────────────────────┘
+```
+
+The **Entra app registration is only an audience identifier** — it needs no client secret, no redirect URI, and no API permissions.
+
+## Prerequisites
+
+| Requirement | Notes |
+|---|---|
+| Foundry project with a **system-assigned managed identity** | Required. This identity is what JFrog trusts. |
+| JFrog Artifactory with a **Docker repository** | You need one-time **Administer** rights to configure OIDC. |
+| Entra app registration | Audience only — no secret needed. |
+| **Azure AI Developer** role on the Foundry project | To create connections and deploy. |
+| `azd`, Azure CLI, Docker | [Install azd](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd) (1.25+), then `azd auth login` and `az login`. |
+
+---
+
+# Part 1 — One-time setup
+
+Do this once per Foundry project. Steps 1–3 usually need an administrator.
+
+## Step 1. Create the Entra app registration (audience only)
+
+Azure portal → **Microsoft Entra ID** → **App registrations** → **New registration**.
+
+- Name: anything, e.g. `foundry-jfrog-audience`
+- Supported account types: **Single tenant**
+- Redirect URI: **leave blank**
+
+Do **not** create a client secret.
+
+➡️ Copy the **Application (client) ID** — this is your `<audience>`.
+
+## Step 2. Get your Foundry project's identity
+
+Foundry portal → your project → **Identity** → confirm **System assigned** is **On**.
+
+Or with the CLI:
+
+```bash
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<account>/projects/<project>?api-version=2025-10-01-preview" \
+  --query identity.principalId -o tsv
+```
+
+➡️ Copy the **principal (object) ID** — this is your `<project-identity>`.
+
+> [!WARNING]
+> This is the **project's** identity, not the object ID of the app registration from Step 1. Confusing the two is the single most common cause of image-pull failures.
+
+## Step 3. Configure OIDC in JFrog
+
+JFrog → **Administration** → **General Management** → **Manage Integrations** → **OIDC**.
+
+**3a. Create the provider**
+
+| Field | Value |
+|---|---|
+| Provider type | `Azure` |
+| Issuer URL | `https://login.microsoftonline.com/<tenant-id>/v2.0` |
+| Audience | `<audience>` from Step 1 |
+
+➡️ Note the **provider name**.
+
+**3b. Add an identity mapping** on that provider:
+
+- **Claims:**
+  ```json
+  {
+    "oid": "<project-identity>",
+    "aud": "<audience>",
+    "iss": "https://login.microsoftonline.com/<tenant-id>/v2.0"
+  }
+  ```
+- **Token scope:** a JFrog group with **read** permission on your Docker repository
+- **Expiry:** ~3600 seconds
+
+## Step 4. Create the Foundry registry connection
+
+```powershell
+./deploy/create-registry-connection.ps1 `
+    -SubscriptionId   <sub> `
+    -ResourceGroup    <rg> `
+    -AccountName      <foundry-account> `
+    -ProjectName      <project> `
+    -JFrogHost        mytenant.jfrog.io `
+    -JFrogRepository  docker-local `
+    -OidcAudience     <audience> `
+    -OidcProviderName <provider-name>
+```
+
+This creates a connection named `jfrog-oidc-registry` containing only non-secret OIDC settings.
+
+✅ Setup is complete and never needs repeating.
+
+---
+
+# Part 2 — Deploy
+
+## Step 5. Build and push the image to JFrog
+
+```bash
+cd src/hello-world-jfrog-invocations
+
+docker build --platform=linux/amd64 -t hello-world-jfrog-invocations:1.0.0 .
+
+docker login mytenant.jfrog.io
+docker tag hello-world-jfrog-invocations:1.0.0 \
+  mytenant.jfrog.io/docker-local/hello-world-jfrog-invocations:1.0.0
+docker push mytenant.jfrog.io/docker-local/hello-world-jfrog-invocations:1.0.0
+```
+
+> [!IMPORTANT]
+> Always build with `--platform=linux/amd64`. Images built natively on Apple Silicon or other ARM64 machines will fail at runtime.
+
+## Step 6. Update `azure.yaml`
+
+Set the `image` field to the tag you just pushed:
+
+```yaml
+image: mytenant.jfrog.io/docker-local/hello-world-jfrog-invocations:1.0.0
+```
+
+Leave `project` and `language` **empty** — that is what tells azd to use your pre-built image instead of rebuilding from source.
+
+## Step 7. Provision and deploy
+
+```bash
+azd provision   # creates the Foundry project, model deployment, App Insights
+azd deploy
+```
+
+`azd deploy` registers the agent. **It will then report a failure — this is expected today.** See the note below.
+
+## Step 8. Create the version that references the connection
+
+```powershell
+./deploy/create-agent-version.ps1 `
+    -ProjectEndpoint https://<account>.services.ai.azure.com/api/projects/<project> `
+    -AgentName       hello-world-jfrog-invocations `
+    -Image           mytenant.jfrog.io/docker-local/hello-world-jfrog-invocations:1.0.0 `
+    -ModelDeployment gpt-5.4-mini
+```
+
+This creates the agent version with `registry_connection_id` set, waits for it to become ready, and routes the endpoint to it.
+
+## Step 9. Invoke
+
+```bash
+azd ai agent invoke "What is Microsoft Foundry?"
+```
+
+To stream logs from the running agent:
+
+```bash
+azd ai agent monitor
+```
+
+---
+
+# The temporary gap
+
+> [!NOTE]
+> **The Foundry service fully supports pulling images from private registries such as JFrog.** The gap is only in the tooling: `azd` (and the `azure-ai-projects` SDK) cannot yet express the registry connection reference, so `azure.yaml` alone can't authorize the pull. That's why Step 8 is a separate script.
+>
+> **The team is actively working to make this completely deployable via `azd`.** Once the field lands in the tooling, Steps 7–8 collapse into a single `azd deploy`, the helper script goes away, and `azure.yaml` will simply name the connection.
+
+**What's happening under the covers:** the agent version needs this field, which only the REST API accepts today:
+
+```json
+"container_configuration": {
+  "image": "mytenant.jfrog.io/docker-local/hello-world-jfrog-invocations:1.0.0",
+  "registry_connection_id": "jfrog-oidc-registry"
+}
+```
+
+Without it, Foundry attempts an anonymous pull and provisioning fails.
+
+---
+
+# Verifying it worked
+
+A successful pull produces this in the platform logs:
+
+```
+Private registry pull starting for hello-world-jfrog-invocations:<v>
+  (connection=jfrog-oidc-registry, host=mytenant.jfrog.io)
+Private registry pull credential resolved and attached
+```
+
+> [!TIP]
+> A version may briefly report `status: active` before turning `failed`. Confirm that `container_protocol_versions` is **non-empty** before treating a deployment as successful — `create-agent-version.ps1` already checks this for you.
+
+# Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Provisioning fails; logs show `buildah pull failed with exit code 125` at `steps/CreateAdcSnapshot` | Foundry could not authenticate to JFrog | The connection wasn't attached (Step 8), or the JFrog identity mapping uses the wrong object ID (Step 2/3b) |
+| `azd deploy` reports *"agent deployment timed out (last status: creating)"* | azd stops polling after ~5 minutes | Cosmetic — provisioning often continues and succeeds. Check the real status in the portal |
+| `failed to fetch builder image .../oryx/builder` | `project` / `language` are not empty in `azure.yaml` | Set both to `''` (Step 6) |
+| `registry_connection_id must be a valid workspace connection name` | The full ARM resource ID was passed | Use the connection **name**, e.g. `jfrog-oidc-registry` |
+| Agent provisions but crashes at startup | Missing Python dependency | Check `azd ai agent monitor` output and add it to `requirements.txt` |
+| Image runs locally but fails in Foundry | Image built for ARM64 | Rebuild with `--platform=linux/amd64` |
+
+# Related
+
+- [`hello-world`](../hello-world/) — the same agent deployed from ACR with a single `azd deploy`
+- [Hosted agents overview](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/hosted-agents)
+- [Hosted agent quickstart](https://learn.microsoft.com/en-us/azure/foundry/agents/quickstarts/quickstart-hosted-agent?view=foundry&pivots=azd)

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/azure.yaml
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/azure.yaml
@@ -1,0 +1,62 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+# Hello World (Python, Invocations) — image pulled from a private JFrog Artifactory registry.
+#
+# This manifest deploys a PRE-BUILT image that you pushed to JFrog yourself.
+# Because the image already exists, `project` and `language` are intentionally left
+# EMPTY so that azd skips packaging and uses the `image` value as-is.
+#
+# NOTE: azd cannot yet attach the Foundry registry connection that authorizes the
+# pull from JFrog. After `azd deploy`, run `deploy/create-agent-version.ps1` (or the
+# equivalent REST call) to create a version that references the connection.
+# See the README, "The temporary gap", for details.
+
+requiredVersions:
+  extensions:
+    azure.ai.agents: '>=1.0.0-beta.4'
+name: hello-world-jfrog-invocations
+services:
+  ai-project:
+    host: azure.ai.project
+    deployments:
+      - name: gpt-5.4-mini
+        model:
+          format: OpenAI
+          name: gpt-5.4-mini
+          version: '2026-03-17'
+        sku:
+          name: GlobalStandard
+          capacity: 10
+  hello-world-jfrog-invocations:
+    host: azure.ai.agent
+    metadata:
+      tags:
+        - AI Agent Hosting
+        - Invocations Protocol
+        - Bring Your Own
+        - Private Registry
+        - Python
+    # Both MUST be empty for a pre-built image. If you set them, azd tries to
+    # rebuild the app from source and fails with an oryx/builder error.
+    project: ''
+    language: ''
+    # Replace with your own JFrog host, repository, and image tag.
+    image: mytenant.jfrog.io/<repository>/hello-world-jfrog-invocations:<tag>
+    uses:
+      - ai-project
+    kind: hosted
+    name: hello-world-jfrog-invocations
+    displayName: Hello World (Python, Invocations, JFrog)
+    description: Minimal Hello World agent using the Invocations protocol, deployed from a pre-built image hosted in a private JFrog Artifactory registry and pulled using Microsoft Entra workload identity federation.
+    protocols:
+      - protocol: invocations
+        version: 2.0.0
+    environmentVariables:
+      - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+        value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+    container:
+      resources:
+        cpu: '0.5'
+        memory: 1Gi
+infra:
+  provider: microsoft.foundry

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/deploy/create-agent-version.ps1
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/deploy/create-agent-version.ps1
@@ -10,6 +10,10 @@
 
     Run it AFTER `azd deploy` has created the agent.
 
+    TEMPORARY: this REST API step is a stopgap. The team is working to make the
+    sample completely deployable via azd; once registry connections are supported
+    in azure.yaml, `azd deploy` will handle this and the script will be removed.
+
     NOTE: `registry_connection_id` takes the connection NAME, not its full ARM
     resource ID. Passing the ARM ID returns an "invalid_payload" error.
 

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/deploy/create-agent-version.ps1
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/deploy/create-agent-version.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    Creates a hosted agent version that pulls its image from a private JFrog
+    registry, and routes the agent endpoint to that version.
+
+.DESCRIPTION
+    This script covers the one step azd cannot do yet: setting
+    `container_configuration.registry_connection_id` so Foundry knows which
+    connection authorizes the image pull.
+
+    Run it AFTER `azd deploy` has created the agent.
+
+    NOTE: `registry_connection_id` takes the connection NAME, not its full ARM
+    resource ID. Passing the ARM ID returns an "invalid_payload" error.
+
+.EXAMPLE
+    ./create-agent-version.ps1 `
+        -ProjectEndpoint https://my-account.services.ai.azure.com/api/projects/my-project `
+        -AgentName       hello-world-jfrog-invocations `
+        -Image           mytenant.jfrog.io/docker-local/hello-world-jfrog-invocations:1.0.0 `
+        -ModelDeployment gpt-5.4-mini
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$ProjectEndpoint,
+    [Parameter(Mandatory)][string]$AgentName,
+    [Parameter(Mandatory)][string]$Image,
+    [Parameter(Mandatory)][string]$ModelDeployment,
+    [string]$ConnectionName = 'jfrog-oidc-registry',
+    [string]$Cpu    = '0.5',
+    [string]$Memory = '1Gi',
+    [int]$TimeoutMinutes = 15
+)
+
+$ErrorActionPreference = 'Stop'
+$base = $ProjectEndpoint.TrimEnd('/')
+
+# --- 1. Create the version, attaching the registry connection -----------------
+$definition = @{
+    definition = @{
+        kind = 'hosted'
+        container_configuration = @{
+            image                  = $Image
+            registry_connection_id = $ConnectionName   # connection NAME, not ARM ID
+        }
+        cpu               = $Cpu
+        memory            = $Memory
+        protocol_versions = @(@{ protocol = 'invocations'; version = '2.0.0' })
+        environment_variables = @{ AZURE_AI_MODEL_DEPLOYMENT_NAME = $ModelDeployment }
+    }
+    description = 'Image pulled from private JFrog registry via Entra OIDC token exchange'
+} | ConvertTo-Json -Depth 12
+
+$verFile = Join-Path ([IO.Path]::GetTempPath()) 'foundry-agent-version.json'
+[IO.File]::WriteAllText($verFile, $definition)
+
+Write-Host "Creating agent version for '$AgentName' ..."
+$created = az rest --method post --resource 'https://ai.azure.com' `
+    --url "$base/agents/$AgentName/versions?api-version=v1" `
+    --headers 'Content-Type=application/json' --body "@$verFile" -o json | ConvertFrom-Json
+Remove-Item $verFile -Force
+
+$version = $created.version
+Write-Host "Created version $version (status: $($created.status))"
+
+# --- 2. Wait for the version to finish provisioning --------------------------
+# A version can report "active" before the container is actually ready, so also
+# require container_protocol_versions to be non-empty.
+$deadline = (Get-Date).AddMinutes($TimeoutMinutes)
+while ((Get-Date) -lt $deadline) {
+    Start-Sleep -Seconds 20
+    $v = az rest --method get --resource 'https://ai.azure.com' `
+        --url "$base/agents/$AgentName/versions/$version`?api-version=v1" -o json | ConvertFrom-Json
+
+    $ready = $v.status -eq 'active' -and $v.definition.container_protocol_versions.Count -gt 0
+    Write-Host "  status=$($v.status) protocols=$($v.definition.container_protocol_versions.Count)"
+
+    if ($v.status -eq 'failed') { throw "Provisioning failed: $($v.error.code) $($v.error.message)" }
+    if ($ready) { break }
+}
+
+# --- 3. Route the endpoint to this version -----------------------------------
+# Required: the endpoint defaults to the "responses" protocol even when the
+# version declares "invocations".
+$patch = @{
+    agent_endpoint = @{
+        version_selector = @{
+            version_selection_rules = @(
+                @{ agent_version = "$version"; traffic_percentage = 100; type = 'FixedRatio' }
+            )
+        }
+        protocol_configuration = @{ invocations = @{} }
+    }
+} | ConvertTo-Json -Depth 10
+
+$patchFile = Join-Path ([IO.Path]::GetTempPath()) 'foundry-agent-endpoint.json'
+[IO.File]::WriteAllText($patchFile, $patch)
+
+Write-Host "Routing endpoint to version $version ..."
+az rest --method patch --resource 'https://ai.azure.com' `
+    --url "$base/agents/$AgentName`?api-version=v1" `
+    --headers 'Content-Type=application/merge-patch+json' --body "@$patchFile" -o none
+Remove-Item $patchFile -Force
+
+Write-Host "Done. Invoke with: azd ai agent invoke `"What is Microsoft Foundry?`""

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/deploy/create-registry-connection.ps1
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/deploy/create-registry-connection.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+    Creates the Microsoft Foundry registry connection used to pull images from a
+    private JFrog Artifactory registry via Entra workload identity federation.
+
+.DESCRIPTION
+    Run this ONCE per Foundry project. The connection stores only non-secret OIDC
+    configuration (audience, token endpoint, provider name).
+
+    Never place a JFrog password, API key, reference token, or Docker "auth" value
+    in this connection. Foundry exchanges a short-lived Entra token at pull time.
+
+.EXAMPLE
+    ./create-registry-connection.ps1 `
+        -SubscriptionId  00000000-0000-0000-0000-000000000000 `
+        -ResourceGroup   my-rg `
+        -AccountName     my-foundry-account `
+        -ProjectName     my-project `
+        -JFrogHost       mytenant.jfrog.io `
+        -JFrogRepository docker-local `
+        -OidcAudience    11111111-1111-1111-1111-111111111111 `
+        -OidcProviderName my-entra-provider
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)][string]$SubscriptionId,
+    [Parameter(Mandatory)][string]$ResourceGroup,
+    [Parameter(Mandatory)][string]$AccountName,
+    [Parameter(Mandatory)][string]$ProjectName,
+    [Parameter(Mandatory)][string]$JFrogHost,
+    [Parameter(Mandatory)][string]$JFrogRepository,
+    # Application (client) ID of the Entra app registration used as the token audience.
+    [Parameter(Mandatory)][string]$OidcAudience,
+    # Name of the OIDC provider configured in JFrog.
+    [Parameter(Mandatory)][string]$OidcProviderName,
+    [string]$ConnectionName = 'jfrog-oidc-registry'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$target        = "https://$JFrogHost"
+$tokenEndpoint = "https://$JFrogHost/access/api/v1/oidc/token"
+
+# The CustomKeys credential type requires at least one key, so the non-secret OIDC
+# settings are stored there as well as in metadata.
+$payload = @{
+    properties = @{
+        authType      = 'CustomKeys'
+        category      = 'CustomKeys'
+        target        = $target
+        isSharedToAll = $false
+        credentials   = @{
+            keys = @{
+                audience      = $OidcAudience
+                tokenEndpoint = $tokenEndpoint
+                providerName  = $OidcProviderName
+            }
+        }
+        metadata = @{
+            type          = 'registry_connection'
+            mode          = 'OAuthTokenExchange'
+            audience      = $OidcAudience
+            tokenEndpoint = $tokenEndpoint
+            providerName  = $OidcProviderName
+            registryHost  = $JFrogHost
+            repository    = $JFrogRepository
+        }
+    }
+} | ConvertTo-Json -Depth 10
+
+$bodyFile = Join-Path ([IO.Path]::GetTempPath()) 'foundry-registry-connection.json'
+[IO.File]::WriteAllText($bodyFile, $payload)
+
+$uri = "https://management.azure.com/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup" +
+       "/providers/Microsoft.CognitiveServices/accounts/$AccountName/projects/$ProjectName" +
+       "/connections/$ConnectionName" + '?api-version=2025-10-01-preview'
+
+Write-Host "Creating registry connection '$ConnectionName' -> $target ..."
+az rest --method put --url $uri --headers 'Content-Type=application/json' --body "@$bodyFile" -o json
+
+Remove-Item $bodyFile -Force
+Write-Host "Done. Reference this connection by NAME ('$ConnectionName') when creating an agent version."

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/deploy/create-registry-connection.ps1
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/deploy/create-registry-connection.ps1
@@ -10,6 +10,11 @@
     Never place a JFrog password, API key, reference token, or Docker "auth" value
     in this connection. Foundry exchanges a short-lived Entra token at pull time.
 
+    TEMPORARY: creating this connection through the REST API is a stopgap. azd
+    cannot declare a registry connection today. The team is working to make this
+    completely deployable via azd, after which the connection will be declared in
+    azure.yaml and this script will be removed.
+
 .EXAMPLE
     ./create-registry-connection.ps1 `
         -SubscriptionId  00000000-0000-0000-0000-000000000000 `

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/.azdignore
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/.azdignore
@@ -1,0 +1,1 @@
+.env.example

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/.dockerignore
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/.dockerignore
@@ -1,0 +1,26 @@
+**/__pycache__/
+**/*.py[cod]
+**/*.egg-info/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# IDE settings
+.vscode/
+.idea/
+
+# Version control
+.git/
+.gitignore
+
+# Docker files
+.dockerignore
+
+# Docs
+README.md
+
+# Local environment (never bake credentials into the image)
+.env

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/.env.example
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/.env.example
@@ -1,0 +1,10 @@
+# Foundry project endpoint — auto-injected in hosted containers.
+# Only set manually if running without `azd ai agent run`.
+# FOUNDRY_PROJECT_ENDPOINT=https://<account>.services.ai.azure.com/api/projects/<project>
+
+# Model deployment name — must match a deployment in your Foundry project.
+AZURE_AI_MODEL_DEPLOYMENT_NAME=
+
+# Application Insights — auto-injected in hosted containers.
+# Set for local telemetry (optional but recommended).
+# APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/Dockerfile
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . user_agent/
+WORKDIR /app/user_agent
+RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+EXPOSE 8088
+
+# Precompile Python bytecode at build time so cold starts don't pay for it.
+# These base images ship almost none of the standard library precompiled
+# (~2% of stdlib .py files, on both Debian-slim and Azure Linux), so without
+# this every new container recompiles hundreds of stdlib modules on first
+# import. Dependencies are best-effort (`|| true`) so a stray unparsable file
+# vendored by a third-party package can't fail the build; application code is
+# compiled strictly so a syntax error surfaces at build time rather than at
+# container start.
+# PYTHONDONTWRITEBYTECODE is cleared for these commands only: it blocks
+# bytecode *writes*, not *reads*, so images that set it still benefit.
+RUN PYTHONDONTWRITEBYTECODE= python -m compileall -q $(python -c "import sysconfig as s; print(s.get_paths()['stdlib'], s.get_paths()['purelib'])") || true; \
+    PYTHONDONTWRITEBYTECODE= python -m compileall -q .
+
+CMD ["python", "main.py"]

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/main.py
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/main.py
@@ -1,0 +1,173 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Hello World — Bring Your Own Invocations agent.
+
+Minimal hosted agent that forwards user input to a Foundry model via the
+Responses API and returns the reply through the Invocations protocol.
+
+This sample demonstrates the simplest possible BYO integration: the protocol
+SDK (``azure-ai-agentserver-invocations``) handles the HTTP contract and
+session resolution, and you supply the model call using the Foundry SDK.
+
+Unlike the Responses protocol, the Invocations protocol does **not** provide
+built-in server-side conversation history. This agent maintains an in-memory
+session store keyed by ``agent_session_id``. In production, replace it with
+durable storage (Redis, Cosmos DB, etc.) so history survives restarts.
+
+Required environment variables:
+    FOUNDRY_PROJECT_ENDPOINT: Foundry project endpoint (auto-injected in hosted containers)
+    AZURE_AI_MODEL_DEPLOYMENT_NAME: Model deployment name (declared in agent.manifest.yaml)
+
+Usage::
+
+    # Set environment variables
+    export FOUNDRY_PROJECT_ENDPOINT="https://<account>.services.ai.azure.com/api/projects/<project>"
+    export AZURE_AI_MODEL_DEPLOYMENT_NAME="gpt-5.4-mini"
+
+    # Start the agent
+    python main.py
+
+    # Turn 1 — start a new conversation
+    curl -sS -N -X POST "http://localhost:8088/invocations?agent_session_id=chat-001" \\
+        -H "Content-Type: application/json" \\
+        -d '{"message": "What is Microsoft Foundry?"}'
+
+    # Turn 2 — continue the same conversation
+    curl -sS -N -X POST "http://localhost:8088/invocations?agent_session_id=chat-001" \\
+        -H "Content-Type: application/json" \\
+        -d '{"message": "What hosted agent options does it offer?"}'
+"""
+
+import json
+import logging
+import os
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse, StreamingResponse
+
+from azure.ai.projects.aio import AIProjectClient
+from azure.identity.aio import DefaultAzureCredential
+
+from azure.ai.agentserver.invocations import InvocationAgentServerHost
+
+logger = logging.getLogger(__name__)
+
+if not os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING"):
+    logger.warning(
+        "APPLICATIONINSIGHTS_CONNECTION_STRING not set — traces will not be sent to "
+        "Application Insights. Set it to enable local telemetry. "
+        "(This variable is auto-injected in hosted Foundry containers — do not declare it in agent.manifest.yaml.)"
+    )
+
+# Initialize Foundry project client — reads FOUNDRY_PROJECT_ENDPOINT.
+# FOUNDRY_PROJECT_ENDPOINT is auto-injected in hosted Foundry containers.
+# Locally, set it manually or use 'azd ai agent run' which sets it automatically.
+_endpoint = os.environ.get("FOUNDRY_PROJECT_ENDPOINT")
+if not _endpoint:
+    raise EnvironmentError(
+        "FOUNDRY_PROJECT_ENDPOINT environment variable is not set. "
+        "Set it to your Foundry project endpoint, or use 'azd ai agent run' "
+        "which sets it automatically."
+    )
+
+_model = os.environ.get("AZURE_AI_MODEL_DEPLOYMENT_NAME")
+if not _model:
+    raise EnvironmentError(
+        "AZURE_AI_MODEL_DEPLOYMENT_NAME environment variable is not set. "
+        "Set it to your model deployment name as declared in agent.manifest.yaml."
+    )
+
+_credential = DefaultAzureCredential()
+_project_client = AIProjectClient(endpoint=_endpoint, credential=_credential)
+
+# Use the Responses API — not chat.completions (Chat Completions API is legacy).
+_openai_client = _project_client.get_openai_client()
+
+_SYSTEM_PROMPT = "You are a helpful AI assistant. Be concise and informative."
+
+app = InvocationAgentServerHost()
+
+# In-memory session store — keyed by agent_session_id.
+# WARNING: state is lost on restart. Use durable storage in production.
+_history: list[dict[str, str]] = []
+
+# ── Required handler ──────────────────────────────────────────────────────────
+# @app.invoke_handler is the only handler you must implement. It receives every
+# POST /invocations request. The function name below is arbitrary.
+#
+# Two optional handlers exist for long-running operations (LRO):
+#   @app.get_invocation_handler    — handle GET /invocations/{id} status polls
+#   @app.cancel_invocation_handler — handle DELETE /invocations/{id} cancellation
+# For a simple streaming agent like this one, neither is needed.
+#
+# To serve an OpenAPI spec at GET /invocations/docs/openapi.json, pass it to
+# the host constructor: InvocationAgentServerHost(openapi_spec={...})
+# ─────────────────────────────────────────────────────────────────────────────
+@app.invoke_handler
+async def handle_invoke(request: Request):
+    """Handle a streaming multi-turn chat request."""
+    # Accept either a JSON object ({"message": "..."} or {"input": "..."}) or a
+    # plain-text body (e.g. sent directly from the Foundry portal chat UI).
+    try:
+        body = await request.body()
+        if not body:
+            raise ValueError("empty body")
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            user_message = body.decode("utf-8", errors="replace").strip()
+        else:
+            if isinstance(data, dict):
+                user_message = data.get("message") or data.get("input") or ""
+            else:
+                user_message = body.decode("utf-8", errors="replace").strip()
+        if not isinstance(user_message, str) or not user_message.strip():
+            raise ValueError("missing message text")
+    except ValueError:
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": "invalid_request",
+                "message": (
+                    'Request body must be a non-empty JSON object with a "message" (or "input") '
+                    'string, or a plain-text body, e.g. {"message": "What is Microsoft Foundry?"}'
+                ),
+            },
+        )
+
+    # The Invocations SDK resolves session and invocation identity from the
+    # incoming request headers and exposes them via request.state.
+    session_id = request.state.session_id
+    invocation_id = request.state.invocation_id
+
+    logger.info(
+        "Processing invocation %s (session %s)", invocation_id, session_id
+    )
+
+    # Retrieve or create conversation history for this session.
+    _history.append({"role": "user", "content": user_message})
+
+    async def event_generator():
+        full_reply = ""
+        async for event in await _openai_client.responses.create(
+            model=_model,
+            instructions="You are a helpful AI assistant.",
+            input=list(_history),
+            store=False,
+            stream=True,
+        ):
+            if event.type == "response.output_text.delta":
+                full_reply += event.delta
+                yield f"data: {json.dumps({'type': 'token', 'content': event.delta})}\n\n"
+
+        yield f"data: {json.dumps({'type': 'done', 'full_text': full_reply})}\n\n"
+        _history.append({"role": "assistant", "content": full_reply})
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache"},
+    )
+
+if __name__ == "__main__":
+    app.run()

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world-jfrog/src/hello-world-jfrog-invocations/requirements.txt
@@ -1,0 +1,12 @@
+aiohttp==3.13.5
+azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-projects==2.0.1
+azure-identity==1.25.3
+
+# azure-ai-projects imports httpx but does not declare it as a dependency.
+# Without this pin the container fails at startup with:
+#   ModuleNotFoundError: No module named 'httpx'
+httpx>=0.27,<1
+
+# debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
+debugpy


### PR DESCRIPTION
Adds a hosted-agent sample that deploys a pre-built image from a private JFrog Artifactory registry, authenticated with Microsoft Entra workload identity federation instead of stored registry credentials.

The sample mirrors the existing hello-world invocations agent and adds:

- README.md covering one-time setup (Entra audience app, project managed identity, JFrog OIDC provider and identity mapping, Foundry registry connection) and the per-deployment flow.
- azure.yaml configured for a pre-built image; project and language are intentionally empty so azd skips buildpacks and uses the image as-is.
- deploy/create-registry-connection.ps1 to create the registry connection.
- deploy/create-agent-version.ps1 to create the agent version with registry_connection_id and route the endpoint to it.

azd cannot yet attach a registry connection to an agent version, so one REST call is still required after azd deploy. This is documented in the README under "The temporary gap", which notes that the team is working to make the sample completely deployable via azd.

requirements.txt also pins httpx, which azure-ai-projects imports but does not declare; without it the container fails at startup.