### PR TITLE
Add durable public agent-routing guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,8 @@
 - `microsoft-foundry/foundry-samples` is the sole venue for work intended for publication. Contributions use the normal public pull request path and existing repository checks; a maintainer initiates the merge.
 - Do not redirect contributors to or recreate publishable work in `microsoft-foundry/foundry-samples-pr`.
 - If a contributor lacks the required access to create the appropriate public-repository branch, surface that clearly and direct them to Brandon Miller / Foundry DevX. Do not invent an alternate publication route.
-- Never propose private staging, promotion commands or environments, classifiers, taxonomies, manifests, cross-repo handoff protocols, exception sync, reverse mirror, replay, reseed, `force_full`, or any automated private publication mechanism.
+- Do not propose private staging as a contributor path or recreate retired destructive behavior such as reverse mirroring, replay, `force_full`, direct-public-main publication, or unverified reseeding.
+- A manual private-to-public bridge exists only for authorized maintainers handling specifically approved internal content. Do not dispatch that bridge or initiate verified seed recovery without explicit operator authorization; normal publication work still starts as a public pull request.
 
 ## Files owned by the AI Platform Docs team
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,10 @@
+## Repository publication routing
+
+- `microsoft-foundry/foundry-samples` is the sole venue for work intended for publication. Contributions use the normal public pull request path and existing repository checks; a maintainer initiates the merge.
+- Do not redirect contributors to or recreate publishable work in `microsoft-foundry/foundry-samples-pr`.
+- If a contributor lacks the required access to create the appropriate public-repository branch, surface that clearly and direct them to Brandon Miller / Foundry DevX. Do not invent an alternate publication route.
+- Never propose private staging, promotion commands or environments, classifiers, taxonomies, manifests, cross-repo handoff protocols, exception sync, reverse mirror, replay, reseed, `force_full`, or any automated private publication mechanism.
+
 ## Files owned by the AI Platform Docs team
 
 If a file is listed in the CODEOWNERS file with @azure-ai-foundry/ai-platform-docs as the owner, it is owned by the AI Platform Docs team.  For these files:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 - `microsoft-foundry/foundry-samples` is the sole venue for work intended for publication. Contributions use the normal public pull request path and existing repository checks; a maintainer initiates the merge.
 - Do not redirect contributors to or recreate publishable work in `microsoft-foundry/foundry-samples-pr`.
-- If a contributor lacks the required access to create the appropriate public-repository branch, surface that clearly and direct them to Brandon Miller / Foundry DevX. Do not invent an alternate publication route.
+- If a contributor lacks the required access to create the appropriate public-repository branch, surface that clearly and pause for repository-maintainer guidance. Do not invent an alternate publication route.
 - Do not propose private staging as a contributor path or recreate retired destructive behavior such as reverse mirroring, replay, `force_full`, direct-public-main publication, or unverified reseeding.
 - A manual private-to-public bridge exists only for authorized maintainers handling specifically approved internal content. Do not dispatch that bridge or initiate verified seed recovery without explicit operator authorization; normal publication work still starts as a public pull request.
 


### PR DESCRIPTION
## Summary

- establish `microsoft-foundry/foundry-samples` as the sole venue for work intended for publication
- keep contributions on the normal public pull request path with existing checks and maintainer-initiated merges
- surface missing public-branch access and pause for repository-maintainer guidance instead of inventing an alternate publication route
- retire destructive private publication paths while limiting the retained manual bridge and verified seed recovery to explicitly authorized operators, preserving the existing AI Platform Docs safeguards

## Scope

This PR changes only `.github/copilot-instructions.md`. It does not change README or contributor-facing documentation, workflows, repository settings, CODEOWNERS, samples, notebooks, other pull requests, or Azure DevOps work items.

## Activation coordination

Coordinate activation alongside [public PR 894](https://github.com/microsoft-foundry/foundry-samples/pull/894) under the retained-bridge boundary. The retained manual bridge and verified seed recovery remain limited to explicitly authorized operators.

## Tracking

- [ADO 5502654](https://msdata.visualstudio.com/Vienna/_workitems/edit/5502654)
- [ADO 5449716](https://msdata.visualstudio.com/Vienna/_workitems/edit/5449716)

## Validation

- parsed `.github/copilot-instructions.md` with PowerShell `ConvertFrom-Markdown`
- `git diff --check`
- final changed-file review limited to `.github/copilot-instructions.md`