### PR TITLE
Restore required trusted validation lane

### DIFF
--- a/.github/scripts/CLASSIFICATION.md
+++ b/.github/scripts/CLASSIFICATION.md
@@ -1,0 +1,103 @@
+# Sample validator classification contract
+
+Authoritative `failure`-vs-`error` contract for `.github/scripts/validate-sample.sh`.
+The public-first validation pipeline — and specifically the quarantine loop (P4.4) —
+**keys on this contract**. Read this before changing the classifier or anything that
+consumes its verdict.
+
+## Exit contract (three-way, load-bearing)
+
+| Exit | Verdict | Meaning | Downstream action |
+|------|---------|---------|-------------------|
+| `0`  | `pass`  | The requested mode passed: build readiness builds/compiles, or the declared live-service command exited 0. Live-service validation with no declaration is also a successful no-op. | none |
+| `1`  | `fail`  | **The SAMPLE is broken**, or a runtime failure we cannot positively attribute to our infra. | P4.4 may count a strike / quarantine (advisory-first). |
+| `2`  | `error` | **OUR INFRA is sick** — a precondition error, a dedicated dependency install with positively-identified transport failure, or a live-service command explicitly reporting caller/cloud infrastructure failure with exit 2. | Page us. **P4.4 must NEVER count or quarantine on `error`.** |
+
+The split is a safety interlock. A real breakage mislabeled `error` hides broken code forever
+(there is no counter behind `error`). A transient infra blip mislabeled `failure` risks
+quarantining a healthy sample. Both directions are dangerous; keep the split honest.
+
+## What is `error` (exit 2)
+
+**Precondition errors (validator can't even run the check):**
+- bad / missing CLI args; unknown or missing `--language`; missing or nonexistent `--sample-dir`
+- `sample.yaml` unreadable or malformed (`yq` read fails)
+- a declared `live_service_validation` block has an invalid shape, a required live-service environment variable is missing,
+  or the caller did not set `SKIP_PROVISION` to exactly `true` or `false`
+- a required toolchain binary missing from `PATH` (`require_tool`)
+- `yq` unavailable when a `sample.yaml` must be read
+- Python venv create/activate failure
+
+**Runtime infrastructure failures:**
+- a `pip install` or `npm install` that failed with **positive transport evidence**:
+  DNS failure, connection refused/reset, connect/read timeout, or a registry `5xx`.
+- a declared live-service command that explicitly exits `2` after identifying a known caller/cloud
+  infrastructure failure (for example credential, endpoint, or cloud transport failure).
+- Pip/npm detection lives in `dep_infra_signature()` — a **narrow allow-list of tool-specific
+  transport strings** (e.g. `ECONNREFUSED`, `ENOTFOUND`, `Temporary failure in name
+  resolution`, `Max retries exceeded`, `503 Server Error`). It is the authoritative signature
+  list for those dedicated install logs only; arbitrary live-service output never enters it.
+
+## What is `failure` (exit 1)
+
+- any `sample.yaml` build/validate/test command exits non-zero
+- a declared `sample.yaml` live-service command exits `1`
+- a declared live-service command exits with any unexpected nonzero status other than explicit error `2`
+- a live-service command exits `1` after printing transport-like application text such as
+  `503 Service Unavailable`; text alone never upgrades it to infrastructure error
+- a compile/build step fails: `dotnet build`, `mvn compile`, `gradle build`, `go build`,
+  `npm run build`, `node --check`, `py_compile`
+- a dependency install (`pip install` / `npm install`) fails **without** transport evidence —
+  i.e. a genuine resolution error: package does not exist, no matching version, version
+  conflict (`No matching distribution found`, npm `E404` / `ETARGET` / `ERESOLVE`).
+
+## Ambiguity-bias rule
+
+When a dependency-install failure shows **no** positive transport evidence, it is classified
+`failure`, **never** `pass`. Live-service commands must normalize a known infrastructure condition to
+exit `2`; output text is not interpreted. When we genuinely cannot tell an infra blip from a
+sample break, we bias to **`failure`**.
+
+Rationale — *recourse asymmetry*, not "strikes are cheap":
+- A false `error` has **no counter**: it silently hides real breakage forever.
+- A false `failure` is recoverable: P4.4 runs advisory-first, quarantine is strike-based, and a
+  human reviews before a sample moves.
+- We keep the transport allow-list **narrow** so false `failure`s stay rare in the first place —
+  we do not lean on the strike mechanism to absorb sloppiness (infra outages are correlated and
+  can survive multiple runs).
+
+Fail-loud (ADO 5247751 lesson): an indeterminate probe must resolve to a defined verdict. It
+never fails **open** to `pass`.
+
+## Honest v1 limits
+
+- Only the two **dedicated** dependency-install steps — `pip install` and `npm install` — are
+  inspected for transport evidence. The **merged resolve+compile tools** (`dotnet build`,
+  `mvn compile`, `gradle build`, `go build`, `npm run build`) interleave dependency download
+  with compilation and user scripts; grepping their combined output would manufacture false
+  `error`s, so in v1 they classify as `failure`. A network blip that strikes *during* one of
+  those merged steps can therefore be misread as a sample `failure`. This is a known limit, not
+  a bug — extending it needs tool-specific restore phases and is deferred.
+- `dep_infra_signature()` is a **narrow heuristic**, not a robust classifier. It matches known
+  transport strings and **will need maintenance** as runner `pip` / `npm` versions drift their
+  error wording. Unknown output stays `failure`.
+- **Blocked-registry / proxy `403`.** The transport allow-list catches connection-level failures
+  (DNS, refused/reset, timeout) and registry `5xx`, but **not** an HTTP `403 Forbidden` or a
+  blocked-page response from a policy proxy. This matters where a registry is deliberately fenced
+  off — e.g. Microsoft Security is blocking direct access to public npm registries on
+  Microsoft-managed devices, routing installs through a CFS-protected feed; a package still inside
+  the release-hold window can come back `403`/blocked. Such a block is arguably *infra*, but in v1
+  it classifies as `failure` (bias-to-`failure`, no false `error`). This is moot for the deliverable
+  itself — the pipeline runs on GitHub-hosted runners, not managed devices — but bites local runs on
+  managed devices. Promoting proxy-`403`/blocked-registry to `error` is deferred follow-up.
+
+## Proof
+
+The contract is exercised end-to-end on a real GitHub Actions runner by
+`.github/scripts/test/run-tests.sh` (invoked from the `validate-harness` job in
+`.github/workflows/scripts-selftest.yml`). It covers declared live-service pass, undeclared no-op,
+explicit live-service fail/error exits, unexpected nonzero failure, transport-like text that remains a
+failure, invalid declarations, missing caller environment, `GITHUB_OUTPUT`, and results files.
+The dependency checks separately prove that a forced-unreachable registry
+(`127.0.0.1:1` blackhole) classifies as `error` (exit 2), while an unaccompanied resolution
+failure classifies as `failure` (exit 1).

--- a/.github/scripts/detect-changed-samples.README.md
+++ b/.github/scripts/detect-changed-samples.README.md
@@ -1,0 +1,81 @@
+# How the changed-sample detector works
+
+Companion doc for [`detect-changed-samples.sh`](./detect-changed-samples.sh) — the in-job
+step (P1.2 of the public-first validation pipeline) that answers one question for the
+validation gate: **"which samples did this PR/push actually change?"** so we validate only
+those, not every sample in the tree.
+
+## The flow
+
+```mermaid
+flowchart TD
+    A["git diff:<br/>which FILES changed under samples/?"] --> B{diff succeeded?}
+    B -- "no (error)" --> X["exit non-zero<br/>FAIL LOUD — never guess"]
+    B -- "yes" --> C["For each changed file,<br/>walk UP to nearest sample.yaml dir"]
+    C --> D["Dedupe + sort → unique sample set"]
+    D --> E["Emit 3 outputs:<br/>has_changes · count · samples (JSON)"]
+    E --> F["Downstream job reads<br/>needs.detect.outputs.*"]
+    F --> G{"has_changes?"}
+    G -- "false (docs-only)" --> H["short-circuit — validate nothing"]
+    G -- "true" --> I["validate each sample in the set"]
+```
+
+## The five moves
+
+1. **Diff** — `git diff <base> HEAD -- samples/`. Base is: an explicit `--base-ref`, else
+   `origin/<target>` for PRs, else `HEAD~1` for push.
+2. **Walk up** — a file matters only if it lives under a folder containing a `sample.yaml`.
+   That marker file *defines* a sample; the loop climbs to the nearest one. Files with no
+   `sample.yaml` above them (docs, shared infra) contribute nothing.
+3. **Dedupe** — many changed files in one sample collapse to one entry; output is
+   sorted and deterministic.
+4. **Emit** — three values to three places: the run log (humans), `$GITHUB_OUTPUT` (the
+   next job), and optionally disk via `--output-dir` (tests).
+5. **Hand off** — a downstream job reads `needs.<detect-job>.outputs.*` and either
+   short-circuits (empty) or validates the set.
+
+## The one rule that matters most
+
+**"I couldn't look" must never look like "nothing changed."** If the diff errors, the
+script exits non-zero and stops — it refuses to emit an empty set. An empty set is only ever
+produced by a diff that *succeeded* and genuinely found no sample touched. (This is the scar
+from ADO 5247751 — a silent empty diff once let an unvalidated change through the gate.)
+
+## The contract
+
+| | |
+|---|---|
+| **Input** | samples root (`--samples-root`, default `samples`), a base ref (explicit `--base-ref` or derived from the GitHub event) |
+| **Outputs** | `has_changes` (true/false) · `count` (int) · `samples` (JSON array of dirs) |
+| **Exit code** | `0` = detection ran (set may be empty) · non-zero = couldn't run (never "nothing changed") |
+| **Requires** | every sample directory has a `sample.yaml` — that's a hard contract, not a convention |
+
+To be consumable as `needs.<job>.outputs.*`, the emitting step needs an `id`, **and** the job
+must re-export the step outputs under its own `outputs:` block. Writing `$GITHUB_OUTPUT` alone
+is necessary but not sufficient. See the `detect`→`consume` jobs in `scripts-selftest.yml` for the wiring.
+
+## Known sharp edges (tracked, not blockers)
+
+These are accepted characteristics of a faithful port of the frozen ADO `DetectChanges`
+design — documented in-code in the "Known limitations" block above `resolve_base_ref`.
+
+- **Base-ref selection** — two-dot PR diff (can over-validate when the target advances),
+  `HEAD~1` on a multi-commit push (misses earlier commits), best-effort fetch (can pass on a
+  stale ref). Tracked: ADO 5473511 —
+  https://msdata.visualstudio.com/Vienna/_workitems/edit/5473511
+- **Post-diff fail-loud coverage** — only the `git diff` stage is provably fail-loud today;
+  the `sort`/`mktemp`/emit pipeline and exotic (control-char) filenames are the gap. Tracked:
+  ADO 5473651 — https://msdata.visualstudio.com/Vienna/_workitems/edit/5473651
+
+## Where it's proven
+
+Scripts self-test workflow ([`../workflows/scripts-selftest.yml`](../workflows/scripts-selftest.yml),
+`contents: read`, no secrets/OIDC), triggered on any PR touching `.github/scripts/**`: a hermetic
+check harness ([`test/run-detect-tests.sh`](./test/run-detect-tests.sh)) proves the detection cases
+plus the docs-only empty-set / `$GITHUB_OUTPUT` hygiene contract, and a real-runner `detect`→`consume`
+job proves a changed-sample payload flows through `needs.*.outputs` uncorrupted.
+
+## Related
+
+- Port source: the private ADO `validation.yml` **`DetectChanges`** stage.
+- Parent work item: ADO 5449686 — https://msdata.visualstudio.com/Vienna/_workitems/edit/5449686

--- a/.github/scripts/detect-changed-samples.sh
+++ b/.github/scripts/detect-changed-samples.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# detect-changed-samples.sh — reusable in-job change detector for the public-first
+# validation pipeline. Ports the private ADO `DetectChanges` stage (job AnalyzeChanges,
+# step detectChanges) from .azure-pipelines/validation.yml into a GitHub-Actions-native,
+# dependency-light script (git + coreutils only).
+#
+# Single responsibility: answer "which sample directories were affected by this push/PR?"
+# by mapping every changed file under <samples-root>/ to its NEAREST ANCESTOR sample.yaml
+# directory, then deduping. The caller (P2.1/P2.2 validate lanes) consumes the result as
+# GitHub Actions job outputs via needs.<detect>.outputs.* and fans out — deriving each
+# sample's --language from its path (samples/<language>/...); this script deliberately does
+# NOT pre-group by language (see "Design" below).
+#
+# Usage:
+#   detect-changed-samples.sh [--base-ref <ref>] [--event <pull_request|push|dispatch>]
+#                             [--target-branch <branch>] [--samples-root samples]
+#                             [--output-dir <dir>] [--print-base-ref]
+#
+# Base-ref resolution (faithful to ADO DetectChanges):
+#   --base-ref <ref>     wins outright (used by tests + callers that already know the base).
+#   event pull_request   git fetch origin <target> (best-effort) then BASE_REF=origin/<target>,
+#                        where <target> is --target-branch or $GITHUB_BASE_REF.
+#   otherwise (push/etc) BASE_REF=HEAD~1.
+#
+# Outputs (the contract P2 consumes):
+#   has_changes  "true" | "false"   — false == docs-only / no sample touched (short-circuit flag)
+#   count        integer            — number of affected sample dirs
+#   samples      JSON array         — deduped, sorted affected sample dirs (repo-relative)
+# Written to $GITHUB_OUTPUT when set; always printed to stdout. When --output-dir is given,
+# also writes changed_files.txt + unique_changed_samples.txt (mirrors ADO's artifacts).
+#
+# Exit codes (2-way — intentionally simpler than validate-sample.sh's 0/1/2 classifier;
+# detection has no "sample broken" tier):
+#   0  OK      detection completed — INCLUDING an empty (docs-only) result.
+#   1  ERROR   fail loud: bad args, not a git repo, or the git diff itself errored.
+#
+# FAIL-LOUD invariant (ADO 5247751 lesson): a git diff *error* must NEVER be swallowed into
+# an empty "nothing changed" result — that fail-opens the sync gate. A diff that SUCCEEDS
+# with zero lines is legitimate docs-only (has_changes=false, exit 0). The two are never
+# conflated: only `git diff` returning non-zero triggers the exit-1 refusal below.
+#
+# NOTE: `set -e` is intentionally NOT used; error paths are routed through error() so no
+# external command can abort the script with an unclassified status.
+set -uo pipefail
+
+BASE_REF=""
+EVENT=""
+TARGET_BRANCH=""
+SAMPLES_ROOT="samples"
+OUTPUT_DIR=""
+PRINT_BASE_REF=false
+
+usage() {
+    cat <<'EOF'
+Usage: detect-changed-samples.sh [options]
+
+  --base-ref <ref>        Explicit base ref to diff HEAD against (overrides resolution).
+  --event <name>          Event kind: pull_request | push | dispatch (default: $GITHUB_EVENT_NAME or push).
+  --target-branch <br>    PR target branch (default: $GITHUB_BASE_REF). Used only for pull_request.
+  --samples-root <dir>    Root under which samples live (default: samples).
+  --output-dir <dir>      If set, write changed_files.txt + unique_changed_samples.txt here.
+  --print-base-ref        Resolve and print the base ref, then exit 0 (no fetch, no diff).
+
+Exit codes: 0 = detection ok (incl. empty/docs-only), 1 = error (fail loud).
+EOF
+}
+
+# error <reason>: fail loud — print to stderr and exit 1. Never emit a fake empty result.
+error() {
+    echo "ERROR: ${1:-detection failure}" >&2
+    exit 1
+}
+
+# --- Argument parsing --------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --base-ref)      BASE_REF="${2:-}";      shift $(( $# > 1 ? 2 : 1 )) ;;
+        --event)         EVENT="${2:-}";         shift $(( $# > 1 ? 2 : 1 )) ;;
+        --target-branch) TARGET_BRANCH="${2:-}"; shift $(( $# > 1 ? 2 : 1 )) ;;
+        --samples-root)  SAMPLES_ROOT="${2:-}";  shift $(( $# > 1 ? 2 : 1 )) ;;
+        --output-dir)    OUTPUT_DIR="${2:-}";    shift $(( $# > 1 ? 2 : 1 )) ;;
+        --print-base-ref) PRINT_BASE_REF=true;   shift ;;
+        -h|--help)       usage; exit 0 ;;
+        *)               usage >&2; error "unknown argument: $1" ;;
+    esac
+done
+
+# --- Guards ------------------------------------------------------------------
+git rev-parse --git-dir >/dev/null 2>&1 || error "not a git repository (cwd=$(pwd))"
+[ -n "$SAMPLES_ROOT" ] || error "missing/empty --samples-root"
+SAMPLES_ROOT="${SAMPLES_ROOT%/}"
+
+# --- Base-ref resolution -----------------------------------------------------
+# Known limitations (faithful port of the frozen ADO DetectChanges design; see
+# the P1.2 close-out for the risk analysis). These are documented, accepted
+# characteristics — not bugs — but the next engineer should know the sharp edges:
+#
+#   1. PR diff is TWO-DOT (`diff origin/<target> HEAD`), not merge-base
+#      (three-dot). If <target> advances after the PR diverged, the diff can
+#      surface files the PR never touched -> extra samples validated. This is a
+#      FALSE POSITIVE (wasteful, never fail-open) and is usually neutralized by
+#      GitHub's synthetic PR merge-commit checkout (refs/pull/N/merge).
+#
+#   2. Non-PR (push/dispatch) base is `HEAD~1` -> only the FINAL commit
+#      transition. A direct multi-commit push can miss samples changed in
+#      earlier commits (the event's `before` SHA is ignored). Merge/squash
+#      commits are fine (HEAD~1 first-parent captures the whole delta). This is
+#      the one direction that could FALSE-NEGATIVE on the push path.
+#
+#   3. The fetch below is BEST-EFFORT (`|| true`). If a fresh fetch fails but a
+#      stale `origin/<target>` already exists, the diff runs against the stale
+#      ref -> exit 0 with a wrong answer. Only fails loud when NO usable ref
+#      remains. Low-probability on a fresh runner (checkout populates the ref
+#      seconds earlier) but in tension with the fail-loud principle (ADO 5247751).
+#
+# Tracked refinement (base-ref robustness): use github.event.before on push and
+# stop swallowing fetch failure. Do NOT change the frozen logic here ad hoc.
+resolve_base_ref() {
+    if [ -n "$BASE_REF" ]; then
+        echo "$BASE_REF"
+        return 0
+    fi
+    local ev="$EVENT"
+    [ -n "$ev" ] || ev="${GITHUB_EVENT_NAME:-push}"
+    if [ "$ev" = "pull_request" ]; then
+        local target="$TARGET_BRANCH"
+        [ -n "$target" ] || target="${GITHUB_BASE_REF:-}"
+        [ -n "$target" ] || error "pull_request event but no target branch (--target-branch / \$GITHUB_BASE_REF)"
+        # Best-effort fetch (ADO parity). If offline/absent, the diff below fails loud.
+        if [ "$PRINT_BASE_REF" != true ]; then
+            git fetch origin "$target" --quiet 2>/dev/null || true
+        fi
+        echo "origin/$target"
+    else
+        echo "HEAD~1"
+    fi
+}
+
+BASE_REF="$(resolve_base_ref)" || exit 1
+
+if [ "$PRINT_BASE_REF" = true ]; then
+    echo "$BASE_REF"
+    exit 0
+fi
+
+# --- Diff (FAIL LOUD on error; empty-but-successful is legit docs-only) -------
+CHANGED_FILES="$(mktemp)"
+trap 'rm -f "$CHANGED_FILES"' EXIT
+# core.quotepath=false keeps non-ASCII paths literal (no octal escaping) so dirname works.
+if ! git -c core.quotepath=false diff --name-only "$BASE_REF" HEAD -- "$SAMPLES_ROOT/" > "$CHANGED_FILES"; then
+    error "git diff '$BASE_REF'..HEAD failed; refusing to continue with an empty change set (would fail-open the gate)"
+fi
+
+# --- Walk each changed file UP to its nearest ancestor sample.yaml dir --------
+UNIQUE="$(mktemp)"
+trap 'rm -f "$CHANGED_FILES" "$UNIQUE"' EXIT
+{
+    while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        dir="$(dirname "$f")"
+        while [ "$dir" != "$SAMPLES_ROOT" ] && [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+            if [ -f "$dir/sample.yaml" ]; then
+                echo "$dir"
+                break
+            fi
+            dir="$(dirname "$dir")"
+        done
+    done < "$CHANGED_FILES"
+} | sort -u > "$UNIQUE"
+
+# --- Compute outputs ---------------------------------------------------------
+# `grep -c . file` prints 0 AND exits 1 on an empty file; a `|| echo 0` fallback
+# then double-prints, making COUNT="0\n0". That later leaks a bare "0" line into
+# $GITHUB_OUTPUT, which GitHub Actions rejects ("Invalid format '0'") — crashing
+# the detect step on any docs-only PR. Guard on file-non-empty so COUNT is always
+# a single clean integer.
+if [ -s "$UNIQUE" ]; then
+    COUNT="$(grep -c . "$UNIQUE")"
+else
+    COUNT=0
+fi
+if [ "$COUNT" -gt 0 ]; then HAS_CHANGES="true"; else HAS_CHANGES="false"; fi
+
+# Build a JSON array (dependency-light; escape backslash and double-quote).
+json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+SAMPLES_JSON="["
+first=true
+while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    if [ "$first" = true ]; then first=false; else SAMPLES_JSON="$SAMPLES_JSON,"; fi
+    SAMPLES_JSON="$SAMPLES_JSON\"$(json_escape "$line")\""
+done < "$UNIQUE"
+SAMPLES_JSON="$SAMPLES_JSON]"
+
+# --- Emit --------------------------------------------------------------------
+echo "=== detect-changed-samples: base=$BASE_REF root=$SAMPLES_ROOT ==="
+echo "has_changes=$HAS_CHANGES"
+echo "count=$COUNT"
+echo "samples=$SAMPLES_JSON"
+if [ "$COUNT" -gt 0 ]; then
+    echo "affected sample dirs:"
+    sed 's/^/  - /' "$UNIQUE"
+else
+    echo "no affected samples (docs-only / nothing under a sample.yaml) — short-circuit"
+fi
+
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    {
+        echo "has_changes=$HAS_CHANGES"
+        echo "count=$COUNT"
+        echo "samples=$SAMPLES_JSON"
+    } >> "$GITHUB_OUTPUT"
+fi
+
+if [ -n "$OUTPUT_DIR" ]; then
+    mkdir -p "$OUTPUT_DIR" || error "could not create --output-dir: $OUTPUT_DIR"
+    cp "$CHANGED_FILES" "$OUTPUT_DIR/changed_files.txt"
+    cp "$UNIQUE" "$OUTPUT_DIR/unique_changed_samples.txt"
+fi
+
+exit 0

--- a/.github/scripts/test/.gitignore
+++ b/.github/scripts/test/.gitignore
@@ -1,0 +1,14 @@
+# Transient toolchain/build artifacts the harness drops into fixtures when it
+# actually builds them on a real runner (or locally). Nothing generated should
+# be committed — the fixtures are the sources, not their build output.
+bin/
+obj/
+.venv/
+node_modules/
+package-lock.json
+target/
+_results*/
+*.out
+# Go leaves no in-tree binary for `go build ./...`, but guard the single-package form.
+go-good/gogood
+go-broken/gobroken

--- a/.github/scripts/test/fixtures/csharp-broken/App.csproj
+++ b/.github/scripts/test/fixtures/csharp-broken/App.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- BROKEN C# fixture: Program.cs has a compile error, so `dotnet build`
+       exits non-zero -> FAIL (exit 1). The sample is broken, not our infra. -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/.github/scripts/test/fixtures/csharp-broken/Program.cs
+++ b/.github/scripts/test/fixtures/csharp-broken/Program.cs
@@ -1,0 +1,9 @@
+public static class Program
+{
+    public static void Main()
+    {
+        // Deliberate compile error: missing expression after '='.
+        int x =;
+        System.Console.WriteLine(x);
+    }
+}

--- a/.github/scripts/test/fixtures/csharp-good/App.csproj
+++ b/.github/scripts/test/fixtures/csharp-good/App.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- GOOD C# fixture: compiles cleanly. Exercises default_validate_csharp's
+       `dotnet build` path (no sample.yaml) -> PASS (exit 0). -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/.github/scripts/test/fixtures/csharp-good/Program.cs
+++ b/.github/scripts/test/fixtures/csharp-good/Program.cs
@@ -1,0 +1,7 @@
+public static class Program
+{
+    public static void Main()
+    {
+        System.Console.WriteLine("csharp-good: ok");
+    }
+}

--- a/.github/scripts/test/fixtures/csharp-yaml-broken/sample.yaml
+++ b/.github/scripts/test/fixtures/csharp-yaml-broken/sample.yaml
@@ -1,0 +1,3 @@
+name: csharp-yaml-broken
+description: Fixture whose validate command exits non-zero (a broken sample => FAIL). Exercises the shared run_sample_yaml path.
+validate: "false"

--- a/.github/scripts/test/fixtures/csharp-yaml-good/sample.yaml
+++ b/.github/scripts/test/fixtures/csharp-yaml-good/sample.yaml
@@ -1,0 +1,3 @@
+name: csharp-yaml-good
+description: Fixture that declares a trivial passing validate command (exit 0). Exercises the shared run_sample_yaml path (needs yq, no toolchain).
+validate: "true"

--- a/.github/scripts/test/fixtures/go-broken/go.mod
+++ b/.github/scripts/test/fixtures/go-broken/go.mod
@@ -1,0 +1,3 @@
+module example.com/gobroken
+
+go 1.21

--- a/.github/scripts/test/fixtures/go-broken/main.go
+++ b/.github/scripts/test/fixtures/go-broken/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func main() {
+	// Deliberate compile error: undefinedVar is not declared.
+	fmt.Println(undefinedVar)
+}

--- a/.github/scripts/test/fixtures/go-good/go.mod
+++ b/.github/scripts/test/fixtures/go-good/go.mod
@@ -1,0 +1,3 @@
+module example.com/gogood
+
+go 1.21

--- a/.github/scripts/test/fixtures/go-good/main.go
+++ b/.github/scripts/test/fixtures/go-good/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("go-good: ok")
+}

--- a/.github/scripts/test/fixtures/java-broken/pom.xml
+++ b/.github/scripts/test/fixtures/java-broken/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- BROKEN Java fixture: App.java has a compile error, so `mvn compile`
+       exits non-zero -> FAIL. -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>java-broken</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/.github/scripts/test/fixtures/java-broken/src/main/java/App.java
+++ b/.github/scripts/test/fixtures/java-broken/src/main/java/App.java
@@ -1,0 +1,7 @@
+public class App {
+    public static void main(String[] args) {
+        // Deliberate compile error: missing expression after '='.
+        int x =;
+        System.out.println(x);
+    }
+}

--- a/.github/scripts/test/fixtures/java-good/pom.xml
+++ b/.github/scripts/test/fixtures/java-good/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!-- GOOD Java fixture: compiles cleanly via `mvn compile` -> PASS. No external
+       dependencies; Maven still fetches the compiler plugin from Central. -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>java-good</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/.github/scripts/test/fixtures/java-good/src/main/java/App.java
+++ b/.github/scripts/test/fixtures/java-good/src/main/java/App.java
@@ -1,0 +1,5 @@
+public class App {
+    public static void main(String[] args) {
+        System.out.println("java-good: ok");
+    }
+}

--- a/.github/scripts/test/fixtures/legacy-l4/sample.yaml
+++ b/.github/scripts/test/fixtures/legacy-l4/sample.yaml
@@ -1,0 +1,4 @@
+name: legacy-l4
+description: Legacy metadata must fail with an actionable migration message.
+l4:
+  command: "true"

--- a/.github/scripts/test/fixtures/live-service-cold/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-cold/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-cold
+description: Hermetic live-service fixture proving the validator preserves cold-cadence semantics.
+live_service_validation:
+  command: 'test "$SKIP_PROVISION" = "false"'

--- a/.github/scripts/test/fixtures/live-service-fail/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-fail/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-fail
+description: Hermetic live-service fixture whose sample assertion explicitly reports failure.
+live_service_validation:
+  command: "echo 'sample assertion failed'; exit 1"

--- a/.github/scripts/test/fixtures/live-service-good/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-good/sample.yaml
@@ -1,0 +1,6 @@
+name: live-service-good
+description: Hermetic live-service fixture proving caller environment and SKIP_PROVISION are inherited.
+live_service_validation:
+  command: 'test "$LIVE_SERVICE_TEST_ENDPOINT" = "https://stub.invalid" && test "$SKIP_PROVISION" = "true"'
+  required_env:
+    - LIVE_SERVICE_TEST_ENDPOINT

--- a/.github/scripts/test/fixtures/live-service-infra/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-infra/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-infra
+description: Hermetic live-service fixture whose command normalizes known caller infrastructure failure.
+live_service_validation:
+  command: "echo 'known caller infrastructure failure' >&2; exit 2"

--- a/.github/scripts/test/fixtures/live-service-invalid-env/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-invalid-env/sample.yaml
@@ -1,0 +1,5 @@
+name: live-service-invalid-env
+description: Hermetic live-service fixture whose required_env field is not a string list.
+live_service_validation:
+  command: "true"
+  required_env: LIVE_SERVICE_TEST_ENDPOINT

--- a/.github/scripts/test/fixtures/live-service-invalid/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-invalid/sample.yaml
@@ -1,0 +1,3 @@
+name: live-service-invalid
+description: Hermetic live-service fixture with an invalid scalar declaration.
+live_service_validation: "true"

--- a/.github/scripts/test/fixtures/live-service-malformed/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-malformed/sample.yaml
@@ -1,0 +1,3 @@
+name: live-service-malformed
+live_service_validation:
+  command: "unterminated

--- a/.github/scripts/test/fixtures/live-service-missing-command/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-missing-command/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-missing-command
+description: Hermetic live-service fixture with a mapping that omits the required command.
+live_service_validation:
+  required_env: []

--- a/.github/scripts/test/fixtures/live-service-transport-like/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-transport-like/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-transport-like
+description: Transport-like application output must not override an explicit sample failure.
+live_service_validation:
+  command: "echo '503 Service Unavailable: sample response assertion failed' >&2; exit 1"

--- a/.github/scripts/test/fixtures/live-service-unexpected/sample.yaml
+++ b/.github/scripts/test/fixtures/live-service-unexpected/sample.yaml
@@ -1,0 +1,4 @@
+name: live-service-unexpected
+description: Unexpected nonzero live-service statuses conservatively classify as sample failure.
+live_service_validation:
+  command: "echo 'unexpected sample command status' >&2; exit 7"

--- a/.github/scripts/test/fixtures/python-broken/main.py
+++ b/.github/scripts/test/fixtures/python-broken/main.py
@@ -1,0 +1,3 @@
+def main(:
+    # Deliberate syntax error above (bad def) so `python -m py_compile` fails.
+    print("python-broken")

--- a/.github/scripts/test/fixtures/python-deps/requirements.txt
+++ b/.github/scripts/test/fixtures/python-deps/requirements.txt
@@ -1,0 +1,6 @@
+# P1.3 fixture (ADO 5449687): a REAL, normally-resolvable package so that a forced-unreachable
+# index makes pip emit transport evidence AND its misleading "No matching distribution"
+# conclusion — proving transport evidence wins (ERROR). Reused with PIP_NO_INDEX + an empty
+# --find-links to prove an unaccompanied resolution failure stays FAIL. Never actually
+# installed in either case.
+requests

--- a/.github/scripts/test/fixtures/python-good/main.py
+++ b/.github/scripts/test/fixtures/python-good/main.py
@@ -1,0 +1,6 @@
+def main() -> None:
+    print("python-good: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test/fixtures/typescript-broken/package.json
+++ b/.github/scripts/test/fixtures/typescript-broken/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "typescript-broken",
+  "version": "1.0.0",
+  "private": true,
+  "description": "BROKEN TS/JS fixture: npm run build exits non-zero -> FAIL. No deps so the failure is the build step, not dependency resolution.",
+  "scripts": {
+    "build": "node -e \"process.exit(1)\""
+  }
+}

--- a/.github/scripts/test/fixtures/typescript-deps/package.json
+++ b/.github/scripts/test/fixtures/typescript-deps/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "typescript-deps",
+  "version": "1.0.0",
+  "private": true,
+  "description": "P1.3 fixture (ADO 5449687): declares a dependency so `npm install` must contact the registry. Pointed at a forced-unreachable registry to prove a transport failure classifies as ERROR (exit 2), never FAIL.",
+  "dependencies": {
+    "is-odd": "3.0.1"
+  },
+  "scripts": {
+    "build": "node -e \"process.exit(0)\""
+  }
+}

--- a/.github/scripts/test/fixtures/typescript-good/package.json
+++ b/.github/scripts/test/fixtures/typescript-good/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "typescript-good",
+  "version": "1.0.0",
+  "private": true,
+  "description": "GOOD TS/JS fixture: npm run build exits 0 -> PASS. No deps so npm install is a no-op.",
+  "scripts": {
+    "build": "node -e \"process.exit(0)\""
+  }
+}

--- a/.github/scripts/test/run-detect-tests.sh
+++ b/.github/scripts/test/run-detect-tests.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# run-detect-tests.sh — hermetic exit gate for detect-changed-samples.sh.
+#
+# Sibling to run-tests.sh (the P1.1 validator harness). Where that harness needs real
+# toolchains, THIS one needs only git + coreutils, so it runs fully GREEN both locally
+# and on a runner — no BLOCKED-on-env cases. It builds a throwaway git repo with a
+# crafted samples/ tree, makes controlled commits, and asserts the detector's outputs
+# over specific base..HEAD ranges.
+#
+# Proves the three acceptance criteria of ADO 5449686 plus the fail-loud invariant:
+#   (a) a changed file inside a sample resolves to that sample's nearest sample.yaml dir
+#   (b) a docs-only change yields has_changes=false / samples=[] / exit 0  (short-circuit)
+#   (c) multiple changed files in one sample dir dedupe to a single entry
+#   (d) a deeply-nested changed file resolves to its nearest ancestor sample.yaml (walk-up)
+#   (e) two different samples changed -> both present, sorted
+#   (f) FAIL LOUD: a nonexistent base ref makes git diff error -> exit 1 (ADO 5247751)
+#   (g) base-ref RESOLUTION: pull_request -> origin/<target>, push -> HEAD~1 (--print-base-ref)
+#   (h) GITHUB_OUTPUT hygiene: an empty (docs-only) result writes clean count=0 /
+#       has_changes=false / samples=[] with no bare-'0' line (grep -c regression guard)
+# Also asserts --output-dir writes changed_files.txt + unique_changed_samples.txt.
+set -uo pipefail
+
+# The unit harness asserts on the detector's STDOUT only. It must NOT leak into the
+# runner's real $GITHUB_OUTPUT — otherwise the ~10 detector invocations below append
+# has_changes/count/samples lines to the step's output file and GitHub rejects it
+# ("Unable to process file command 'output'"). The GITHUB_OUTPUT emission is proven
+# separately by the detect->consume plumbing job in the selftest workflow.
+unset GITHUB_OUTPUT GITHUB_ENV GITHUB_STATE 2>/dev/null || true
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../detect-changed-samples.sh"
+
+PASS_N=0
+FAIL_N=0
+
+pass() { echo "  PASS  $1"; PASS_N=$((PASS_N + 1)); }
+fail() { echo "  FAIL  $1"; FAIL_N=$((FAIL_N + 1)); }
+
+# run_detect <base-ref> [extra args...] -> populates OUT (stdout+stderr) and RC.
+run_detect() {
+    local base="$1"; shift
+    OUT="$(bash "$SCRIPT" --base-ref "$base" "$@" 2>&1)"
+    RC=$?
+}
+
+# field <key> — extract the last `key=value` line the script printed to stdout.
+field() { printf '%s\n' "$OUT" | sed -n "s/^$1=\(.*\)$/\1/p" | tail -1; }
+
+# expect_out <desc> <expected-value> — assert the `samples=` JSON equals expected.
+expect_samples() {
+    local desc="$1" want="$2" got
+    got="$(field samples)"
+    if [ "$got" = "$want" ]; then pass "$desc  (samples=$got)"; else fail "$desc  expected samples=$want got=${got:-<none>}"; fi
+}
+expect_field() {
+    local desc="$1" key="$2" want="$3" got
+    got="$(field "$key")"
+    if [ "$got" = "$want" ]; then pass "$desc  ($key=$got)"; else fail "$desc  expected $key=$want got=${got:-<none>}"; fi
+}
+expect_rc() {
+    local desc="$1" want="$2"
+    if [ "$RC" = "$want" ]; then pass "$desc  (exit=$RC)"; else fail "$desc  expected exit=$want got=$RC"; fi
+}
+
+# --- Build a throwaway git repo with a crafted samples/ tree -----------------
+REPO="$(mktemp -d)"
+trap 'rm -rf "$REPO"' EXIT
+cd "$REPO" || { echo "cannot cd to temp repo"; exit 1; }
+
+git init -q
+git config user.email t@t.test
+git config user.name  test
+git config commit.gpgsign false
+
+mkdir -p samples/python/quickstart/foo
+mkdir -p samples/csharp/quickstart/bar
+mkdir -p samples/python/deep/a/b/c/src
+mkdir -p samples/docs                      # docs area under samples/, NO sample.yaml
+printf 'name: foo\n'  > samples/python/quickstart/foo/sample.yaml
+printf 'print("v1")\n' > samples/python/quickstart/foo/main.py
+printf 'name: bar\n'  > samples/csharp/quickstart/bar/sample.yaml
+printf 'x\n'          > samples/csharp/quickstart/bar/Program.cs
+printf 'y\n'          > samples/csharp/quickstart/bar/extra.cs
+printf 'name: deep\n' > samples/python/deep/a/b/c/sample.yaml
+printf 'deep\n'       > samples/python/deep/a/b/c/src/x.py
+printf '# top\n'      > samples/docs/README.md
+printf '# repo\n'     > README.md            # root doc, entirely outside samples/
+git add -A >/dev/null
+git commit -qm "base"
+BASE="$(git rev-parse HEAD)"
+
+echo "=============================================================="
+echo " detect-changed-samples: acceptance cases (git + coreutils only)"
+echo "=============================================================="
+
+# (a) change a file inside foo -> resolves to foo
+printf 'print("v2")\n' > samples/python/quickstart/foo/main.py
+git commit -qam "touch foo/main.py"
+run_detect "$BASE"
+expect_rc      "(a) changed sample -> ok"                 0
+expect_field   "(a) has_changes true"        has_changes  true
+expect_field   "(a) count 1"                 count        1
+expect_samples "(a) resolves to foo"         '["samples/python/quickstart/foo"]'
+BASE="$(git rev-parse HEAD)"
+
+# (b) docs-only: change a file under samples/ with no sample.yaml ancestor + a root doc
+printf '# top v2\n' > samples/docs/README.md
+printf '# repo v2\n' > README.md
+git commit -qam "docs only"
+run_detect "$BASE"
+expect_rc      "(b) docs-only -> ok"                      0
+expect_field   "(b) has_changes false"      has_changes   false
+expect_field   "(b) count 0"                count         0
+expect_samples "(b) empty set"              '[]'
+BASE="$(git rev-parse HEAD)"
+
+# (c) multiple files in ONE sample dir -> dedupe to a single entry
+printf 'x2\n' > samples/csharp/quickstart/bar/Program.cs
+printf 'y2\n' > samples/csharp/quickstart/bar/extra.cs
+git commit -qam "two files in bar"
+run_detect "$BASE"
+expect_rc      "(c) multi-file one dir -> ok"             0
+expect_field   "(c) count 1 (deduped)"      count         1
+expect_samples "(c) single bar entry"       '["samples/csharp/quickstart/bar"]'
+BASE="$(git rev-parse HEAD)"
+
+# (d) deeply-nested changed file -> nearest ancestor sample.yaml (walk-up)
+printf 'deep v2\n' > samples/python/deep/a/b/c/src/x.py
+git commit -qam "nested deep change"
+run_detect "$BASE"
+expect_rc      "(d) nested -> ok"                         0
+expect_samples "(d) walks up to c"          '["samples/python/deep/a/b/c"]'
+BASE="$(git rev-parse HEAD)"
+
+# (e) two different samples changed -> both present, sorted (csharp < python)
+printf 'print("v3")\n' > samples/python/quickstart/foo/main.py
+printf 'x3\n'          > samples/csharp/quickstart/bar/Program.cs
+git commit -qam "two samples"
+run_detect "$BASE"
+expect_rc      "(e) two samples -> ok"                    0
+expect_field   "(e) count 2"                count         2
+expect_samples "(e) both, sorted"           '["samples/csharp/quickstart/bar","samples/python/quickstart/foo"]'
+BASE="$(git rev-parse HEAD)"
+
+echo ""
+echo "=============================================================="
+echo " FAIL-LOUD invariant (ADO 5247751)"
+echo "=============================================================="
+# (f) nonexistent base ref -> git diff errors -> exit 1, and NOT a fake empty set
+OUT="$(bash "$SCRIPT" --base-ref does-not-exist-ref 2>&1)"; RC=$?
+expect_rc "(f) bad base ref -> fail loud" 1
+if printf '%s\n' "$OUT" | grep -q "refusing to continue"; then
+    pass "(f) prints refusal (no fake empty set)"
+else
+    fail "(f) missing refusal message"
+fi
+
+echo ""
+echo "=============================================================="
+echo " Base-ref RESOLUTION (--print-base-ref, no network)"
+echo "=============================================================="
+# (g) pull_request event -> origin/<target>; push -> HEAD~1
+G="$(bash "$SCRIPT" --event pull_request --target-branch main --print-base-ref 2>&1)"; GRC=$?
+if [ "$GRC" = 0 ] && [ "$G" = "origin/main" ]; then pass "(g) pull_request -> origin/main"; else fail "(g) pull_request expected origin/main got '$G' (rc=$GRC)"; fi
+G="$(bash "$SCRIPT" --event push --print-base-ref 2>&1)"; GRC=$?
+if [ "$GRC" = 0 ] && [ "$G" = "HEAD~1" ]; then pass "(g) push -> HEAD~1"; else fail "(g) push expected HEAD~1 got '$G' (rc=$GRC)"; fi
+# env fallback: GITHUB_BASE_REF supplies the target when --target-branch is absent
+G="$(GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=release bash "$SCRIPT" --print-base-ref 2>&1)"; GRC=$?
+if [ "$GRC" = 0 ] && [ "$G" = "origin/release" ]; then pass "(g) env pull_request -> origin/release"; else fail "(g) env pull_request expected origin/release got '$G' (rc=$GRC)"; fi
+
+echo ""
+echo "=============================================================="
+echo " --output-dir artifacts"
+echo "=============================================================="
+# The last real diff (e) had 2 samples; re-run it with --output-dir and assert files.
+ART="$(mktemp -d)"
+bash "$SCRIPT" --base-ref "$(git rev-parse HEAD~1)" --output-dir "$ART" >/dev/null 2>&1
+if [ -f "$ART/unique_changed_samples.txt" ] && [ -f "$ART/changed_files.txt" ]; then
+    if grep -q "samples/python/quickstart/foo" "$ART/unique_changed_samples.txt"; then
+        pass "--output-dir wrote unique_changed_samples.txt"
+    else
+        fail "--output-dir unique_changed_samples.txt missing expected entry"
+    fi
+else
+    fail "--output-dir did not write expected artifact files"
+fi
+rm -rf "$ART"
+
+echo ""
+echo "=============================================================="
+echo " GITHUB_OUTPUT hygiene on EMPTY result (regression: bare '0')"
+echo "=============================================================="
+# An empty (docs-only) result must write ONLY clean key=value lines to the real
+# $GITHUB_OUTPUT. Regression guard for the grep -c double-'0' bug that emitted a
+# bare "0" line and made GitHub reject the step ("Invalid format '0'").
+# Diffing HEAD against itself is a guaranteed empty-but-successful diff.
+GO="$(mktemp)"
+GITHUB_OUTPUT="$GO" bash "$SCRIPT" --base-ref HEAD >/dev/null 2>&1
+if grep -qxE '[0-9]+' "$GO"; then
+    fail "(h) empty result leaked a bare numeric line into GITHUB_OUTPUT: $(tr '\n' '|' < "$GO")"
+elif [ "$(grep -c '^count=0$' "$GO")" = 1 ] \
+     && grep -q '^has_changes=false$' "$GO" \
+     && grep -q '^samples=\[\]$' "$GO"; then
+    pass "(h) empty result writes clean count=0 / has_changes=false / samples=[]"
+else
+    fail "(h) empty-result GITHUB_OUTPUT malformed: $(tr '\n' '|' < "$GO")"
+fi
+rm -f "$GO"
+
+echo ""
+echo "==================================================="
+echo "  checks passed: $PASS_N   failed: $FAIL_N"
+echo "==================================================="
+
+if [ "$FAIL_N" -ne 0 ]; then
+    echo "detect exit gate: RED — a check failed."
+    exit 1
+fi
+echo "detect exit gate: GREEN — all detection acceptance cases + fail-loud proved."

--- a/.github/scripts/test/run-tests.sh
+++ b/.github/scripts/test/run-tests.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# run-tests.sh — Phase-1 exit gate for validate-sample.sh (all 5 languages).
+#
+# Proves the classifier's three-way split on REAL toolchains:
+#   - <lang>-good    => exit 0 / verdict=pass   (language default succeeds)
+#   - <lang>-broken  => exit 1 / verdict=fail   (default fails at the compile step)
+#   - toolchain gone => exit 2 / verdict=error  (required binary absent from PATH)
+# for lang in { csharp, python, typescript, java, go }.
+#
+# Plus, toolchain-free proofs:
+#   - shared run_sample_yaml path: sample.yaml validate:true => pass, :false => fail (needs yq)
+#   - live-service contract: declared pass/fail/error, required environment, and undeclared no-op
+#   - guardrails: unknown language, missing --sample-dir, missing --language => error
+#   - --results-dir plumbing lands each sample path in passed/failed/errored.txt
+#
+# Plus P1.3 (ADO 5449687) dependency-install transport classification:
+#   - pip/npm install against a forced-unreachable registry (127.0.0.1:1) => error (exit 2)
+#   - an unaccompanied resolution failure (package not found, no transport) => fail (exit 1)
+#
+# Designed to run on a GitHub Actions ubuntu-latest runner AFTER setup-dotnet /
+# setup-python / setup-node / setup-java / setup-go have put the toolchains on PATH
+# (that is the "callable from GH Actions on a real runner" proof). It also runs
+# locally: any language whose toolchain is absent has its good/broken cases SKIPPED
+# (BLOCKED-on-env) while its ERROR case — which needs no toolchain — still runs.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/../validate-sample.sh"
+FIX="$HERE/fixtures"
+BASH_BIN="$(command -v bash)"
+
+LANGS="csharp python typescript java go"
+
+# language -> the toolchain binary its default requires (drives run-vs-skip + scrub).
+reqbin() {
+    case "$1" in
+        csharp)     echo dotnet ;;
+        python)     echo python ;;
+        typescript) echo npm ;;
+        java)       echo mvn ;;
+        go)         echo go ;;
+    esac
+}
+
+# Whether ALL binaries a language default needs are present (drives run-vs-skip of
+# the good/broken cases). Some toolchains need more than their headline binary:
+#   - typescript: npm's build path shells out to node -> need both.
+#   - java: mvn needs a real JDK (javac + a valid JAVA_HOME) to compile -> require javac.
+# The scrub ERROR case still keys off reqbin (the binary require_tool hits first), so
+# it runs regardless.
+toolchain_ready() {
+    case "$1" in
+        typescript) command -v node  >/dev/null 2>&1 && command -v npm >/dev/null 2>&1 ;;
+        java)       command -v javac >/dev/null 2>&1 && command -v mvn >/dev/null 2>&1 ;;
+        *)          command -v "$(reqbin "$1")" >/dev/null 2>&1 ;;
+    esac
+}
+
+# --- bootstrap yq if missing (the workflow provides it via a setup step) ------
+if ! command -v yq >/dev/null 2>&1; then
+    BIN="${HOME:-/tmp}/.local/bin"
+    mkdir -p "$BIN"
+    echo "yq not found; bootstrapping static binary into $BIN ..."
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64 \
+            -o "$BIN/yq" && chmod +x "$BIN/yq" || true
+    fi
+    export PATH="$BIN:$PATH"
+fi
+YQ_OK=false
+command -v yq >/dev/null 2>&1 && YQ_OK=true
+
+PASS_N=0
+FAIL_N=0
+SKIP_N=0
+
+# check <desc> <expected_exit> <expected_verdict> -- <command...>
+check() {
+    local desc="$1" exp_code="$2" exp_verdict="$3"
+    shift 3
+    [ "$1" = "--" ] && shift
+    local out code verdict
+    out="$("$@" 2>&1)"
+    code=$?
+    verdict="$(printf '%s\n' "$out" | sed -n 's/^verdict=\(pass\|fail\|error\)$/\1/p' | tail -1)"
+    if [ "$code" = "$exp_code" ] && [ "$verdict" = "$exp_verdict" ]; then
+        echo "  PASS  $desc  (exit=$code verdict=$verdict)"
+        PASS_N=$((PASS_N + 1))
+    else
+        echo "  FAIL  $desc  expected exit=$exp_code verdict=$exp_verdict, got exit=$code verdict=${verdict:-<none>}"
+        printf '%s\n' "$out" | sed 's/^/        | /'
+        FAIL_N=$((FAIL_N + 1))
+    fi
+}
+
+# check_live_service <desc> <expected_exit> <expected_verdict> <expected_declared> -- <command...>
+check_live_service() {
+    local desc="$1" exp_code="$2" exp_verdict="$3" exp_declared="$4"
+    shift 4
+    [ "$1" = "--" ] && shift
+    local out code verdict declared
+    out="$("$@" 2>&1)"
+    code=$?
+    verdict="$(printf '%s\n' "$out" | sed -n 's/^verdict=\(pass\|fail\|error\)$/\1/p' | tail -1)"
+    declared="$(printf '%s\n' "$out" | sed -n 's/^live_service_validation_declared=\(true\|false\)$/\1/p' | tail -1)"
+    if [ "$code" = "$exp_code" ] && [ "$verdict" = "$exp_verdict" ] && [ "$declared" = "$exp_declared" ]; then
+        echo "  PASS  $desc  (exit=$code verdict=$verdict live_service_validation_declared=$declared)"
+        PASS_N=$((PASS_N + 1))
+    else
+        echo "  FAIL  $desc  expected exit=$exp_code verdict=$exp_verdict live_service_validation_declared=$exp_declared, got exit=$code verdict=${verdict:-<none>} live_service_validation_declared=${declared:-<none>}"
+        printf '%s\n' "$out" | sed 's/^/        | /'
+        FAIL_N=$((FAIL_N + 1))
+    fi
+}
+
+assert_file_has() {
+    # $1 = file, $2 = substring
+    if grep -qF "$2" "$1" 2>/dev/null; then
+        echo "  PASS  $(basename "$1") contains $2"
+        PASS_N=$((PASS_N + 1))
+    else
+        echo "  FAIL  $(basename "$1") missing $2"
+        FAIL_N=$((FAIL_N + 1))
+    fi
+}
+
+RESULTS="$(mktemp -d)"
+OUTPUTS="$(mktemp)"
+
+# SCRUB_BIN: a PATH holding ONLY coreutils the script needs to REACH its
+# require_tool check (ls to detect *.csproj, mkdir for --results-dir, etc.) but
+# NONE of the language toolchains (dotnet/python/node/npm/mvn/go). This proves the
+# "required toolchain binary missing -> ERROR" branch deterministically, regardless
+# of what is preinstalled on the runner.
+SCRUB_BIN="$(mktemp -d)"
+for tool in ls mkdir cat rm sed grep dirname basename cp mv; do
+    src="$(command -v "$tool" 2>/dev/null)"
+    [ -n "$src" ] && ln -s "$src" "$SCRUB_BIN/$tool"
+done
+trap 'rm -rf "$RESULTS" "$SCRUB_BIN" "$OUTPUTS"' EXIT
+
+echo "=============================================================="
+echo " Per-language classifier (good=0 / broken=1 / toolchain-gone=2)"
+echo "=============================================================="
+for lang in $LANGS; do
+    bin="$(reqbin "$lang")"
+    echo "== $lang (requires: $bin) =="
+
+    # ERROR tier — needs NO toolchain (scrubbed PATH), so it always runs.
+    check "$lang: toolchain missing ($bin) -> error" 2 error -- \
+        env "PATH=$SCRUB_BIN" "$BASH_BIN" "$SCRIPT" --language "$lang" --sample-dir "$FIX/$lang-good"
+
+    # PASS/FAIL tier — needs the real toolchain. Skip (not fail) when it is absent.
+    if toolchain_ready "$lang"; then
+        check "$lang: good -> pass"   0 pass -- bash "$SCRIPT" --language "$lang" --sample-dir "$FIX/$lang-good"   --results-dir "$RESULTS"
+        check "$lang: broken -> fail" 1 fail -- bash "$SCRIPT" --language "$lang" --sample-dir "$FIX/$lang-broken" --results-dir "$RESULTS"
+    else
+        echo "  SKIP  $lang good/broken — toolchain '$bin' absent (BLOCKED-on-env; the runner has it)"
+        SKIP_N=$((SKIP_N + 2))
+    fi
+done
+
+echo ""
+echo "=============================================================="
+echo " Shared run_sample_yaml path (sample.yaml; needs yq, no toolchain)"
+echo "=============================================================="
+if [ "$YQ_OK" = true ]; then
+    check "sample.yaml validate:true -> pass"  0 pass -- bash "$SCRIPT" --language csharp --sample-dir "$FIX/csharp-yaml-good"   --results-dir "$RESULTS"
+    check "sample.yaml validate:false -> fail" 1 fail -- bash "$SCRIPT" --language csharp --sample-dir "$FIX/csharp-yaml-broken" --results-dir "$RESULTS"
+else
+    echo "  SKIP  sample.yaml pass/fail — yq unavailable (BLOCKED-on-env)"
+    SKIP_N=$((SKIP_N + 2))
+fi
+
+echo ""
+echo "=============================================================="
+echo " Per-sample live-service declaration contract (toolchain-free; needs yq)"
+echo "=============================================================="
+if [ "$YQ_OK" = true ]; then
+    check_live_service "live-service declared command + inherited env -> pass" 0 pass true -- \
+        env "GITHUB_OUTPUT=$OUTPUTS" "SKIP_PROVISION=true" "LIVE_SERVICE_TEST_ENDPOINT=https://stub.invalid" \
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-good" --results-dir "$RESULTS"
+    check_live_service "live-service cold caller keeps SKIP_PROVISION=false -> pass" 0 pass true -- \
+        env "SKIP_PROVISION=false" \
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-cold" --results-dir "$RESULTS"
+    check_live_service "live-service undeclared -> clean no-op" 0 pass false -- \
+        env "GITHUB_OUTPUT=$OUTPUTS" \
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/csharp-yaml-good" --results-dir "$RESULTS"
+    check_live_service "live-service explicit exit 1 -> fail" 1 fail true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-fail" --results-dir "$RESULTS"
+    check_live_service "live-service explicit exit 2 -> error" 2 error true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-infra" --results-dir "$RESULTS"
+    check_live_service "live-service exit 1 with transport-like text -> fail" 1 fail true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-transport-like" --results-dir "$RESULTS"
+    check_live_service "live-service unexpected exit 7 -> fail" 1 fail true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-unexpected" --results-dir "$RESULTS"
+    check_live_service "live-service missing required env -> error" 2 error true -- \
+        env -u LIVE_SERVICE_TEST_ENDPOINT "SKIP_PROVISION=true" \
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-good" --results-dir "$RESULTS"
+    check_live_service "live-service missing SKIP_PROVISION -> error" 2 error true -- \
+        env -u SKIP_PROVISION "LIVE_SERVICE_TEST_ENDPOINT=https://stub.invalid" \
+            bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-good" --results-dir "$RESULTS"
+    check_live_service "live-service invalid declaration shape -> error" 2 error true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-invalid" --results-dir "$RESULTS"
+    check_live_service "live-service missing command -> error" 2 error true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-missing-command" --results-dir "$RESULTS"
+    check_live_service "live-service invalid required_env -> error" 2 error true -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-invalid-env" --results-dir "$RESULTS"
+    check "live-service malformed sample.yaml -> error" 2 error -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/live-service-malformed" --results-dir "$RESULTS"
+    check "legacy l4 declaration -> actionable error" 2 error -- \
+        env "SKIP_PROVISION=true" bash "$SCRIPT" --mode live-service --sample-dir "$FIX/legacy-l4" --results-dir "$RESULTS"
+else
+    echo "  SKIP  live-service contract cases — yq unavailable (BLOCKED-on-env)"
+    SKIP_N=$((SKIP_N + 14))
+fi
+
+echo ""
+echo "=============================================================="
+echo " Guardrails (ERROR tier, no toolchain required)"
+echo "=============================================================="
+check "unknown language -> error"   2 error -- bash "$SCRIPT" --language rust   --sample-dir "$FIX/csharp-good"
+check "missing sample-dir -> error" 2 error -- bash "$SCRIPT" --language csharp --sample-dir "$FIX/does-not-exist"
+check "missing --language -> error" 2 error -- bash "$SCRIPT" --sample-dir "$FIX/csharp-good"
+check "unknown --mode -> error" 2 error -- bash "$SCRIPT" --mode unknown --sample-dir "$FIX/csharp-good"
+check_live_service "live-service absent sample.yaml -> no-op without yq" 0 pass false -- \
+    env "PATH=$SCRUB_BIN" "$BASH_BIN" "$SCRIPT" --mode live-service --sample-dir "$FIX/csharp-good"
+
+echo ""
+echo "=============================================================="
+echo " --results-dir plumbing (passed/failed/errored.txt)"
+echo "=============================================================="
+# An ERROR case with --results-dir must land in errored.txt (toolchain-free scrub).
+env "PATH=$SCRUB_BIN" "$BASH_BIN" "$SCRIPT" --language csharp --sample-dir "$FIX/csharp-good" --results-dir "$RESULTS" >/dev/null 2>&1 || true
+assert_file_has "$RESULTS/errored.txt" "$FIX/csharp-good"
+if [ "$YQ_OK" = true ]; then
+    # The yq sample.yaml cases above already appended to passed/failed.txt.
+    assert_file_has "$RESULTS/passed.txt" "$FIX/csharp-yaml-good"
+    assert_file_has "$RESULTS/passed.txt" "$FIX/live-service-good"
+    assert_file_has "$RESULTS/passed.txt" "$FIX/live-service-cold"
+    assert_file_has "$RESULTS/failed.txt" "$FIX/live-service-fail"
+    assert_file_has "$RESULTS/errored.txt" "$FIX/live-service-infra"
+    assert_file_has "$RESULTS/errored.txt" "$FIX/live-service-malformed"
+    assert_file_has "$RESULTS/failed.txt" "$FIX/live-service-transport-like"
+    assert_file_has "$RESULTS/failed.txt" "$FIX/live-service-unexpected"
+    assert_file_has "$RESULTS/failed.txt" "$FIX/csharp-yaml-broken"
+    assert_file_has "$OUTPUTS" "live_service_validation_declared=true"
+    assert_file_has "$OUTPUTS" "live_service_validation_declared=false"
+fi
+
+echo ""
+echo "=============================================================="
+echo " Dependency-install transport classification (P1.3 / ADO 5449687)"
+echo "=============================================================="
+# Proves the failure-vs-error split on dependency RESOLUTION — the P1.3 gap:
+#   - a forced-unreachable registry (localhost blackhole) => ERROR (exit 2), NEVER fail.
+#   - an unaccompanied resolution failure (package not found) => FAIL (exit 1).
+# Both are hermetic: 127.0.0.1:1 has nothing listening (=> connection refused), and the FAIL
+# case uses PIP_NO_INDEX + an empty --find-links so pip resolves nothing WITHOUT any network.
+EMPTY_LINKS="$(mktemp -d)"
+
+# pip: blackhole index => transport evidence => ERROR. requirements.txt names a REAL package,
+# so pip ALSO prints its misleading "No matching distribution" conclusion after exhausting
+# retries — this case proves transport evidence WINS over that generic line (the precedence fix).
+# The FAIL case (no index at all) prints the SAME "No matching distribution" WITHOUT transport
+# evidence => must stay FAIL. Same fixture, opposite verdicts: the whole point of P1.3.
+if toolchain_ready python; then
+    check "pip install: registry unreachable -> error" 2 error -- \
+        env "PIP_INDEX_URL=http://127.0.0.1:1" "PIP_RETRIES=1" "PIP_DEFAULT_TIMEOUT=5" \
+            bash "$SCRIPT" --language python --sample-dir "$FIX/python-deps" --results-dir "$RESULTS"
+    check "pip install: unresolvable package (no transport) -> fail" 1 fail -- \
+        env "PIP_NO_INDEX=1" "PIP_FIND_LINKS=$EMPTY_LINKS" \
+            bash "$SCRIPT" --language python --sample-dir "$FIX/python-deps" --results-dir "$RESULTS"
+else
+    echo "  SKIP  pip transport cases — python toolchain absent (BLOCKED-on-env; the runner has it)"
+    SKIP_N=$((SKIP_N + 2))
+fi
+
+# npm: blackhole registry => connect ECONNREFUSED => ERROR (exit 2).
+if toolchain_ready typescript; then
+    check "npm install: registry unreachable -> error" 2 error -- \
+        env "NPM_CONFIG_REGISTRY=http://127.0.0.1:1" "NPM_CONFIG_FETCH_RETRIES=0" \
+            bash "$SCRIPT" --language typescript --sample-dir "$FIX/typescript-deps" --results-dir "$RESULTS"
+else
+    echo "  SKIP  npm transport case — node/npm toolchain absent (BLOCKED-on-env; the runner has it)"
+    SKIP_N=$((SKIP_N + 1))
+fi
+rm -rf "$EMPTY_LINKS"
+
+echo ""
+echo "==================================================="
+echo "  checks passed: $PASS_N   failed: $FAIL_N   skipped: $SKIP_N"
+echo "==================================================="
+
+if [ "$FAIL_N" -ne 0 ]; then
+    echo "Phase-1 exit gate: RED — a check failed."
+    exit 1
+fi
+if [ "$SKIP_N" -ne 0 ] || [ "$YQ_OK" != true ]; then
+    echo "Phase-1 exit gate: PARTIAL — some cases were BLOCKED-on-env (missing toolchain/yq)."
+    echo "A full GREEN requires every toolchain present (i.e. a real Actions runner)."
+    exit 3
+fi
+echo "Phase-1 exit gate: GREEN — all 5 languages proved pass=0 / fail=1 / error=2."

--- a/.github/scripts/test/run-workflow-structure-tests.sh
+++ b/.github/scripts/test/run-workflow-structure-tests.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Structural regression gate for the single required `trusted` job.
+#
+# Root cause pinned here: a job-level `if:` skip concludes `skipped`, and GitHub treats a
+# skipped required check as satisfied. The job must run and fail forks explicitly after build readiness.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW_SOURCE="$HERE/../../workflows/validate.yml"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+PASS_N=0
+FAIL_N=0
+
+pass() {
+    echo "  PASS  $1"
+    PASS_N=$((PASS_N + 1))
+}
+
+fail() {
+    echo "  FAIL  $1"
+    FAIL_N=$((FAIL_N + 1))
+}
+
+expect_count() {
+    local desc="$1" pattern="$2" expected="$3" file="${4:-$WORKFLOW}" count
+    count="$(grep -cE "$pattern" "$file" 2>/dev/null || true)"
+    if [ "$count" = "$expected" ]; then
+        pass "$desc (count=$count)"
+    else
+        fail "$desc expected count=$expected got=$count"
+    fi
+}
+
+expect_has() {
+    local desc="$1" pattern="$2" file="${3:-$WORKFLOW}"
+    if grep -qE "$pattern" "$file"; then
+        pass "$desc"
+    else
+        fail "$desc"
+    fi
+}
+
+expect_not_has() {
+    local desc="$1" pattern="$2" file="${3:-$WORKFLOW}"
+    if grep -qE "$pattern" "$file"; then
+        fail "$desc"
+    else
+        pass "$desc"
+    fi
+}
+
+extract_step() {
+    local name="$1" output="$2"
+    awk -v wanted="$name" '
+        $0 == "      - name: " wanted { in_step=1 }
+        in_step && seen && /^      - (name:|uses:)/ { exit }
+        in_step { print; seen=1 }
+    ' "$TRUSTED" > "$output"
+}
+
+if [ ! -f "$WORKFLOW_SOURCE" ]; then
+    echo "FAIL: workflow not found: $WORKFLOW_SOURCE"
+    exit 1
+fi
+
+# Keep the hermetic structure assertions stable in Windows worktrees where Git may check out
+# YAML with CRLF. The committed workflow remains untouched.
+WORKFLOW="$TMP/validate.yml"
+tr -d '\r' < "$WORKFLOW_SOURCE" > "$WORKFLOW"
+
+# Extract the trusted job by top-level job indentation. It is currently the final job, but this
+# stops correctly if a later top-level job is added.
+awk '
+    /^  trusted:$/ { in_trusted=1 }
+    in_trusted && seen && /^  [A-Za-z0-9_-]+:$/ { exit }
+    in_trusted { print; seen=1 }
+' "$WORKFLOW" > "$TMP/trusted.yml"
+TRUSTED="$TMP/trusted.yml"
+
+steps_line="$(grep -n '^    steps:$' "$TRUSTED" | cut -d: -f1 | head -1)"
+if [ -z "$steps_line" ]; then
+    echo "FAIL: trusted job has no steps block"
+    exit 1
+fi
+head -n "$((steps_line - 1))" "$TRUSTED" > "$TMP/trusted-job.yml"
+
+echo "=============================================================="
+echo " validate.yml required trusted-gate structure"
+echo "=============================================================="
+
+expect_count "workflow name remains validate" '^name: validate$' 1
+expect_count "pull_request trigger remains present" '^  pull_request:$' 1
+expect_not_has "pull_request_target is absent" '^[[:space:]]*pull_request_target:'
+expect_count "exactly one trusted job exists" '^  trusted:$' 1
+expect_count "trusted has exactly one job-level condition" '^    if:' 1 "$TMP/trusted-job.yml"
+expect_count "trusted job runs after dependency failure unless cancelled" '^    if: \$\{\{ !cancelled\(\) \}\}$' 1 "$TMP/trusted-job.yml"
+expect_not_has "trusted job has no matrix" '^    (strategy:|matrix:)' "$TRUSTED"
+expect_has "trusted job keeps legacy L4-validation environment" '^    environment: L4-validation$' "$TRUSTED"
+expect_not_has "job-level fork skip is absent" 'head\.repo\.fork != true' "$TMP/trusted-job.yml"
+expect_not_has "job-level draft skip is absent" 'pull_request\.draft' "$TMP/trusted-job.yml"
+
+extract_step "Validate sample detection contract" "$TMP/detect-contract.yml"
+first_step="$(tail -n "+$((steps_line + 1))" "$TRUSTED" | grep -m1 -E '^      - (name:|uses:)')"
+if [ "$first_step" = "      - name: Validate sample detection contract" ]; then
+    pass "detection contract is the first trusted step"
+else
+    fail "detection contract must be the first trusted step (got: ${first_step:-<none>})"
+fi
+contract_line="$(grep -nF -- '- name: Validate sample detection contract' "$TRUSTED" | cut -d: -f1)"
+checkout_line="$(grep -nF -- '- uses: actions/checkout@v4' "$TRUSTED" | cut -d: -f1 | head -1)"
+if [ -n "$contract_line" ] && [ -n "$checkout_line" ] && [ "$contract_line" -lt "$checkout_line" ]; then
+    pass "detection contract runs before checkout"
+else
+    fail "detection contract must run before checkout"
+fi
+expect_has "contract reads needs.detect.result" 'DETECT_RESULT: \$\{\{ needs\.detect\.result \}\}' "$TMP/detect-contract.yml"
+expect_has "contract reads has_changes output" 'HAS_CHANGES: \$\{\{ needs\.detect\.outputs\.has_changes \}\}' "$TMP/detect-contract.yml"
+expect_has "contract reads count output" 'COUNT: \$\{\{ needs\.detect\.outputs\.count \}\}' "$TMP/detect-contract.yml"
+expect_has "contract reads samples output" 'SAMPLES: \$\{\{ needs\.detect\.outputs\.samples \}\}' "$TMP/detect-contract.yml"
+expect_has "contract requires successful dependency" 'DETECT_RESULT.*!=.*success' "$TMP/detect-contract.yml"
+expect_has "contract restricts has_changes domain" 'true\|false' "$TMP/detect-contract.yml"
+expect_has "contract parses samples as JSON array" 'type == "array"' "$TMP/detect-contract.yml"
+expect_has "contract validates sample path shape" 'startswith\("samples/"\)' "$TMP/detect-contract.yml"
+expect_has "contract fails non-zero" '^[[:space:]]*exit 1$' "$TMP/detect-contract.yml"
+expect_not_has "contract cannot ignore failures" 'continue-on-error:' "$TMP/detect-contract.yml"
+
+# Execute the inline contract hermetically. Static assertions prove its position and Actions
+# wiring; these cases prove the shell logic rejects dependency/output corruption.
+awk '
+    /^        run: \|$/ { in_run=1; next }
+    in_run {
+        sub(/^          /, "")
+        print
+    }
+' "$TMP/detect-contract.yml" > "$TMP/detect-contract.sh"
+
+run_contract_case() {
+    local desc="$1" expected="$2" result="$3" has_changes="$4" count="$5" samples="$6"
+    local output="$TMP/contract-output.txt" rc
+    if DETECT_RESULT="$result" HAS_CHANGES="$has_changes" COUNT="$count" SAMPLES="$samples" \
+        bash "$TMP/detect-contract.sh" > "$output" 2>&1; then
+        rc=0
+    else
+        rc=$?
+    fi
+    if [ "$rc" = "$expected" ]; then
+        pass "$desc (exit=$rc)"
+    else
+        fail "$desc expected exit=$expected got=$rc: $(tr '\n' '|' < "$output")"
+    fi
+}
+
+run_contract_case "valid changed-sample contract passes" 0 success true 1 '["samples/python/foo"]'
+run_contract_case "valid docs-only contract passes" 0 success false 0 '[]'
+run_contract_case "failed detect result fails closed" 1 failure false 0 '[]'
+run_contract_case "malformed samples JSON fails closed" 1 success true 1 '{'
+run_contract_case "non-array samples fails closed" 1 success true 1 '{"sample":"samples/python/foo"}'
+run_contract_case "true with empty samples fails closed" 1 success true 0 '[]'
+run_contract_case "false with samples fails closed" 1 success false 1 '["samples/python/foo"]'
+run_contract_case "count mismatch fails closed" 1 success true 2 '["samples/python/foo"]'
+
+extract_step "Short-circuit docs-only PRs before secrets" "$TMP/docs-only.yml"
+expect_has "docs-only success is same-repo guarded" 'head\.repo\.fork != true' "$TMP/docs-only.yml"
+
+extract_step "Validate changed sample build readiness (in-job parallel)" "$TMP/build-readiness.yml"
+extract_step "Reject fork until maintainer promotion" "$TMP/fork-reject.yml"
+expect_has "fork rejection is fork-only" 'head\.repo\.fork == true' "$TMP/fork-reject.yml"
+expect_has "fork rejection runs after a readiness failure" '!cancelled\(\)' "$TMP/fork-reject.yml"
+expect_has "fork rejection checks OIDC request surface" 'ACTIONS_ID_TOKEN_REQUEST_(URL|TOKEN)' "$TMP/fork-reject.yml"
+expect_has "fork rejection emits promotion error" '::error::.*promot' "$TMP/fork-reject.yml"
+expect_has "fork rejection exits non-zero" '^[[:space:]]*exit 1$' "$TMP/fork-reject.yml"
+
+readiness_line="$(grep -nF -- '- name: Validate changed sample build readiness (in-job parallel)' "$TRUSTED" | cut -d: -f1)"
+fork_line="$(grep -nF -- '- name: Reject fork until maintainer promotion' "$TRUSTED" | cut -d: -f1)"
+if [ -n "$readiness_line" ] && [ -n "$fork_line" ] && [ "$readiness_line" -lt "$fork_line" ]; then
+    pass "credential-free build readiness runs before fork rejection"
+else
+    fail "credential-free build readiness must run before fork rejection"
+fi
+
+# Any step containing a current credential/live-service marker must carry an explicit same-repo guard.
+if awk '
+    function flush() {
+        if (active && credentialed && !same_repo) {
+            print "unguarded credentialed step: " step
+            bad=1
+        }
+    }
+    /^      - (name:|uses:)/ {
+        flush()
+        active=1
+        step=$0
+        credentialed=0
+        same_repo=0
+    }
+    active && /azure\/login|vars\.AZURE_|az account|get-access-token|Live-service smoke/ {
+        credentialed=1
+    }
+    active && /head\.repo\.fork != true/ {
+        same_repo=1
+    }
+    END {
+        flush()
+        exit bad
+    }
+' "$TRUSTED"; then
+    pass "every credentialed/live-service step has a same-repo guard"
+else
+    fail "every credentialed/live-service step must have a same-repo guard"
+fi
+
+extract_step "Trusted verdict" "$TMP/verdict.yml"
+expect_has "trusted success verdict is same-repo guarded" 'head\.repo\.fork != true' "$TMP/verdict.yml"
+
+echo ""
+echo "==================================================="
+echo "  checks passed: $PASS_N   failed: $FAIL_N"
+echo "==================================================="
+
+if [ "$FAIL_N" -ne 0 ]; then
+    echo "workflow structure exit gate: RED"
+    exit 1
+fi
+echo "workflow structure exit gate: GREEN"

--- a/.github/scripts/validate-sample.README.md
+++ b/.github/scripts/validate-sample.README.md
@@ -1,0 +1,92 @@
+# Per-sample validation contract
+
+`.github/scripts/validate-sample.sh` validates one sample for either build readiness
+or live-service behavior. Build readiness is the default.
+
+## CLI
+
+```bash
+# Build readiness (default)
+bash .github/scripts/validate-sample.sh \
+  --language python \
+  --sample-dir samples/python/quickstart/responses
+
+# Opt-in live-service validation
+SKIP_PROVISION=true bash .github/scripts/validate-sample.sh \
+  --mode live-service \
+  --sample-dir samples/python/quickstart/responses
+```
+
+These commands invoke individual validation modes; calling `--mode live-service`
+directly does not implicitly run build readiness first. The repository validation
+pilot provides the end-to-end sequence: every supported sample runs build readiness,
+and a sample with a `live_service_validation` declaration proceeds to live-service
+validation only after readiness passes. Declaring live-service validation therefore
+does not opt a sample out of build readiness.
+
+Both modes use the same exit and verdict contract:
+
+| Exit | Verdict | Meaning |
+|---|---|---|
+| `0` | `pass` | The requested check passed. In live-service mode, no declaration is also a clean no-op. |
+| `1` | `fail` | The sample command/assertion failed. |
+| `2` | `error` | The validator precondition or caller environment is invalid, or a live-service command explicitly reported caller/cloud infrastructure failure. |
+
+See `CLASSIFICATION.md` for the authoritative failure-versus-error rules.
+
+## `sample.yaml` live-service declaration
+
+Live-service validation is opt-in. A sample declares it with a top-level
+`live_service_validation` mapping:
+
+```yaml
+live_service_validation:
+  command: >-
+    python run_sample.py --assert-response
+  required_env:
+    - AZURE_OPENAI_ENDPOINT
+    - MODEL_DEPLOYMENT
+```
+
+The contract is:
+
+- `live_service_validation.command` is a required, non-empty shell string. The validator runs it from
+  the sample directory with Bash and captures/preserves its output.
+- The command owns a strict three-way result: exit `0` means pass, exit `1`
+  means the sample/assertion failed, and exit `2` means a known caller/cloud
+  infrastructure failure. Any other nonzero exit is conservatively classified
+  as sample failure.
+- The validator never infers live-service infrastructure failure from stdout/stderr text.
+  A broken sample can legitimately print `503 Service Unavailable`, `Bad
+  Gateway`, or similar application responses. If a command can distinguish a
+  known credential, endpoint, or cloud transport failure, it must normalize
+  that condition to exit `2`; ambiguous conditions must exit `1`.
+- Do not expose a tool's raw exit code unless it already follows this contract.
+  Common tools use `2` for sample-side conditions such as invalid arguments,
+  interrupted tests, or usage errors. Wrap those commands so only a known
+  caller/cloud infrastructure failure exits `2`; normalize other nonzero
+  statuses to `1`.
+- `live_service_validation.required_env` is optional. When present, it must be a list of valid
+  environment-variable names. Every listed variable must be non-empty or the
+  validator returns infrastructure error (`2`) before executing sample code.
+- `SKIP_PROVISION` is a reserved caller input and must be set to exactly `true`
+  or `false` whenever live-service validation is declared. The validator does not override it:
+  trusted PR callers can use the warm project with `true`, while the cold
+  cadence can use `false`.
+- Authentication and cloud configuration are caller-owned. The command inherits
+  the caller's environment and existing CLI/OIDC login. Do not put credentials,
+  secrets, resource provisioning, or production mutations in `sample.yaml`.
+- If `live_service_validation` is omitted (or `sample.yaml` itself is absent),
+  `--mode live-service` exits `0`
+  without requiring credentials or `SKIP_PROVISION`. It emits
+  `live_service_validation_declared=false`; a declared check emits
+  `live_service_validation_declared=true`.
+- If `$GITHUB_OUTPUT` is set, `verdict` and `live_service_validation_declared`
+  are appended there.
+  `--results-dir` continues to write the sample path to
+  `passed.txt`, `failed.txt`, or `errored.txt`.
+
+The validator rejects the legacy `l4` key with a migration message. It also rejects
+a scalar `live_service_validation`, a missing/non-string/empty `command`, a non-list
+`required_env`, invalid variable names, malformed YAML, and missing declared
+environment inputs as infrastructure errors.

--- a/.github/scripts/validate-sample.sh
+++ b/.github/scripts/validate-sample.sh
@@ -1,0 +1,538 @@
+#!/usr/bin/env bash
+# validate-sample.sh — reusable single-sample build-readiness or live-service validator.
+#
+# Ported from .azure-pipelines/validation.yml Stage 2, which duplicated the same
+# per-sample body across five per-language jobs (C#, Python, TypeScript, Java, Go).
+# That duplication is collapsed here into ONE function set: the sample.yaml command
+# runner lives once, and only the genuinely per-language default differs.
+#
+# Single responsibility: validate ONE sample directory. The caller owns the
+# `while read dir` loop (per-sample granularity for validation/<pipeline>/<sample-path>
+# statuses) and the toolchain SETUP (setup-dotnet / setup-python / ... actions).
+# This script assumes the required toolchain is already on PATH and reports ERROR if not.
+#
+# Usage:
+#   validate-sample.sh [--mode build-readiness] --language <csharp|python|typescript|java|go> \
+#                      --sample-dir <path> [--results-dir <dir>]
+#   validate-sample.sh --mode live-service --sample-dir <path> [--results-dir <dir>]
+#
+# Verdict / exit codes — the classifier. This split is load-bearing: downstream lanes
+# and the sync gate trust it, and ERROR must NEVER be treated as a sample failure
+# (that is what protects good samples from being quarantined when our infra breaks).
+#
+#   0  PASS   the requested level passed
+#             (build-readiness commands/default pass; or live-service command passes/none is declared)
+#   1  FAIL   the SAMPLE is broken
+#             (a build-readiness/live-service sample command exits non-zero; or the language default's
+#              compile/build/py_compile exits non-zero, without positive infra evidence)
+#   2  ERROR  OUR INFRA is sick — page us, do not quarantine
+#             PRECONDITION errors (bad/missing args, unknown language, missing sample dir,
+#             unreadable or malformed sample.yaml, a required toolchain binary missing from
+#             PATH, yq unavailable when a sample.yaml must be read), OR a dedicated `pip install` /
+#             `npm install` failure with positive transport evidence, OR a live-service command that
+#             explicitly reports caller/cloud infrastructure failure with exit 2.
+#
+# failure-vs-error at runtime (honest v1): the two DEDICATED install steps (`pip install`,
+# `npm install`) are inspected for positive transport evidence. Arbitrary live-service output is NEVER
+# inferred: its command owns normalization to 0=PASS, 1=FAIL, or 2=ERROR; every other nonzero
+# remains FAIL (bias ambiguous->fail, never fail-open). The merged resolve+compile tools
+# (dotnet build, mvn compile, gradle build, go build, npm run build) are NOT inspected in v1.
+# Documented limit in CLASSIFICATION.md.
+#
+# Outputs:
+#   - prints `verdict=pass|fail|error` on stdout (also appended to $GITHUB_OUTPUT if set)
+#   - in live-service mode, also prints/appends `live_service_validation_declared=true|false`
+#   - if --results-dir is given, appends the sample path to
+#     passed.txt | failed.txt | errored.txt in that directory.
+#
+# NOTE: `set -e` is intentionally NOT used. The classifier owns every exit code, so a
+# failing external command must be caught (`if ! cmd`) and routed to fail()/error(),
+# never allowed to abort the script with its own status.
+set -uo pipefail
+
+LANGUAGE=""
+SAMPLE_DIR=""
+RESULTS_DIR=""
+MODE="build-readiness"
+LIVE_SERVICE_VALIDATION_DECLARED=""
+SAMPLE_YAML_FAIL_STEP=""
+PYTHON_VENV_DIR=""
+
+usage() {
+    cat <<'EOF'
+Usage:
+  validate-sample.sh [--mode build-readiness] --language <lang> --sample-dir <path> [--results-dir <dir>]
+  validate-sample.sh --mode live-service --sample-dir <path> [--results-dir <dir>]
+
+  --mode         Validation mode: build-readiness (default) or live-service.
+  --language     One of: csharp | python | typescript | java | go (frozen set).
+                 Required for build readiness; optional for live-service validation.
+  --sample-dir   Path to the single sample directory to validate.
+  --results-dir  Optional. Directory to append passed.txt/failed.txt/errored.txt.
+
+Exit codes: 0 = pass, 1 = fail (sample broken), 2 = error (infra broken).
+EOF
+}
+
+# --- Classifier emit helpers -------------------------------------------------
+# Each terminates the process with the verdict's exit code so no path can fall
+# through without emitting exactly one verdict.
+
+emit_verdict() {
+    # $1 = pass|fail|error, $2 = exit code
+    local verdict="$1" code="$2"
+    if [ "$MODE" = "live-service" ] && [ -n "$LIVE_SERVICE_VALIDATION_DECLARED" ]; then
+        echo "live_service_validation_declared=${LIVE_SERVICE_VALIDATION_DECLARED}"
+    fi
+    echo "verdict=${verdict}"
+    if [ -n "${GITHUB_OUTPUT:-}" ]; then
+        if [ "$MODE" = "live-service" ] && [ -n "$LIVE_SERVICE_VALIDATION_DECLARED" ]; then
+            echo "live_service_validation_declared=${LIVE_SERVICE_VALIDATION_DECLARED}" >> "$GITHUB_OUTPUT"
+        fi
+        echo "verdict=${verdict}" >> "$GITHUB_OUTPUT"
+    fi
+    if [ -n "$RESULTS_DIR" ]; then
+        mkdir -p "$RESULTS_DIR"
+        case "$verdict" in
+            pass)  echo "$SAMPLE_DIR" >> "$RESULTS_DIR/passed.txt" ;;
+            fail)  echo "$SAMPLE_DIR" >> "$RESULTS_DIR/failed.txt" ;;
+            error) echo "$SAMPLE_DIR" >> "$RESULTS_DIR/errored.txt" ;;
+        esac
+    fi
+    exit "$code"
+}
+
+pass() {
+    echo "PASS: ${SAMPLE_DIR:-<no-dir>}"
+    emit_verdict pass 0
+}
+
+fail() {
+    # $1 = reason (optional)
+    echo "FAIL: ${SAMPLE_DIR:-<no-dir>}${1:+ — $1}"
+    emit_verdict fail 1
+}
+
+error() {
+    # $1 = reason (optional). ERROR is infra-sick: page us, never quarantine.
+    echo "ERROR: ${1:-infra failure} (sample=${SAMPLE_DIR:-<no-dir>})" >&2
+    emit_verdict error 2
+}
+
+# require_tool <bin>: a required toolchain binary must be on PATH, else ERROR.
+require_tool() {
+    command -v "$1" >/dev/null 2>&1 || error "required toolchain binary not found on PATH: $1"
+}
+
+# ensure_yq: lazy precondition — only needed to read a sample.yaml. yq setup itself
+# belongs to the caller/workflow; the script only asserts its presence.
+ensure_yq() {
+    command -v yq >/dev/null 2>&1 || error "yq not available on PATH (required to read sample.yaml)"
+}
+
+# dep_infra_signature <logfile>: return 0 IFF a captured dedicated dependency-install log shows
+# HIGH-CONFIDENCE transport/registry evidence (DNS / connection refused-reset / connect-read
+# timeout / registry 5xx). This is a deliberately NARROW pip/npm heuristic:
+#   - it matches only tool-specific transport strings, never generic words like "timeout";
+#   - a positive match wins even when pip later prints a generic "No matching distribution"
+#     line (pip emits that AFTER exhausting retries against an unreachable index);
+#   - it is scoped to direct `pip install` and `npm install` logs only;
+#   - arbitrary sample/live-service output MUST NOT be passed here;
+#   - anything unmatched stays FAIL (bias ambiguous->fail, never fail-open to pass);
+#   - EXPECT maintenance as runner pip/npm versions drift their error strings.
+# The full captured log is printed by the caller before classifying, so diagnosis is preserved.
+dep_infra_signature() {
+    local log="${1:-}"
+    [ -n "$log" ] && [ -f "$log" ] || return 1
+    grep -Eiq \
+        -e 'temporary failure in name resolution' \
+        -e 'could not resolve host' \
+        -e 'name or service not known' \
+        -e 'getaddrinfo' \
+        -e 'eai_again' \
+        -e 'enotfound' \
+        -e 'econnrefused' \
+        -e 'connection refused' \
+        -e 'econnreset' \
+        -e 'connection reset' \
+        -e 'etimedout' \
+        -e 'connection timed out' \
+        -e 'read timed out' \
+        -e 'readtimeouterror' \
+        -e 'connecttimeouterror' \
+        -e 'network timeout' \
+        -e 'newconnectionerror' \
+        -e 'max retries exceeded' \
+        -e 'failed to establish a new connection' \
+        -e 'proxyerror' \
+        -e 'network is unreachable' \
+        -e '50[0234] server error' \
+        -e 'service unavailable' \
+        -e 'bad gateway' \
+        -e 'gateway time-?out' \
+        -e 'internal server error' \
+        "$log"
+}
+
+# --- Part 1: the once-only shared sample.yaml runner -------------------------
+# Byte-identical across all five ADO jobs today. Reads build -> validate -> test
+# and runs them in order; the first non-zero command is a sample FAIL.
+#
+# Returns: 0 = ran >=1 command and all passed (caller should PASS)
+#          1 = a command exited non-zero    (caller should FAIL)
+#          3 = no sample.yaml, or it declared no commands (caller runs the default)
+# Unreadable/malformed YAML calls error() directly (ERROR 2).
+#
+# For Python the per-sample venv is already activated in the parent shell before this
+# runs, so the `( cd ... && eval )` subshell inherits it — keeping this function
+# identical for all five languages (mirrors ADO, which sourced the venv per command).
+run_sample_yaml() {
+    local yaml="$SAMPLE_DIR/sample.yaml"
+    [ -f "$yaml" ] || return 3
+
+    ensure_yq
+
+    if ! yq eval '.' "$yaml" >/dev/null 2>&1; then
+        error "sample.yaml is unreadable or malformed: $yaml"
+    fi
+    if [ "$(yq eval 'has("l4")' "$yaml" 2>/dev/null)" = "true" ]; then
+        error "legacy sample.yaml key 'l4' is unsupported; rename it to 'live_service_validation'"
+    fi
+
+    local had_cmd=false cmd cmd_type
+    for cmd_type in build validate test; do
+        cmd="$(yq eval ".${cmd_type} // \"\"" "$yaml" 2>/dev/null)"
+        if [ -n "$cmd" ] && [ "$cmd" != "null" ]; then
+            had_cmd=true
+            echo "Running $cmd_type: $cmd"
+            if ! ( cd "$SAMPLE_DIR" && eval "$cmd" ); then
+                SAMPLE_YAML_FAIL_STEP="$cmd_type"
+                return 1
+            fi
+        fi
+    done
+
+    [ "$had_cmd" = true ] && return 0
+    return 3
+}
+
+# --- Part 2: per-language defaults (grounded in validation.yml Stage 2) -------
+# Each ends by calling pass() or fail(). require_tool guards are placed only where
+# the tool is actually invoked, preserving ADO's "no build file present => PASS" edges.
+
+# ADO validation.yml L285-298
+default_validate_csharp() {
+    if ls "$SAMPLE_DIR"/*.csproj 1>/dev/null 2>&1; then
+        require_tool dotnet
+        local proj
+        for proj in "$SAMPLE_DIR"/*.csproj; do
+            echo "Building: $proj"
+            if ! dotnet build "$proj" --verbosity minimal; then
+                fail "dotnet build failed: $proj"
+            fi
+        done
+        pass
+    else
+        echo "No .csproj found in $SAMPLE_DIR"
+        pass
+    fi
+}
+
+# ADO validation.yml L368-439. Venv is created + activated by python_setup_venv
+# (called before the sample.yaml/default branch, mirroring ADO's up-front venv).
+default_validate_python() {
+    if [ -f "$SAMPLE_DIR/requirements.txt" ]; then
+        echo "Installing requirements..."
+        local piplog; piplog="$(mktemp)"
+        if ! pip install -r "$SAMPLE_DIR/requirements.txt" -q >"$piplog" 2>&1; then
+            cat "$piplog"
+            if dep_infra_signature "$piplog"; then
+                rm -f "$piplog"
+                error "pip install: registry/network unreachable (transport evidence in log)"
+            fi
+            rm -f "$piplog"
+            echo "[classify:fail] pip install dependency-resolution failure (no transport evidence)"
+            fail "pip install failed"
+        fi
+        rm -f "$piplog"
+    fi
+    local pyfile
+    for pyfile in "$SAMPLE_DIR"/*.py; do
+        [ -f "$pyfile" ] || continue
+        echo "Checking: $pyfile"
+        if ! python -m py_compile "$pyfile"; then
+            fail "py_compile failed: $pyfile"
+        fi
+    done
+    pass
+}
+
+# ADO validation.yml L528-569
+default_validate_typescript() {
+    if [ -f "$SAMPLE_DIR/package.json" ]; then
+        require_tool npm
+        echo "Installing dependencies..."
+        local npmlog; npmlog="$(mktemp)"
+        # NOT --silent: that suppresses error output too, which would blind
+        # dep_infra_signature to transport errors. --loglevel=error keeps success
+        # quiet while still emitting the network/registry failure text we classify on.
+        if ! ( cd "$SAMPLE_DIR" && npm install --no-audit --no-fund --loglevel=error ) >"$npmlog" 2>&1; then
+            cat "$npmlog"
+            if dep_infra_signature "$npmlog"; then
+                rm -f "$npmlog"
+                error "npm install: registry/network unreachable (transport evidence in log)"
+            fi
+            rm -f "$npmlog"
+            echo "[classify:fail] npm install dependency-resolution failure (no transport evidence)"
+            fail "npm install failed"
+        fi
+        rm -f "$npmlog"
+        if ( cd "$SAMPLE_DIR" && npm run build --if-present ); then
+            pass
+        else
+            fail "npm run build failed"
+        fi
+    else
+        require_tool node
+        local jsfile tsfile
+        for jsfile in "$SAMPLE_DIR"/*.js; do
+            [ -f "$jsfile" ] || continue
+            echo "Checking: $jsfile"
+            if ! node --check "$jsfile"; then
+                fail "node --check failed: $jsfile"
+            fi
+        done
+        for tsfile in "$SAMPLE_DIR"/*.ts; do
+            [ -f "$tsfile" ] || continue
+            echo "TypeScript file without package.json, skipping: $tsfile"
+        done
+        pass
+    fi
+}
+
+# ADO validation.yml L669-694
+default_validate_java() {
+    if [ -f "$SAMPLE_DIR/pom.xml" ]; then
+        require_tool mvn
+        echo "Building with Maven..."
+        if ( cd "$SAMPLE_DIR" && mvn compile -q ); then
+            pass
+        else
+            fail "mvn compile failed"
+        fi
+    elif [ -f "$SAMPLE_DIR/build.gradle" ] || [ -f "$SAMPLE_DIR/build.gradle.kts" ]; then
+        echo "Building with Gradle..."
+        # Prefer the sample-provided wrapper; only require a system gradle when there is none.
+        if [ ! -f "$SAMPLE_DIR/gradlew" ]; then
+            require_tool gradle
+        fi
+        if ( cd "$SAMPLE_DIR" && { ./gradlew build -q 2>/dev/null || gradle build -q; } ); then
+            pass
+        else
+            fail "gradle build failed"
+        fi
+    else
+        echo "No pom.xml or build.gradle found in $SAMPLE_DIR"
+        pass
+    fi
+}
+
+# ADO validation.yml L787-811
+default_validate_go() {
+    require_tool go
+    if [ -f "$SAMPLE_DIR/go.mod" ]; then
+        echo "Building Go module..."
+        if ( cd "$SAMPLE_DIR" && go build ./... ); then
+            pass
+        else
+            fail "go build ./... failed"
+        fi
+    else
+        local gofile
+        for gofile in "$SAMPLE_DIR"/*.go; do
+            [ -f "$gofile" ] || continue
+            echo "Checking: $gofile"
+            if ! ( cd "$SAMPLE_DIR" && go build "$(basename "$gofile")" ); then
+                fail "go build failed: $gofile"
+            fi
+        done
+        pass
+    fi
+}
+
+# Python isolation pre-step (mirrors ADO: venv created up front, torn down on exit).
+cleanup_python_venv() {
+    [ -n "$PYTHON_VENV_DIR" ] || return 0
+    command -v deactivate >/dev/null 2>&1 && deactivate || true
+    rm -rf "$PYTHON_VENV_DIR"
+}
+
+# --- Part 3: opt-in live-service validation ---------------------------------
+# Contract:
+#   live_service_validation:
+#     command: "<credentialed runtime assertion>"
+#     required_env: [OPTIONAL_ENV_NAME, ...]  # optional
+#
+# The caller owns authentication and configuration. This script never provisions, logs in,
+# or invents defaults: it inherits the caller environment and requires the caller to set
+# SKIP_PROVISION to exactly true or false. A missing declaration is a successful no-op.
+run_live_service_validation() {
+    local yaml="$SAMPLE_DIR/sample.yaml"
+    if [ ! -f "$yaml" ]; then
+        LIVE_SERVICE_VALIDATION_DECLARED=false
+        echo "No sample.yaml live-service declaration; nothing owes live-service validation."
+        pass
+    fi
+
+    ensure_yq
+    if ! yq eval '.' "$yaml" >/dev/null 2>&1; then
+        error "sample.yaml is unreadable or malformed: $yaml"
+    fi
+
+    if [ "$(yq eval 'has("l4")' "$yaml" 2>/dev/null)" = "true" ]; then
+        error "legacy sample.yaml key 'l4' is unsupported; rename it to 'live_service_validation'"
+    fi
+    if [ "$(yq eval 'has("live_service_validation")' "$yaml" 2>/dev/null)" != "true" ]; then
+        LIVE_SERVICE_VALIDATION_DECLARED=false
+        echo "No sample.yaml live-service declaration; nothing owes live-service validation."
+        pass
+    fi
+    LIVE_SERVICE_VALIDATION_DECLARED=true
+
+    local declaration_kind command_tag cmd
+    declaration_kind="$(yq eval '.live_service_validation | kind' "$yaml" 2>/dev/null)" ||
+        error "failed to read sample.yaml live_service_validation declaration: $yaml"
+    [ "$declaration_kind" = "map" ] ||
+        error "sample.yaml live_service_validation must be a mapping with a string command"
+
+    command_tag="$(yq eval '.live_service_validation.command | tag' "$yaml" 2>/dev/null)" ||
+        error "failed to read sample.yaml live_service_validation.command: $yaml"
+    [ "$command_tag" = "!!str" ] ||
+        error "sample.yaml live_service_validation.command must be a non-empty string"
+    cmd="$(yq eval '.live_service_validation.command' "$yaml" 2>/dev/null)" ||
+        error "failed to read sample.yaml live_service_validation.command: $yaml"
+    printf '%s' "$cmd" | grep -q '[^[:space:]]' ||
+        error "sample.yaml live_service_validation.command must be a non-empty string"
+
+    if [ "$(yq eval '.live_service_validation | has("required_env")' "$yaml" 2>/dev/null)" = "true" ]; then
+        local required_env_kind env_count i env_name env_tag
+        required_env_kind="$(yq eval '.live_service_validation.required_env | kind' "$yaml" 2>/dev/null)" ||
+            error "failed to read sample.yaml live_service_validation.required_env: $yaml"
+        [ "$required_env_kind" = "seq" ] ||
+            error "sample.yaml live_service_validation.required_env must be a list of environment-variable names"
+        env_count="$(yq eval '.live_service_validation.required_env | length' "$yaml" 2>/dev/null)" ||
+            error "failed to read sample.yaml live_service_validation.required_env: $yaml"
+        i=0
+        while [ "$i" -lt "$env_count" ]; do
+            env_tag="$(yq eval ".live_service_validation.required_env[$i] | tag" "$yaml" 2>/dev/null)" ||
+                error "failed to read sample.yaml live_service_validation.required_env[$i]: $yaml"
+            [ "$env_tag" = "!!str" ] ||
+                error "sample.yaml live_service_validation.required_env[$i] must be a string"
+            env_name="$(yq eval ".live_service_validation.required_env[$i]" "$yaml" 2>/dev/null)" ||
+                error "failed to read sample.yaml live_service_validation.required_env[$i]: $yaml"
+            [[ "$env_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] ||
+                error "sample.yaml live_service_validation.required_env[$i] is not a valid environment-variable name: $env_name"
+            [ -n "${!env_name:-}" ] ||
+                error "required live-service environment variable is missing or empty: $env_name"
+            i=$((i + 1))
+        done
+    fi
+
+    case "${SKIP_PROVISION:-}" in
+        true|false) ;;
+        "") error "SKIP_PROVISION must be set by the live-service caller to true or false" ;;
+        *) error "SKIP_PROVISION must be exactly true or false (got: $SKIP_PROVISION)" ;;
+    esac
+
+    echo "Running live-service command (SKIP_PROVISION=$SKIP_PROVISION): $cmd"
+    local live_service_log
+    live_service_log="$(mktemp)" || error "failed to create temporary live-service command log"
+    local live_service_rc
+    ( cd "$SAMPLE_DIR" && eval "$cmd" ) >"$live_service_log" 2>&1
+    live_service_rc=$?
+    cat "$live_service_log"
+    rm -f "$live_service_log"
+    case "$live_service_rc" in
+        0) pass ;;
+        1) fail "sample.yaml live_service_validation.command reported sample failure (exit 1)" ;;
+        2) error "sample.yaml live_service_validation.command reported caller/cloud infrastructure error (exit 2)" ;;
+        *) fail "sample.yaml live_service_validation.command exited with unexpected status $live_service_rc (classified fail)" ;;
+    esac
+}
+
+python_setup_venv() {
+    require_tool python
+    PYTHON_VENV_DIR="$SAMPLE_DIR/.venv"
+    echo "Creating virtual environment..."
+    if ! python -m venv "$PYTHON_VENV_DIR"; then
+        error "failed to create Python venv (toolchain/infra failure): $PYTHON_VENV_DIR"
+    fi
+    # shellcheck disable=SC1091
+    source "$PYTHON_VENV_DIR/bin/activate" || error "failed to activate Python venv: $PYTHON_VENV_DIR"
+}
+
+# --- Argument parsing --------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --mode)        MODE="${2:-}";        shift $(( $# > 1 ? 2 : 1 )) ;;
+        --language)    LANGUAGE="${2:-}";    shift $(( $# > 1 ? 2 : 1 )) ;;
+        --sample-dir)  SAMPLE_DIR="${2:-}";  shift $(( $# > 1 ? 2 : 1 )) ;;
+        --results-dir) RESULTS_DIR="${2:-}"; shift $(( $# > 1 ? 2 : 1 )) ;;
+        -h|--help)     usage; exit 0 ;;
+        *)             usage >&2; error "unknown argument: $1" ;;
+    esac
+done
+
+# --- Guards (ordered so the ERROR tier is provable without any toolchain) -----
+case "$MODE" in
+    build-readiness|live-service) ;;
+    "") error "missing value for --mode (expected build-readiness or live-service)" ;;
+    *)  error "unsupported validation mode '$MODE' (expected build-readiness or live-service)" ;;
+esac
+
+[ -n "$SAMPLE_DIR" ] || error "missing required --sample-dir"
+[ -d "$SAMPLE_DIR" ] || error "sample directory not found: $SAMPLE_DIR"
+SAMPLE_DIR="${SAMPLE_DIR%/}"
+
+if [ "$MODE" = "build-readiness" ] || [ -n "$LANGUAGE" ]; then
+    case "$LANGUAGE" in
+        csharp|python|typescript|java|go) ;;
+        "") error "missing required --language for build readiness" ;;
+        *)  error "unsupported language '$LANGUAGE' (frozen set: csharp|python|typescript|java|go)" ;;
+    esac
+fi
+
+echo "=== validate-sample: mode=$MODE language=${LANGUAGE:-n/a} dir=$SAMPLE_DIR ==="
+
+if [ "$MODE" = "live-service" ]; then
+    run_live_service_validation
+    error "internal: no live-service verdict emitted"
+fi
+
+# Python creates its isolated venv before the sample.yaml/default branch (ADO parity),
+# so sample.yaml commands also run inside the venv.
+if [ "$LANGUAGE" = python ]; then
+    trap cleanup_python_venv EXIT
+    python_setup_venv
+fi
+
+# Part 1: sample.yaml commands take precedence over language defaults.
+run_sample_yaml
+rc=$?
+case "$rc" in
+    0) pass ;;
+    1) fail "sample.yaml '${SAMPLE_YAML_FAIL_STEP:-?}' command exited non-zero" ;;
+    3) : ;;  # no commands declared — fall through to the language default
+esac
+
+# Part 2: language default.
+case "$LANGUAGE" in
+    csharp)     default_validate_csharp ;;
+    python)     default_validate_python ;;
+    typescript) default_validate_typescript ;;
+    java)       default_validate_java ;;
+    go)         default_validate_go ;;
+esac
+
+# Unreachable: every default_validate_* ends in pass()/fail().
+error "internal: no verdict emitted for language=$LANGUAGE"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,420 @@
+name: validate
+
+# The REAL PR-triggered build-readiness floor lane (P2.1, ADO 5449695) — distinct from the inert
+# scripts-selftest.yml dev harness. It validates every changed sample to Build Readiness
+# using the shared scripts ported in Phase 1.
+#
+# FORK-SAFE BY CONSTRUCTION (this is the headline property):
+#   - on: pull_request  (NEVER pull_request_target) — so PRs from forks run this with a
+#     read-only GITHUB_TOKEN and NO access to secrets, per GitHub's documented behavior.
+#   - The required `trusted` job ALWAYS runs. Forks execute its credential-free readiness path, then
+#     fail explicitly with a promotion-required error. A job-level fork skip is forbidden:
+#     GitHub treats a required check that concludes `skipped` as satisfied.
+#   - `trusted` uses the status-function condition `!cancelled()` so a failed/malformed `detect`
+#     dependency starts the job and fails its first contract-check step instead of skipping open.
+#   - Every credentialed live-service step has an explicit same-repo guard. Fork isolation remains
+#     layered: read-only fork token/no secrets/no OIDC issuance + step-level guards.
+#   - The job checks out and EXECUTES untrusted fork code (dotnet build, npm install,
+#     pip install, mvn compile, ...). That is intentional and safe *because* the runner is
+#     barren: nothing here can exfiltrate a credential, because there is no credential.
+#
+# Frozen constraints honored: no pull_request_target, no trust-scoring, no org-membership
+# API calls, no aggregator/gate-shim job, no `on: paths:` trigger filter. "What changed" is
+# decided IN-JOB by detect-changed-samples.sh and fanned out via needs.*.outputs. The
+# trusted live-service lane (secrets, fork-gated) is the `trusted` job at the BOTTOM of THIS workflow
+# (P2.2, ADO 5449696) — a SINGLE job (never a matrix), so its required-check context is exactly
+# `trusted` (displayed by Actions as `validate / trusted`).
+
+on:
+  pull_request:
+    # `ready_for_review` preserves an explicit re-trigger when a draft is marked ready. The
+    # trusted job also runs on drafts: a job-level draft skip would produce a skipped check.
+    # No `branches:` filter (runs for every PR, incl. those targeting main) and no `paths:`
+    # filter (path detection is data-driven in-job, not a trigger shim).
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  # --- Which samples did this PR touch? (in-job, data-driven) -------------------
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.detect.outputs.has_changes }}
+      count:       ${{ steps.detect.outputs.count }}
+      samples:     ${{ steps.detect.outputs.samples }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0            # detector diffs origin/<target>..HEAD; needs full history
+      - name: Detect changed samples
+        id: detect
+        # Reads $GITHUB_EVENT_NAME (pull_request) + $GITHUB_BASE_REF (target branch), diffs
+        # scoped to samples/, and emits has_changes/count/samples to $GITHUB_OUTPUT. Fails
+        # loud (exit 1) if the git diff itself errors — never a fake empty set.
+        run: bash .github/scripts/detect-changed-samples.sh
+
+  # --- Validate each changed sample for build readiness, one runner per sample -
+  validate:
+    needs: detect
+    if: needs.detect.outputs.has_changes == 'true'   # docs-only PRs skip this job entirely
+    strategy:
+      fail-fast: false                                # one broken sample must not cancel the rest
+      matrix:
+        sample: ${{ fromJSON(needs.detect.outputs.samples) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Derive language from sample path
+        id: lang
+        # matrix.sample is an untrusted, PR-controlled path — pass it via env and quote it,
+        # never interpolate ${{ }} straight into the script body (injection-safe).
+        env:
+          SAMPLE: ${{ matrix.sample }}
+        run: |
+          set -euo pipefail
+          rest="${SAMPLE#samples/}"
+          dir="${rest%%/*}"
+          case "$dir" in
+            csharp)     language=csharp ;;
+            python)     language=python ;;
+            typescript) language=typescript ;;
+            javascript) language=typescript ;;   # JS validated via the TS default (node/npm)
+            java)       language=java ;;
+            go)         language=go ;;
+            *)          language=unsupported ;;   # not in the frozen 5-lang set — skip, don't error
+          esac
+          echo "language=$language" >> "$GITHUB_OUTPUT"
+          echo "sample=$SAMPLE  dir=$dir  ->  language=$language"
+
+      # Toolchain setup — GH-native setup-* actions, versions pinned to match the P1.4 audit.
+      # Each installs ONLY for the language this leg actually needs (barren-by-default).
+      - name: Set up .NET
+        if: steps.lang.outputs.language == 'csharp'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Set up Python
+        if: steps.lang.outputs.language == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Set up Node.js
+        if: steps.lang.outputs.language == 'typescript'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Set up Java (Temurin)
+        if: steps.lang.outputs.language == 'java'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Go
+        if: steps.lang.outputs.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Install yq
+        if: steps.lang.outputs.language != 'unsupported'
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Skip unsupported language
+        if: steps.lang.outputs.language == 'unsupported'
+        env:
+          SAMPLE: ${{ matrix.sample }}
+        run: echo "::notice::Skipping ${SAMPLE} — language not covered by build readiness."
+
+      - name: Validate sample build readiness
+        if: steps.lang.outputs.language != 'unsupported'
+        env:
+          SAMPLE: ${{ matrix.sample }}
+          LANGUAGE: ${{ steps.lang.outputs.language }}
+        # validate-sample.sh owns the verdict: exit 0 = pass, 1 = sample broken (FAIL),
+        # 2 = infra sick (ERROR). Both 1 and 2 make this leg red — the floor never goes
+        # green on an unresolved run — while the script's log distinguishes them.
+        run: bash .github/scripts/validate-sample.sh --language "$LANGUAGE" --sample-dir "$SAMPLE"
+
+  # === P2.2 · ADO 5449696 · trusted live-service validation ===================
+  # The credentialed counterpart to the floor `validate` job above. It produces the
+  # required-merge-gate check context `validate / trusted` (workflow name `validate` + job name
+  # `trusted`). FROZEN, non-negotiable properties (violating any is a defect):
+  #   - SINGLE JOB, no per-language matrix. A matrix of required checks reinstates the rejected
+  #     aggregator/gate-shim. Speed comes from IN-JOB parallelism (the readiness step backgrounds
+  #     validate-sample.sh per changed sample), never from fan-out into multiple checks.
+  #   - ALWAYS RUNS for every triggered PR. Forks run credential-free readiness, then fail in-job with
+  #     a promotion-required error. Never restore a job-level fork/draft `if:`: P3.3 proved that
+  #     GitHub treats a required job that concludes `skipped` as satisfying the merge gate.
+  #   - FAILS CLOSED when `detect` fails or emits malformed outputs. The exact job-level
+  #     `!cancelled()` status condition starts trusted after dependency failure; the FIRST step
+  #     validates the dependency result/output contract before checkout or docs-only handling.
+  #   - Docs-only PRs SHORT-CIRCUIT before any Azure/secret step (has_changes gate). A docs-only
+  #     same-repo PR yields a PRESENT, PASSING check (correct "no sample owes live-service validation"); every fork
+  #     yields a PRESENT, FAILING check and requires maintainer promotion.
+  #   - Concurrency cancels superseded runs.
+  #   - Live-service validation uses the pre-provisioned WARM project via SKIP_PROVISION=true (never provisions
+  #     per PR — cold provisioning is the cadence lane's sole job). OIDC federated login, no stored
+  #     secret. The legacy external environment identifier L4-validation MUST carry zero
+  #     protection_rules: because this always-running job
+  #     binds the environment, an environment reviewer rule would stall a fork instead of failing it.
+  trusted:
+    needs: detect
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    # Legacy external identifier: renaming it also requires an Entra OIDC subject migration.
+    # It scopes vars.AZURE_* and binds the matching Azure federated credential.
+    environment: L4-validation
+    # Job-level permissions REPLACE the workflow default for this job: add id-token for OIDC.
+    permissions:
+      id-token: write
+      contents: read
+    # Cancel a superseded trusted run when a newer commit lands on the same PR. Scoped to this job
+    # so the floor lane's behavior is untouched.
+    concurrency:
+      group: validate-trusted-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    env:
+      # Reuse the warm project — never provision per PR (①-guardrail: cold provisioning belongs to
+      # the cadence lane only and must never be "warmed" here for speed).
+      SKIP_PROVISION: "true"
+    steps:
+      # MUST remain first. A failed `needs` job normally skips dependents; the job-level
+      # !cancelled() condition starts trusted, and this contract check turns dependency/output
+      # corruption into a terminal failure before missing values can resemble "docs-only".
+      - name: Validate sample detection contract
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          HAS_CHANGES: ${{ needs.detect.outputs.has_changes }}
+          COUNT: ${{ needs.detect.outputs.count }}
+          SAMPLES: ${{ needs.detect.outputs.samples }}
+        run: |
+          set -euo pipefail
+          fail_contract() {
+            echo "::error::$1"
+            exit 1
+          }
+
+          if [ "$DETECT_RESULT" != "success" ]; then
+            fail_contract "Sample detection did not succeed (result=${DETECT_RESULT:-missing}); trusted fails closed."
+          fi
+          case "$HAS_CHANGES" in
+            true|false) ;;
+            *) fail_contract "Invalid detect output has_changes='${HAS_CHANGES:-missing}'; expected exactly true or false." ;;
+          esac
+          case "$COUNT" in
+            ''|*[!0-9]*) fail_contract "Invalid detect output count='${COUNT:-missing}'; expected a non-negative integer." ;;
+          esac
+
+          if ! sample_count="$(printf '%s' "$SAMPLES" | jq -er '
+            if type == "array"
+              and all(.[]; type == "string" and startswith("samples/") and length > 8)
+            then length
+            else error("samples must be an array of sample paths")
+            end
+          ')"; then
+            fail_contract "Invalid detect output samples; expected JSON array of paths under samples/."
+          fi
+          if [ "$COUNT" != "$sample_count" ]; then
+            fail_contract "Detect output count=$COUNT does not match samples length=$sample_count."
+          fi
+          if [ "$HAS_CHANGES" = "true" ] && [ "$sample_count" = "0" ]; then
+            fail_contract "Detect output has_changes=true requires at least one sample."
+          fi
+          if [ "$HAS_CHANGES" = "false" ] && [ "$sample_count" != "0" ]; then
+            fail_contract "Detect output has_changes=false requires samples=[] and count=0."
+          fi
+          echo "Detection contract valid: has_changes=$HAS_CHANGES count=$COUNT."
+
+      - uses: actions/checkout@v4
+
+      # --- Docs-only short-circuit (BEFORE any secret/Azure step) ---------------
+      # If detect found no changed sample, nothing owes live-service validation, so the trusted gate is satisfied. Log and
+      # let a SAME-REPO job end green WITHOUT touching OIDC/secrets. Forks never short-circuit to
+      # success; they reach the explicit promotion failure below.
+      - name: Short-circuit docs-only PRs before secrets
+        if: needs.detect.outputs.has_changes != 'true' && github.event.pull_request.head.repo.fork != true
+        run: echo "No changed samples (docs-only) -> no sample owes live-service validation -> trusted gate satisfied. Skipping build readiness and live-service validation without touching secrets."
+
+      # --- Derive which toolchains the changed samples actually need ------------
+      - name: Derive languages from changed samples
+        id: langs
+        if: needs.detect.outputs.has_changes == 'true'
+        env:
+          SAMPLES: ${{ needs.detect.outputs.samples }}   # untrusted JSON array — consumed via env, jq-parsed (never inlined)
+        run: |
+          set -euo pipefail
+          langs="$(printf '%s' "$SAMPLES" | jq -r '.[]' | awk -F/ '{print $2}' | sort -u)"
+          has_csharp=false; has_python=false; has_node=false; has_java=false; has_go=false
+          while IFS= read -r d; do
+            [ -z "$d" ] && continue
+            case "$d" in
+              csharp)                has_csharp=true ;;
+              python)                has_python=true ;;
+              typescript|javascript) has_node=true ;;   # JS validated via the TS default (node/npm)
+              java)                  has_java=true ;;
+              go)                    has_go=true ;;
+            esac
+          done <<< "$langs"
+          {
+            echo "has_csharp=$has_csharp"
+            echo "has_python=$has_python"
+            echo "has_node=$has_node"
+            echo "has_java=$has_java"
+            echo "has_go=$has_go"
+          } >> "$GITHUB_OUTPUT"
+          echo "languages present: $(printf '%s' "$langs" | tr '\n' ' ')"
+
+      # --- Toolchain setup (only what the changed samples need) -----------------
+      - name: Set up .NET
+        if: needs.detect.outputs.has_changes == 'true' && steps.langs.outputs.has_csharp == 'true'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Set up Python
+        if: needs.detect.outputs.has_changes == 'true' && steps.langs.outputs.has_python == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Set up Node.js
+        if: needs.detect.outputs.has_changes == 'true' && steps.langs.outputs.has_node == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Set up Java (Temurin)
+        if: needs.detect.outputs.has_changes == 'true' && steps.langs.outputs.has_java == 'true'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Set up Go
+        if: needs.detect.outputs.has_changes == 'true' && steps.langs.outputs.has_go == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+      - name: Install yq
+        if: needs.detect.outputs.has_changes == 'true'
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      # --- Build readiness for EVERY changed sample, IN-JOB PARALLEL (no matrix)
+      # Single job; concurrency comes from backgrounding validate-sample.sh per sample. GITHUB_OUTPUT
+      # is blanked per-invocation so the parallel legs don't race on the shared output file; each
+      # leg's verdict is its exit code (0 pass / 1 fail / 2 error). Any fail OR error → job red, and
+      # the default success() gating means live-service validation never runs after a red result.
+      - name: Validate changed sample build readiness (in-job parallel)
+        if: needs.detect.outputs.has_changes == 'true'
+        env:
+          SAMPLES: ${{ needs.detect.outputs.samples }}
+        run: |
+          set -uo pipefail
+          mkdir -p _build_readiness
+          map_lang() {
+            case "$1" in
+              csharp)                echo csharp ;;
+              python)                echo python ;;
+              typescript|javascript) echo typescript ;;
+              java)                  echo java ;;
+              go)                    echo go ;;
+              *)                     echo unsupported ;;
+            esac
+          }
+          n=0
+          while IFS= read -r sample; do
+            [ -z "$sample" ] && continue
+            dir="$(printf '%s' "$sample" | awk -F/ '{print $2}')"
+            lang="$(map_lang "$dir")"
+            safe="$(printf '%s' "$sample" | tr '/ ' '__')"
+            n=$((n+1))
+            if [ "$lang" = unsupported ]; then
+              echo "::notice::Skipping $sample — language '$dir' not in the build-readiness set."
+              echo 0 > "_build_readiness/$safe.rc"
+              : > "_build_readiness/$safe.log"
+              continue
+            fi
+            (
+              GITHUB_OUTPUT= bash .github/scripts/validate-sample.sh --language "$lang" --sample-dir "$sample" > "_build_readiness/$safe.log" 2>&1
+              echo $? > "_build_readiness/$safe.rc"
+            ) &
+          done < <(printf '%s' "$SAMPLES" | jq -r '.[]')
+          wait
+          pass=0; failed=0; errored=0
+          for rcf in _build_readiness/*.rc; do
+            rc="$(cat "$rcf")"
+            base="$(basename "$rcf" .rc)"
+            echo "----- $base (rc=$rc) -----"
+            cat "_build_readiness/$base.log" 2>/dev/null || true
+            case "$rc" in
+              0) pass=$((pass+1)) ;;
+              1) failed=$((failed+1));  echo "::error::BUILD READINESS FAIL ($base)" ;;
+              2) errored=$((errored+1)); echo "::error::BUILD READINESS ERROR/infra ($base)" ;;
+              *) errored=$((errored+1)); echo "::error::BUILD READINESS unexpected rc=$rc ($base)" ;;
+            esac
+          done
+          echo "Build-readiness summary: total=$n pass=$pass fail=$failed error=$errored"
+          if [ "$failed" -gt 0 ] || [ "$errored" -gt 0 ]; then
+            echo "Build readiness not green -> trusted gate red; not proceeding to live-service validation."
+            exit 1
+          fi
+          echo "Build readiness green for all $pass changed sample(s)."
+
+      # A fork must produce a terminal FAILURE, never a skipped required check. This step uses a
+      # status function so it still emits the promotion instruction after a fork's readiness fails.
+      - name: Reject fork until maintainer promotion
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.fork == true }}
+        run: |
+          set -euo pipefail
+          if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            echo "::error::Fork runner unexpectedly received an OIDC request surface; refusing to continue."
+            exit 1
+          fi
+          echo "::error::Fork PRs cannot satisfy the trusted gate directly. A maintainer must promote this commit to a same-repo branch, where live-service validation can run."
+          exit 1
+
+      # --- Reach the warm project via OIDC (only after build readiness is green) -
+      # Reached only when real samples changed and readiness passed. This
+      # is the trusted secret boundary: federated OIDC login, no stored secret.
+      - name: Azure login via OIDC (no secret)
+        if: needs.detect.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork != true
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Live-service smoke against the warm project (SKIP_PROVISION)
+        if: needs.detect.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork != true
+        env:
+          AZURE_OPENAI_ENDPOINT: ${{ vars.AZURE_OPENAI_ENDPOINT }}
+          MODEL_DEPLOYMENT: gpt-5.4-mini
+        run: |
+          set -euo pipefail
+          echo "SKIP_PROVISION=$SKIP_PROVISION — targeting the pre-provisioned warm project (no azd provision)."
+          az account show -o json
+          TOKEN="$(az account get-access-token --resource https://cognitiveservices.azure.com --query accessToken -o tsv)"
+          HTTP="$(curl -sS -o resp.json -w '%{http_code}' \
+            "${AZURE_OPENAI_ENDPOINT}/openai/v1/responses" \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"model\":\"${MODEL_DEPLOYMENT}\",\"input\":\"Reply with the single word: pong\"}")"
+          echo "HTTP ${HTTP}"
+          cat resp.json; echo
+          test "${HTTP}" = "200"
+          echo "LIVE-SERVICE OK: OIDC + SKIP_PROVISION warm-project reach + least-priv inference all green."
+
+      - name: Trusted verdict
+        if: needs.detect.outputs.has_changes == 'true' && github.event.pull_request.head.repo.fork != true
+        run: echo "validate / trusted GREEN — build readiness passed for all changed samples AND the live-service warm-project smoke passed."


### PR DESCRIPTION
## Context

Force-full sync commit `1a7f828fd60e6b0f14549612cf25e7bf2c906931` replaced the public tree with the private export and unintentionally removed the public-only workflow that emits the ruleset-required `trusted` status. With the ruleset unchanged, pull requests cannot satisfy the required check.

## What changed

- Restore `.github/workflows/validate.yml` from rollback point `328833f9d39e8e0a80975950cc98dc00d9c63aff`.
- Restore its runtime dependencies: `detect-changed-samples.sh` and `validate-sample.sh`.
- Restore the corresponding behavior documentation, focused regression runners, and their fixtures.
- Preserve every sample and other change delivered by the force-full sync.
- Leave the unrelated validation pilot/report workflows and assets deleted.

All 41 restored files byte-match the rollback point.

## Validation

- `run-detect-tests.sh`: 23 passed, 0 failed.
- `run-workflow-structure-tests.sh`: 39 passed, 0 failed.
- Shell syntax checks passed for both runtime scripts and all three test runners.
- `validate.yml` parses successfully as YAML.
- `git diff --cached --check` passed before commit.
- Full classifier harness exercised 39 passing cases; its remaining local run was environment-limited by unavailable NuGet network access and absent Python/Node/Java/Go toolchains. The restored GitHub runner workflow provisions those toolchains.

## Scope note

The force-full commit also removed Foundry Local sample content and the separate validation pilot/report stack. This PR intentionally does not restore those unrelated paths; it is limited to making the existing required `trusted` lane operational again.