### PR TITLE
Unpin azure-ai-agentserver-{core,invocations,responses} in Python hosted-agent samples

### DIFF
--- a/samples/python/hosted-agents/agent-framework/responses/12-foundry-skills/src/agent-framework-agent-foundry-skills-responses/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/12-foundry-skills/src/agent-framework-agent-foundry-skills-responses/requirements.txt
@@ -15,9 +15,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-invocations==1.1.0b1
-azure-ai-agentserver-responses==2.1.0b1
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
+azure-ai-agentserver-responses
 azure-ai-inference==1.0.0b9
 azure-ai-projects==2.3.0
 azure-core==1.41.0

--- a/samples/python/hosted-agents/agent-framework/responses/12-foundry-skills/src/agent-framework-agent-foundry-skills-responses/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/12-foundry-skills/src/agent-framework-agent-foundry-skills-responses/requirements.txt
@@ -15,9 +15,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-inference==1.0.0b9
 azure-ai-projects==2.3.0
 azure-core==1.41.0

--- a/samples/python/hosted-agents/agent-framework/responses/13-foundry-memory/src/agent-framework-agent-foundry-memory-responses/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/13-foundry-memory/src/agent-framework-agent-foundry-memory-responses/requirements.txt
@@ -15,9 +15,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-invocations==1.1.0b1
-azure-ai-agentserver-responses==2.1.0b1
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
+azure-ai-agentserver-responses
 azure-ai-inference==1.0.0b9
 azure-ai-projects==2.3.0
 azure-core==1.41.0

--- a/samples/python/hosted-agents/agent-framework/responses/13-foundry-memory/src/agent-framework-agent-foundry-memory-responses/requirements.txt
+++ b/samples/python/hosted-agents/agent-framework/responses/13-foundry-memory/src/agent-framework-agent-foundry-memory-responses/requirements.txt
@@ -15,9 +15,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-inference==1.0.0b9
 azure-ai-projects==2.3.0
 azure-core==1.41.0

--- a/samples/python/hosted-agents/bring-your-own/invocations/ag-ui/src/ag-ui-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/ag-ui/src/ag-ui-invocations/requirements.txt
@@ -2,7 +2,7 @@ pydantic-ai-slim[openai]==1.75.0
 openai==2.32.0
 azure-identity==1.25.3
 ag-ui-protocol==0.1.16
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
 debugpy

--- a/samples/python/hosted-agents/bring-your-own/invocations/ag-ui/src/ag-ui-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/ag-ui/src/ag-ui-invocations/requirements.txt
@@ -2,7 +2,7 @@ pydantic-ai-slim[openai]==1.75.0
 openai==2.32.0
 azure-identity==1.25.3
 ag-ui-protocol==0.1.16
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
 debugpy

--- a/samples/python/hosted-agents/bring-your-own/invocations/claude-agent-sdk/src/claude-agent-sdk-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/claude-agent-sdk/src/claude-agent-sdk-invocations/requirements.txt
@@ -1,5 +1,5 @@
 claude-agent-sdk>=0.1.74
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 httpx<1.0
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.

--- a/samples/python/hosted-agents/bring-your-own/invocations/claude-agent-sdk/src/claude-agent-sdk-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/claude-agent-sdk/src/claude-agent-sdk-invocations/requirements.txt
@@ -1,5 +1,5 @@
 claude-agent-sdk>=0.1.74
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 httpx<1.0
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.

--- a/samples/python/hosted-agents/bring-your-own/invocations/diagnostic-agent/src/diagnostic-agent-python-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/diagnostic-agent/src/diagnostic-agent-python-invocations/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 
 # azure-identity backs the opt-in startup self-ping loop (authenticated keep-alive).
 azure-identity

--- a/samples/python/hosted-agents/bring-your-own/invocations/diagnostic-agent/src/diagnostic-agent-python-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/diagnostic-agent/src/diagnostic-agent-python-invocations/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-invocations==1.0.0b8
+azure-ai-agentserver-invocations
 
 # azure-identity backs the opt-in startup self-ping loop (authenticated keep-alive).
 azure-identity

--- a/samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger/src/event-grid-trigger-python-invocations/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger/src/event-grid-trigger-python-invocations/requirements.in
@@ -1,7 +1,7 @@
 aiohttp==3.13.5
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-core
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger/src/event-grid-trigger-python-invocations/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger/src/event-grid-trigger-python-invocations/requirements.in
@@ -1,7 +1,7 @@
 aiohttp==3.13.5
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger/src/event-grid-trigger-python-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger/src/event-grid-trigger-python-invocations/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger/src/event-grid-trigger-python-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/event-grid-trigger/src/event-grid-trigger-python-invocations/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/github-copilot/src/github-copilot-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/github-copilot/src/github-copilot-invocations/requirements.txt
@@ -1,6 +1,6 @@
 github-copilot-sdk>=0.2.0
 
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 azure-identity>=1.17.0
 python-dotenv==1.1.1
 

--- a/samples/python/hosted-agents/bring-your-own/invocations/github-copilot/src/github-copilot-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/github-copilot/src/github-copilot-invocations/requirements.txt
@@ -1,6 +1,6 @@
 github-copilot-sdk>=0.2.0
 
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 azure-identity>=1.17.0
 python-dotenv==1.1.1
 

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world/src/hello-world-python-invocations/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world/src/hello-world-python-invocations/requirements.in
@@ -1,7 +1,7 @@
 aiohttp==3.13.5
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-core
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world/src/hello-world-python-invocations/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world/src/hello-world-python-invocations/requirements.in
@@ -1,7 +1,7 @@
 aiohttp==3.13.5
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world/src/hello-world-python-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world/src/hello-world-python-invocations/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/hello-world/src/hello-world-python-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/hello-world/src/hello-world-python-invocations/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/src/human-in-the-loop-invocations/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/src/human-in-the-loop-invocations/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-core
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/src/human-in-the-loop-invocations/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/src/human-in-the-loop-invocations/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/src/human-in-the-loop-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/src/human-in-the-loop-invocations/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/src/human-in-the-loop-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/human-in-the-loop/src/human-in-the-loop-invocations/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/langgraph-chat/src/langgraph-chat-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/langgraph-chat/src/langgraph-chat-invocations/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 azure-identity==1.25.3
 langgraph==1.1.8
 langgraph-prebuilt==1.0.10

--- a/samples/python/hosted-agents/bring-your-own/invocations/langgraph-chat/src/langgraph-chat-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/langgraph-chat/src/langgraph-chat-invocations/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 azure-identity==1.25.3
 langgraph==1.1.8
 langgraph-prebuilt==1.0.10

--- a/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/src/notetaking-agent-invocations-python/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/src/notetaking-agent-invocations-python/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-core
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/src/notetaking-agent-invocations-python/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/src/notetaking-agent-invocations-python/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/src/notetaking-agent-invocations-python/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/src/notetaking-agent-invocations-python/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/src/notetaking-agent-invocations-python/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/notetaking-agent/src/notetaking-agent-invocations-python/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/resilient-approval-gate/src/resilient-approval-gate/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/resilient-approval-gate/src/resilient-approval-gate/requirements.in
@@ -1,7 +1,7 @@
-azure-ai-agentserver-invocations==1.0.0b8
+azure-ai-agentserver-invocations
 
 # Core 2.1 removed the TaskContext.metadata API used by this sample.
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-core
 
 azure-ai-projects==2.0.1
 azure-identity==1.25.3

--- a/samples/python/hosted-agents/bring-your-own/invocations/resilient-approval-gate/src/resilient-approval-gate/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/resilient-approval-gate/src/resilient-approval-gate/requirements.in
@@ -1,7 +1,7 @@
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 
 # Core 2.1 removed the TaskContext.metadata API used by this sample.
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 
 azure-ai-projects==2.0.1
 azure-identity==1.25.3

--- a/samples/python/hosted-agents/bring-your-own/invocations/resilient-approval-gate/src/resilient-approval-gate/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/resilient-approval-gate/src/resilient-approval-gate/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-invocations==1.0.0b8
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/resilient-approval-gate/src/resilient-approval-gate/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/resilient-approval-gate/src/resilient-approval-gate/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/resilient-research/src/resilient-research/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/resilient-research/src/resilient-research/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations==1.0.0b8
+azure-ai-agentserver-invocations
 # Core 2.1 removed the TaskContext.metadata API used by this sample.
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-core
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/resilient-research/src/resilient-research/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/resilient-research/src/resilient-research/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 # Core 2.1 removed the TaskContext.metadata API used by this sample.
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/resilient-research/src/resilient-research/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/resilient-research/src/resilient-research/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-invocations==1.0.0b8
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/resilient-research/src/resilient-research/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/resilient-research/src/resilient-research/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/toolbox/src/toolbox-python-invocations/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/toolbox/src/toolbox-python-invocations/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-core
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/toolbox/src/toolbox-python-invocations/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/invocations/toolbox/src/toolbox-python-invocations/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/invocations/toolbox/src/toolbox-python-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/toolbox/src/toolbox-python-invocations/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/invocations/toolbox/src/toolbox-python-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/invocations/toolbox/src/toolbox-python-invocations/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/background-agent/src/background-agent-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/background-agent/src/background-agent-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/background-agent/src/background-agent-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/background-agent/src/background-agent-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/background-agent/src/background-agent-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/background-agent/src/background-agent-responses/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/background-agent/src/background-agent-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/background-agent/src/background-agent-responses/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/main.py
+++ b/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/main.py
@@ -45,8 +45,8 @@ from azure.ai.agentserver.responses import (
     ResponseEventStream,
     ResponsesAgentServerHost,
     ResponsesServerOptions,
-    get_input_expanded,
 )
+from azure.ai.agentserver.responses.models import get_input_expanded
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from azure.ai.projects import AIProjectClient
 

--- a/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects>=2.0.0
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects>=2.0.0
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.4.0
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/bring-your-own-toolbox/src/toolbox-python-responses/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-projects==2.4.0
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/main.py
+++ b/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/main.py
@@ -18,8 +18,8 @@ from azure.ai.agentserver.responses import (
     ResponseEventStream,
     ResponsesAgentServerHost,
     ResponsesServerOptions,
-    get_input_expanded,
 )
+from azure.ai.agentserver.responses.models import get_input_expanded
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from azure.ai.projects import AIProjectClient
 import asyncio

--- a/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects>=2.0.0
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects>=2.0.0
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.4.0
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/browser-automation/src/bat-python-byo/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-projects==2.4.0
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/env-vars-agent/src/env-vars-agent-responses-python/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/env-vars-agent/src/env-vars-agent-responses-python/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/env-vars-agent/src/env-vars-agent-responses-python/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/env-vars-agent/src/env-vars-agent-responses-python/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/env-vars-agent/src/env-vars-agent-responses-python/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/env-vars-agent/src/env-vars-agent-responses-python/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/env-vars-agent/src/env-vars-agent-responses-python/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/env-vars-agent/src/env-vars-agent-responses-python/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/hello-world/src/hello-world-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/hello-world/src/hello-world-python-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/hello-world/src/hello-world-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/hello-world/src/hello-world-python-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/hello-world/src/hello-world-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/hello-world/src/hello-world-python-responses/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/hello-world/src/hello-world-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/hello-world/src/hello-world-python-responses/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-chat/src/langgraph-chat-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-chat/src/langgraph-chat-responses/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-identity==1.25.3
 langgraph==1.1.8
 langgraph-prebuilt==1.0.10

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-chat/src/langgraph-chat-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-chat/src/langgraph-chat-responses/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-identity==1.25.3
 langgraph==1.1.8
 langgraph-prebuilt==1.0.10

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/main.py
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/main.py
@@ -41,9 +41,8 @@ from azure.ai.agentserver.responses import (
     ResponseEventStream,
     ResponsesAgentServerHost,
     ResponsesServerOptions,
-    get_input_expanded,
 )
-from azure.ai.agentserver.responses.models import CreateResponse
+from azure.ai.agentserver.responses.models import CreateResponse, get_input_expanded
 from azure.identity import DefaultAzureCredential
 from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 from langchain_azure_ai.tools import AzureAIProjectToolbox

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 langchain-azure-ai>=1.2.3
 langgraph>=1.1.8
 langchain-mcp-adapters>=0.2.2

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 langchain-azure-ai>=1.2.3
 langgraph>=1.1.8
 langchain-mcp-adapters>=0.2.2

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox-user-identity/src/toolbox-langgraph-user-identity/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/main.py
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/main.py
@@ -42,9 +42,8 @@ from azure.ai.agentserver.responses import (
     ResponseEventStream,
     ResponsesAgentServerHost,
     ResponsesServerOptions,
-    get_input_expanded,
 )
-from azure.ai.agentserver.responses.models import CreateResponse
+from azure.ai.agentserver.responses.models import CreateResponse, get_input_expanded
 from azure.identity import DefaultAzureCredential
 from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 from langchain_azure_ai.tools import AzureAIProjectToolbox

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 langchain-azure-ai>=1.2.3
 langgraph>=1.1.8
 langchain-mcp-adapters>=0.2.2

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 langchain-azure-ai>=1.2.3
 langgraph>=1.1.8
 langchain-mcp-adapters>=0.2.2

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/langgraph-toolbox/src/toolbox-langgraph/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/src/notetaking-agent-responses-python/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/src/notetaking-agent-responses-python/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/src/notetaking-agent-responses-python/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/src/notetaking-agent-responses-python/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/src/notetaking-agent-responses-python/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/src/notetaking-agent-responses-python/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/src/notetaking-agent-responses-python/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/notetaking-agent/src/notetaking-agent-responses-python/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/openai-agents-sdk/src/openai-agents-sdk-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/openai-agents-sdk/src/openai-agents-sdk-invocations/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-identity==1.25.3
 openai-agents>=0.1.0
 

--- a/samples/python/hosted-agents/bring-your-own/responses/openai-agents-sdk/src/openai-agents-sdk-invocations/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/openai-agents-sdk/src/openai-agents-sdk-invocations/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-identity==1.25.3
 openai-agents>=0.1.0
 

--- a/samples/python/hosted-agents/bring-your-own/responses/optimization-customer-support/src/optimization-customer-support-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/optimization-customer-support/src/optimization-customer-support-python-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/optimization-customer-support/src/optimization-customer-support-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/optimization-customer-support/src/optimization-customer-support-python-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/optimization-customer-support/src/optimization-customer-support-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/optimization-customer-support/src/optimization-customer-support-python-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-agentserver-optimization==1.0.0b1
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/optimization-customer-support/src/optimization-customer-support-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/optimization-customer-support/src/optimization-customer-support-python-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
+azure-ai-agentserver-core
 azure-ai-agentserver-optimization==1.0.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/optimization-hello-world/src/optimization-hello-world-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/optimization-hello-world/src/optimization-hello-world-python-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/optimization-hello-world/src/optimization-hello-world-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/optimization-hello-world/src/optimization-hello-world-python-responses/requirements.in
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/optimization-hello-world/src/optimization-hello-world-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/optimization-hello-world/src/optimization-hello-world-python-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-agentserver-optimization==1.0.0b1
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/optimization-hello-world/src/optimization-hello-world-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/optimization-hello-world/src/optimization-hello-world-python-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
+azure-ai-agentserver-core
 azure-ai-agentserver-optimization==1.0.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/resilient-steering/src/resilient-steering/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/resilient-steering/src/resilient-steering/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b1
+azure-ai-agentserver-responses
 # resilient_background / steerable_conversations need core's resilient-task
 # recovery gate (set_resilient_tasks_enabled), added in core 2.0.0b10.
 azure-ai-agentserver-core>=2.0.0b10

--- a/samples/python/hosted-agents/bring-your-own/responses/resilient-steering/src/resilient-steering/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/resilient-steering/src/resilient-steering/requirements.txt
@@ -1,7 +1,7 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 # resilient_background / steerable_conversations need core's resilient-task
 # recovery gate (set_resilient_tasks_enabled), added in core 2.0.0b10.
-azure-ai-agentserver-core>=2.0.0b10
+azure-ai-agentserver-core==2.1.0b2
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
 debugpy

--- a/samples/python/hosted-agents/bring-your-own/responses/resilient-streaming/src/resilient-streaming/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/resilient-streaming/src/resilient-streaming/requirements.txt
@@ -1,7 +1,7 @@
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 # stream.checkpoint() / context.persisted_response + resilient-task recovery
 # gate (set_resilient_tasks_enabled) live in core 2.0.0+.
-azure-ai-agentserver-core>=2.0.0b10
+azure-ai-agentserver-core==2.1.0b2
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
 debugpy

--- a/samples/python/hosted-agents/bring-your-own/responses/resilient-streaming/src/resilient-streaming/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/resilient-streaming/src/resilient-streaming/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-responses==2.0.0b1
+azure-ai-agentserver-responses
 # stream.checkpoint() / context.persisted_response + resilient-task recovery
 # gate (set_resilient_tasks_enabled) live in core 2.0.0+.
 azure-ai-agentserver-core>=2.0.0b10

--- a/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/requirements.in
@@ -1,5 +1,5 @@
 # AgentServer packages release independently; use the latest prerelease for each package.
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/requirements.in
@@ -1,5 +1,5 @@
 # AgentServer packages release independently; use the latest prerelease for each package.
-azure-ai-agentserver-responses
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/responses/session-multiplexing/src/hello-world-session-multiplexing-python-responses/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/responses/uv-pyproject/src/uv-pyproject-python-responses/pyproject.toml
+++ b/samples/python/hosted-agents/bring-your-own/responses/uv-pyproject/src/uv-pyproject-python-responses/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A minimal Microsoft Foundry Responses agent managed with uv."
 requires-python = ">=3.13"
 dependencies = [
-    "azure-ai-agentserver-responses==2.0.0b0",
+    "azure-ai-agentserver-responses",
     "azure-ai-projects==2.0.1",
     "azure-identity==1.25.3",
     "debugpy",

--- a/samples/python/hosted-agents/bring-your-own/responses/uv-pyproject/src/uv-pyproject-python-responses/pyproject.toml
+++ b/samples/python/hosted-agents/bring-your-own/responses/uv-pyproject/src/uv-pyproject-python-responses/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A minimal Microsoft Foundry Responses agent managed with uv."
 requires-python = ">=3.13"
 dependencies = [
-    "azure-ai-agentserver-responses",
+    "azure-ai-agentserver-responses==2.1.0b2",
     "azure-ai-projects==2.0.1",
     "azure-identity==1.25.3",
     "debugpy",

--- a/samples/python/hosted-agents/bring-your-own/voicelive/foreground-background-agents-responses-voicelive/src/foreground-background-agents-voicelive/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/foreground-background-agents-responses-voicelive/src/foreground-background-agents-voicelive/requirements.in
@@ -1,5 +1,5 @@
-azure-ai-agentserver-responses
-azure-ai-agentserver-core
+azure-ai-agentserver-responses==2.1.0b2
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/voicelive/foreground-background-agents-responses-voicelive/src/foreground-background-agents-voicelive/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/foreground-background-agents-responses-voicelive/src/foreground-background-agents-voicelive/requirements.in
@@ -1,5 +1,5 @@
-azure-ai-agentserver-responses==2.0.0b0
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-responses
+azure-ai-agentserver-core
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/voicelive/foreground-background-agents-responses-voicelive/src/foreground-background-agents-voicelive/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/foreground-background-agents-responses-voicelive/src/foreground-background-agents-voicelive/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/voicelive/foreground-background-agents-responses-voicelive/src/foreground-background-agents-voicelive/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/foreground-background-agents-responses-voicelive/src/foreground-background-agents-voicelive/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/voicelive/handoff-langgraph-responses-voicelive/src/handoff-langgraph-responses-voicelive/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/handoff-langgraph-responses-voicelive/src/handoff-langgraph-responses-voicelive/requirements.in
@@ -1,5 +1,5 @@
-azure-ai-agentserver-responses
-azure-ai-agentserver-core
+azure-ai-agentserver-responses==2.1.0b2
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/voicelive/handoff-langgraph-responses-voicelive/src/handoff-langgraph-responses-voicelive/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/handoff-langgraph-responses-voicelive/src/handoff-langgraph-responses-voicelive/requirements.in
@@ -1,5 +1,5 @@
-azure-ai-agentserver-responses==2.0.0b0
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-responses
+azure-ai-agentserver-core
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/voicelive/handoff-langgraph-responses-voicelive/src/handoff-langgraph-responses-voicelive/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/handoff-langgraph-responses-voicelive/src/handoff-langgraph-responses-voicelive/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/voicelive/handoff-langgraph-responses-voicelive/src/handoff-langgraph-responses-voicelive/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/handoff-langgraph-responses-voicelive/src/handoff-langgraph-responses-voicelive/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-responses==2.0.0b0
+azure-ai-agentserver-core
+azure-ai-agentserver-responses
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/src/hello-world-python-invocations-voicelive/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/src/hello-world-python-invocations-voicelive/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core==2.0.0
+azure-ai-agentserver-core
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/src/hello-world-python-invocations-voicelive/requirements.in
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/src/hello-world-python-invocations-voicelive/requirements.in
@@ -1,6 +1,6 @@
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 # Keep the 1.0 Invocations SDK on its compatible Core 2.0 line.
-azure-ai-agentserver-core
+azure-ai-agentserver-core==2.1.0b2
 azure-ai-projects==2.0.1
 # azure-ai-projects imports httpx directly, while OpenAI 3 uses httpx2.
 openai<3

--- a/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/src/hello-world-python-invocations-voicelive/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/src/hello-world-python-invocations-voicelive/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.0.0
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/src/hello-world-python-invocations-voicelive/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/hello-world-invocations-voicelive/src/hello-world-python-invocations-voicelive/requirements.txt
@@ -11,8 +11,8 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
 azure-ai-projects==2.0.1
 azure-core==1.41.0
 azure-core-tracing-opentelemetry==1.0.0b13

--- a/samples/python/hosted-agents/bring-your-own/voicelive/hotel-booking-invocations-voicelive/src/hotel-booking-python-invocations-voicelive/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/hotel-booking-invocations-voicelive/src/hotel-booking-python-invocations-voicelive/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-invocations
+azure-ai-agentserver-invocations==1.1.0b1
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
 debugpy

--- a/samples/python/hosted-agents/bring-your-own/voicelive/hotel-booking-invocations-voicelive/src/hotel-booking-python-invocations-voicelive/requirements.txt
+++ b/samples/python/hosted-agents/bring-your-own/voicelive/hotel-booking-invocations-voicelive/src/hotel-booking-python-invocations-voicelive/requirements.txt
@@ -1,4 +1,4 @@
-azure-ai-agentserver-invocations==1.0.0b7
+azure-ai-agentserver-invocations
 
 # debugpy enables local debugging of this agent with the Foundry Toolkit VS Code extension.
 debugpy

--- a/samples/python/hosted-agents/langgraph/invocations/01-langgraph-chat/src/langgraph-chat-invocations/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/invocations/01-langgraph-chat/src/langgraph-chat-invocations/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/invocations/01-langgraph-chat/src/langgraph-chat-invocations/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/invocations/01-langgraph-chat/src/langgraph-chat-invocations/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-invocations==1.1.0b1
-azure-ai-agentserver-responses==1.0.0b9
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
+azure-ai-agentserver-responses
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/01-langgraph-chat/src/langgraph-chat-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/01-langgraph-chat/src/langgraph-chat-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/01-langgraph-chat/src/langgraph-chat-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/01-langgraph-chat/src/langgraph-chat-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-invocations==1.1.0b1
-azure-ai-agentserver-responses==1.0.0b9
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
+azure-ai-agentserver-responses
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/02-langgraph-toolbox/src/toolbox-langgraph/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/02-langgraph-toolbox/src/toolbox-langgraph/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/02-langgraph-toolbox/src/toolbox-langgraph/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/02-langgraph-toolbox/src/toolbox-langgraph/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-invocations==1.1.0b1
-azure-ai-agentserver-responses==1.0.0b9
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
+azure-ai-agentserver-responses
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/05-workflows/src/langgraph-workflows-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/05-workflows/src/langgraph-workflows-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/05-workflows/src/langgraph-workflows-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/05-workflows/src/langgraph-workflows-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-invocations==1.1.0b1
-azure-ai-agentserver-responses==1.0.0b9
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
+azure-ai-agentserver-responses
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/06-files/src/langgraph-files-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/06-files/src/langgraph-files-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/06-files/src/langgraph-files-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/06-files/src/langgraph-files-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-invocations==1.1.0b1
-azure-ai-agentserver-responses==1.0.0b9
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
+azure-ai-agentserver-responses
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/07-human-in-the-loop/src/langgraph-human-in-the-loop-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/07-human-in-the-loop/src/langgraph-human-in-the-loop-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/07-human-in-the-loop/src/langgraph-human-in-the-loop-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/07-human-in-the-loop/src/langgraph-human-in-the-loop-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-invocations==1.1.0b1
-azure-ai-agentserver-responses==1.0.0b9
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
+azure-ai-agentserver-responses
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/08-observability/src/langgraph-observability-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/08-observability/src/langgraph-observability-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core
-azure-ai-agentserver-invocations
-azure-ai-agentserver-responses
+azure-ai-agentserver-core==2.1.0b2
+azure-ai-agentserver-invocations==1.1.0b1
+azure-ai-agentserver-responses==2.1.0b2
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0

--- a/samples/python/hosted-agents/langgraph/responses/08-observability/src/langgraph-observability-responses/requirements.txt
+++ b/samples/python/hosted-agents/langgraph/responses/08-observability/src/langgraph-observability-responses/requirements.txt
@@ -11,9 +11,9 @@ annotated-types==0.8.0
 anyio==4.14.2
 asgiref==3.12.1
 attrs==26.1.0
-azure-ai-agentserver-core==2.1.0b1
-azure-ai-agentserver-invocations==1.1.0b1
-azure-ai-agentserver-responses==1.0.0b9
+azure-ai-agentserver-core
+azure-ai-agentserver-invocations
+azure-ai-agentserver-responses
 azure-ai-contentsafety==1.0.0
 azure-ai-contentunderstanding==1.2.0b3
 azure-ai-projects==2.4.0


### PR DESCRIPTION
## What

Unpin the `==<version>` specifiers on the three `azure-ai-agentserver-*` packages (`core`, `invocations`, `responses`) across the Python hosted-agent samples so they install the latest published releases instead of being frozen on a specific preview build.

Only these three packages are unpinned. All other pinned dependencies (`azure-ai-projects`, `azure-core`, `openai`, `azure-identity`, etc.) are left unchanged. 62 files updated (`requirements.txt`, `requirements.in`, and one `pyproject.toml`).

## Why

The three `agentserver` packages ship as a coordinated set and must stay version-aligned. Hard pins make a sample install a mismatched combination once one package moves ahead.

A concrete example this fixes: `azure-ai-agentserver-responses==2.1.0b1` (the version several samples pin, directly or transitively) contains a hosted hard-fail branch that returns **HTTP 500** (`Resilient task subsystem missing in hosted environment`) when paired with `azure-ai-agentserver-core==2.1.0b2` — which is exactly what `pip install ...responses==2.1.0b1` resolves to, because it pulls the latest satisfying core. The responses-side fix (swallow → run in-process) merged in Azure/azure-sdk-for-python#48591 but is not yet published, so the pinned samples cannot pick it up. Unpinning lets samples move to the fixed build automatically once it releases.

## Scope

- No functional/code changes — dependency specifiers only.
- Lockfile-style `requirements.txt` files keep all other transitive pins; only the three agentserver lines are unpinned.
