### PR TITLE
Add fresh public agent-routing guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,11 @@
+## Repository publication routing
+
+- `microsoft-foundry/foundry-samples` is the sole venue for work intended for publication. Contributions use the normal public pull request path and existing repository checks; a maintainer initiates the merge.
+- Do not redirect contributors to or recreate publishable work in `microsoft-foundry/foundry-samples-pr`.
+- If a contributor lacks the required access to create the appropriate public-repository branch, surface that clearly and pause for repository-maintainer guidance. Do not invent an alternate publication route.
+- Do not propose private staging as a contributor path or recreate retired destructive behavior such as reverse mirroring, replay, `force_full`, direct-public-main publication, or unverified reseeding.
+- A manual private-to-public bridge exists only for authorized maintainers handling specifically approved internal content. Do not dispatch that bridge or initiate verified seed recovery without explicit operator authorization; normal publication work still starts as a public pull request.
+
 ## Files owned by the AI Platform Docs team
 
 If a file is listed in the CODEOWNERS file with @azure-ai-foundry/ai-platform-docs as the owner, it is owned by the AI Platform Docs team.  For these files:


### PR DESCRIPTION
## Summary

- single-commit replacement for blocked [PR 929](https://github.com/microsoft-foundry/foundry-samples/pull/929)
- establish `microsoft-foundry/foundry-samples` as the sole venue for work intended for publication
- keep publication work on the normal public pull request, repository-check, and maintainer-merge route
- pause for repository-maintainer guidance when public-branch access is unavailable, without redirecting or recreating work in `foundry-samples-pr`
- prohibit retired destructive private paths and reserve the retained manual bridge and verified seed recovery for explicitly authorized operators

## Scope

This PR changes only `.github/copilot-instructions.md`. It preserves the existing AI Platform Docs safeguards exactly and does not modify workflows, repository settings, CODEOWNERS, samples, notebooks, Azure DevOps work items, or any other pull request.

## Tracking

- [ADO 5502654](https://msdata.visualstudio.com/Vienna/_workitems/edit/5502654)
- [ADO 5555657](https://msdata.visualstudio.com/Vienna/_workitems/edit/5555657)

## Validation

- parsed `.github/copilot-instructions.md` with PowerShell `ConvertFrom-Markdown`
- `git diff --check`
- exactly one changed file: `.github/copilot-instructions.md`
- exactly one commit over current `origin/main`