### PR TITLE
Restore public-first contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,32 @@
 # Contributing to Microsoft Foundry Samples
 
-This repository contains official Microsoft Foundry documentation samples. The contents are published automatically from a private staging repository and are not edited directly here.
+This repository contains official Microsoft Foundry documentation samples. Changes are submitted as pull requests directly to this repository.
 
 ## Reporting Issues
 
 If you find a bug, have a question, or want to suggest an improvement to an existing sample, please [open an issue](https://github.com/microsoft-foundry/foundry-samples/issues/new) on this repository. We welcome feedback from everyone!
 
-## Contributing Changes (Microsoft Contributors)
+Before starting a substantial change, check for an existing issue. Open one when discussion or design agreement would help avoid duplicate work.
 
-Sample contributions are currently limited to Microsoft Foundry teams.
+## Contributing Changes
 
-All changes — new samples, updates, and bug fixes — are submitted through the private staging repository [`foundry-samples-pr`](https://github.com/microsoft-foundry/foundry-samples-pr). Changes merged there are automatically synced to this public repository on a nightly basis.
+Sample contributions are currently limited to Microsoft Foundry teams with permission to create a branch in this repository. Fork pull requests cannot satisfy the intentionally failing `trusted` gate, so sample changes must use a same-repository branch.
 
-> [!NOTE]
-> The link above will return a **404** until you've completed step 1 below.
+Contributors should always submit publishable changes through a public same-repository pull request. Maintainers may independently operate a separate bridge for approved eligible content already in the private repository; contributors must not dispatch it.
 
-### How to get started
+1. **Create a branch in this repository.** Use a same-repository branch for all sample changes.
+2. **Make a focused change.** Keep each pull request scoped to one sample, fix, or related set of updates. Follow the conventions in the surrounding sample.
+3. **Respect file ownership.** Review [CODEOWNERS](.github/CODEOWNERS) before editing. The listed owners will be requested when their files are changed.
+4. **Validate locally.** Run the setup, build, test, or sample-specific validation documented by the affected sample. Never commit credentials, local environment files, or generated secrets.
+5. **Open a pull request against `main`.** In the pull request description, explain what changed, why it changed, and the local validation you ran. Link the relevant issue when one exists.
 
-1. **Join the `microsoft-foundry` GitHub organization.** Navigate to the organization page on the Open Source Management Portal and click **Join**:
+### Pull request checks
 
-   <https://repos.opensource.microsoft.com/orgs/microsoft-foundry>
+Pull requests run repository validation automatically:
 
-2. **Access the staging repository.** Once you've joined the org, you'll be able to view [`foundry-samples-pr`](https://github.com/microsoft-foundry/foundry-samples-pr).
-
-3. **Follow the contributing guide there.** The `foundry-samples-pr` repository has its own [`CONTRIBUTING.md`](https://github.com/microsoft-foundry/foundry-samples-pr/blob/main/CONTRIBUTING.md) with full instructions for setting up write access, creating a branch, and submitting a pull request.
+- The required `trusted` check must pass.
+- Review and address the other checks reported on the pull request.
+- Contributor pull requests are not merged automatically; after required checks and review, a maintainer triggers the merge.
 
 ## Contributor License Agreement
 
@@ -32,4 +35,3 @@ This project requires a Contributor License Agreement (CLA). When you submit a p
 ## Code of Conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com).
-

--- a/README.md
+++ b/README.md
@@ -10,5 +10,4 @@ Use the samples in this repository to try out Microsoft Foundry scenarios on you
 
 Found a bug or have a suggestion? [Open an issue](https://github.com/microsoft-foundry/foundry-samples/issues/new) — we welcome feedback from everyone!
 
-Sample contributions are submitted through a private staging repository. If you're a Microsoft employee or contractor, see the [contributing guidelines](CONTRIBUTING.md) for how to get started.
-
+Microsoft contributors with permission to create a branch in this repository can contribute a sample or fix by opening a pull request directly against `main`. Pull requests must pass the required `trusted` check and are merged by a maintainer. See the [contributing guidelines](CONTRIBUTING.md) for setup, validation, and review details.


### PR DESCRIPTION
## Summary

- restore `README.md` and `CONTRIBUTING.md` to their exact contents at pre-sync public SHA `71dd35f71a23cac12c9f5f88bf8e8cd102d41196`
- restore the public-first, same-repository contribution workflow
- reverse the unintended documentation regression introduced by [microsoft-foundry/foundry-samples#940](https://github.com/microsoft-foundry/foundry-samples/pull/940)

## Validation

- confirmed both restored blobs exactly match SHA `71dd35f71a23cac12c9f5f88bf8e8cd102d41196`
- confirmed the diff contains only `README.md` and `CONTRIBUTING.md`
- ran `git diff --check`

## Tracking

ADO 5555347: https://msdata.visualstudio.com/Vienna/_workitems/edit/5555347