### PR TITLE
cli/training: name training job output asset

### DIFF
--- a/samples/cli/training/sample_training_job.yaml
+++ b/samples/cli/training/sample_training_job.yaml
@@ -20,3 +20,4 @@ inputs:
 outputs:
   result_file:
     type: uri_folder
+    asset_name: output-result


### PR DESCRIPTION
## Summary

- Add `asset_name: output-result` to the custom training job's `result_file` output.
- Port the intended sample repair from [microsoft-foundry/foundry-samples-pr#947](https://github.com/microsoft-foundry/foundry-samples-pr/pull/947) as a normal public-side change.

## Why

The `azure.ai.training` extension maps `asset_name` to the Foundry Jobs API `assetName` field. This makes the sample output a named, registered `uri_folder` asset; because `asset_version` is omitted, the service assigns the version.

## Validation

- Parsed all training YAML files with PyYAML.
- Verified the output contract and local sample paths.
- Confirmed the resulting file is byte-for-byte identical to the current private source.
- Ran `git diff --check`.

## Tracking

[ADO 5449716](https://msdata.visualstudio.com/Vienna/_workitems/edit/5449716)