### PR TITLE
Consolidate public contribution and validation guidance

### DIFF
--- a/.github/scripts/CLASSIFICATION.md
+++ b/.github/scripts/CLASSIFICATION.md
@@ -1,21 +1,24 @@
 # Sample validator classification contract
 
 Authoritative `failure`-vs-`error` contract for `.github/scripts/validate-sample.sh`.
-The public-first validation pipeline — and specifically the quarantine loop (P4.4) —
-**keys on this contract**. Read this before changing the classifier or anything that
-consumes its verdict.
+Current workflows and reports key on this contract. Planned reaction and
+quarantine automation must preserve it, but that automation is not yet
+delivered. Read this before changing the classifier or anything that consumes
+its verdict.
 
 ## Exit contract (three-way, load-bearing)
 
 | Exit | Verdict | Meaning | Downstream action |
 |------|---------|---------|-------------------|
 | `0`  | `pass`  | The requested mode passed: build readiness builds/compiles, or the declared live-service command exited 0. Live-service validation with no declaration is also a successful no-op. | none |
-| `1`  | `fail`  | **The SAMPLE is broken**, or a runtime failure we cannot positively attribute to our infra. | P4.4 may count a strike / quarantine (advisory-first). |
-| `2`  | `error` | **OUR INFRA is sick** — a precondition error, a dedicated dependency install with positively-identified transport failure, or a live-service command explicitly reporting caller/cloud infrastructure failure with exit 2. | Page us. **P4.4 must NEVER count or quarantine on `error`.** |
+| `1`  | `fail`  | **The SAMPLE is broken**, or a runtime failure we cannot positively attribute to our infra. | Inspect the sample output. Future reaction automation may treat this as sample-owned. |
+| `2`  | `error` | **OUR INFRA is sick** — a precondition error, a dedicated dependency install with positively-identified transport failure, or a live-service command explicitly reporting caller/cloud infrastructure failure with exit 2. | Inspect the workflow or caller environment. Future reaction automation must not count this against a sample. |
 
-The split is a safety interlock. A real breakage mislabeled `error` hides broken code forever
-(there is no counter behind `error`). A transient infra blip mislabeled `failure` risks
-quarantining a healthy sample. Both directions are dangerous; keep the split honest.
+The split is a safety interlock for current reports and future reaction
+automation. A real breakage mislabeled `error` hides broken code from
+sample-owned reporting. A transient infrastructure issue mislabeled `failure`
+could make future automation act on a healthy sample. Both directions are
+dangerous; keep the split honest.
 
 ## What is `error` (exit 2)
 
@@ -59,9 +62,9 @@ exit `2`; output text is not interpreted. When we genuinely cannot tell an infra
 sample break, we bias to **`failure`**.
 
 Rationale — *recourse asymmetry*, not "strikes are cheap":
-- A false `error` has **no counter**: it silently hides real breakage forever.
-- A false `failure` is recoverable: P4.4 runs advisory-first, quarantine is strike-based, and a
-  human reviews before a sample moves.
+- A false `error` can silently hide real sample breakage.
+- A false `failure` is visible for human review. Any future quarantine mechanism
+  must be advisory-first and require review before a sample moves.
 - We keep the transport allow-list **narrow** so false `failure`s stay rare in the first place —
   we do not lean on the strike mechanism to absorb sloppiness (infra outages are correlated and
   can survive multiple runs).

--- a/.github/scripts/validate-sample.README.md
+++ b/.github/scripts/validate-sample.README.md
@@ -24,6 +24,27 @@ and a sample with a `live_service_validation` declaration proceeds to live-servi
 validation only after readiness passes. Declaring live-service validation therefore
 does not opt a sample out of build readiness.
 
+## Build readiness
+
+The validator supports `csharp`, `python`, `typescript`, `java`, and `go`.
+Workflow callers map JavaScript samples to `typescript`.
+
+If `sample.yaml` declares `build`, `validate`, or `test`, the validator runs
+each non-empty command in that order and stops at the first failure. Declared
+commands take precedence over the language default.
+
+| Language | Default when no commands are declared |
+|---|---|
+| C# | Run `dotnet build --verbosity minimal` for every top-level `.csproj`; pass when none exists. |
+| Python | Create and activate a temporary `.venv` in the sample directory, install `requirements.txt` when present, run `python -m py_compile` for each top-level `.py`, and remove the virtual environment on exit. |
+| TypeScript / JavaScript | With `package.json`, run `npm install --no-audit --no-fund` and `npm run build --if-present`. Without it, run `node --check` for top-level `.js`; top-level `.ts` files have no default compile step. |
+| Java | Run `mvn compile -q` for `pom.xml`, or a Gradle build for `build.gradle`/`build.gradle.kts`, preferring `./gradlew` before a system `gradle`; pass when neither build file exists. |
+| Go | Run `go build ./...` with `go.mod`, otherwise build each top-level `.go`; pass when no top-level `.go` exists. |
+
+Rust is not supported. The full-fleet cadence currently enables C#, Java,
+Python, TypeScript, and JavaScript; Go remains available to local and
+pull-request callers but is not enabled by cadence discovery.
+
 Both modes use the same exit and verdict contract:
 
 | Exit | Verdict | Meaning |
@@ -34,9 +55,9 @@ Both modes use the same exit and verdict contract:
 
 See `CLASSIFICATION.md` for the authoritative failure-versus-error rules.
 
-## `sample.yaml` live-service declaration
+## `sample.yaml` Live-service declaration
 
-Live-service validation is opt-in. A sample declares it with a top-level
+Live-service validation is opt-in and sample-owned. A sample declares it with a top-level
 `live_service_validation` mapping:
 
 ```yaml
@@ -70,9 +91,10 @@ The contract is:
   environment-variable names. Every listed variable must be non-empty or the
   validator returns infrastructure error (`2`) before executing sample code.
 - `SKIP_PROVISION` is a reserved caller input and must be set to exactly `true`
-  or `false` whenever live-service validation is declared. The validator does not override it:
-  trusted PR callers can use the warm project with `true`, while the cold
-  cadence can use `false`.
+  or `false` whenever live-service validation is declared. The validator
+  passes it through but never provisions resources itself. Current repository
+  workflows use the warm project with `true`; cold provisioning and a caller
+  policy for `false` are not yet delivered.
 - Authentication and cloud configuration are caller-owned. The command inherits
   the caller's environment and existing CLI/OIDC login. Do not put credentials,
   secrets, resource provisioning, or production mutations in `sample.yaml`.
@@ -90,3 +112,17 @@ The validator rejects the legacy `l4` key with a migration message. It also reje
 a scalar `live_service_validation`, a missing/non-string/empty `command`, a non-list
 `required_env`, invalid variable names, malformed YAML, and missing declared
 environment inputs as infrastructure errors.
+
+## Caller responsibilities
+
+Local callers must install the language toolchain and Bash. Install `yq` when
+the sample has `sample.yaml`; repository workflows pin `yq` 4.44.3. Callers
+also own authentication, environment variables, and the decision to use a warm
+or future cold environment. The validator does not log in, create cloud
+resources, or infer credentials.
+
+The pull-request workflow runs Build readiness for changed supported samples
+and uses the existing warm project for its required `trusted` check. The daily
+cadence discovers the full metadata-bearing inventory and publishes normalized
+results as described in the
+[daily validation guide](../validation-pilot.README.md).

--- a/.github/validation-pilot.README.md
+++ b/.github/validation-pilot.README.md
@@ -1,33 +1,88 @@
 # Daily public validation cadence
 
-`validation-pilot.yml` runs daily at 07:00 UTC and can also be dispatched
-manually. It discovers every `samples/**/sample.yaml` at the checked-out commit,
-generates a deterministic manifest and matrix, and runs with `fail-fast: false`.
-The first full-fleet run should be manually reviewed before the first scheduled
-occurrence.
+The [Daily public validation cadence](workflows/validation-pilot.yml) runs at
+07:00 UTC and supports manual dispatch from GitHub Actions. A newer run cancels
+an older in-progress run.
 
-All supported samples run build readiness. Samples declaring live-service validation use a separate credentialed
-matrix leg to avoid duplicate validation and unnecessary environment deployment
-records, but that leg still runs build readiness first and proceeds to live-service
-validation only when readiness passes. Declaring live-service validation never opts
-a sample out of build readiness. JavaScript uses the existing
-TypeScript/node validator mapping. Rust samples remain in the manifest and emit
-`skipped/not-completed` with an explicit unsupported-language reason.
+## Discovery and eligibility
 
-Each matrix leg persists `sample-result.json` and `diagnostics.log` in a
-versioned artifact. Declared `sample.yaml` live-service commands run through the
-existing `L4-validation` OIDC environment and warm-project seam. That environment
-name is a legacy external GitHub/Entra identifier and is not the validation mode
-name. P4.1 does not provision
-resources and does not set a cold-provisioning default.
+At the checked-out commit, discovery sorts every
+`samples/**/sample.yaml`, derives a stable ID from its path, and emits the
+schema-v2 manifest and matrices used by that run. There is no static sample
+matrix to update.
 
-The result schema remains owned by the producer and includes
-sample identity, one of `passed`, `sample failure`, `infrastructure/error`, or
-`skipped/not-completed`, the completed stage, duration, references to the
-diagnostic and result artifacts, completion time, and GitHub run metadata.
+Discovery handles ineligible metadata deterministically:
 
-The completeness job fails the run if any discovered sample is missing,
-duplicated, malformed, or missing its diagnostic. Individual sample failures
-remain valid result records and do not prevent later matrix legs from running.
-The generated manifest is included in the normalized run artifact so the
-same-run report consumes exactly the inventory that was executed.
+- Unreadable or invalid YAML remains in the manifest and produces
+  `skipped/not-completed` with the metadata error as its reason.
+- A language not enabled by cadence discovery remains in the manifest and
+  produces `skipped/not-completed` with an unsupported-language reason.
+- Duplicate derived IDs, metadata that is not a regular file inside the
+  repository, and the legacy top-level `l4` key fail discovery.
+
+The cadence currently enables C#, Java, Python, and TypeScript. JavaScript maps
+to the TypeScript/Node.js validator. Go is supported by the local and
+pull-request validator but is not yet enabled by full-fleet discovery. Rust
+Build readiness is not supported.
+
+This eligibility handling does not move files, count strikes, or quarantine
+samples. Automated reaction and quarantine remain unfinished.
+
+## Validation sequence and caller policy
+
+Samples without a `live_service_validation` declaration run in the
+credential-free Build-readiness matrix. Declared samples run in a separate
+credentialed matrix leg that performs Build readiness first and runs the
+sample-owned Live-service command only after readiness passes. The matrices use
+`fail-fast: false`, so one sample result does not cancel unrelated samples.
+
+The current cadence uses an existing warm project and sets
+`SKIP_PROVISION=true`; it does not provision resources. Its GitHub environment
+is named `L4-validation` only because that legacy external identifier is part
+of the GitHub/Entra OIDC configuration. `L4` is not a current validation
+concept.
+
+See the [per-sample validation contract](scripts/validate-sample.README.md) for
+local commands, Build-readiness behavior, Live-service metadata, and result
+classification.
+
+## Results and report
+
+Every matrix leg uploads a `validation-pilot-{sample-id}` artifact containing
+`sample-result.json` and `diagnostics.log` for 30 days. The completeness job
+combines those artifacts with the exact generated manifest and uploads
+`validation-pilot-run-{run-id}-{attempt}` for 90 days.
+
+Producers write schema v2. Completeness and report readers also accept
+historical schema-v1 artifacts and translate their legacy completed-stage
+labels for display. A result contains sample identity, outcome, completed
+stage, duration, artifact references, completion time, and GitHub run metadata.
+
+The `report / report` job writes the run-scoped report to the GitHub Actions job
+summary. It puts actionable records first, includes sanitized diagnostic
+excerpts and links to samples at the validated commit, and collapses passing
+records. Use the per-sample or consolidated artifact for full diagnostics.
+
+Outcomes mean:
+
+| Outcome | Interpretation |
+|---|---|
+| `passed` | The requested validation sequence completed successfully. |
+| `sample failure` | Sample-owned code, dependencies, or assertions failed. |
+| `infrastructure/error` | The validator or caller environment could not complete a valid check. |
+| `skipped/not-completed` | Discovery retained the sample but current eligibility prevented execution. |
+
+Completeness fails when a discovered sample has no result, a duplicate or
+malformed result, an identity mismatch, or a missing diagnostic. A reported
+sample failure is complete data even though it requires maintainer attention.
+
+Open the
+[workflow runs](https://github.com/microsoft-foundry/foundry-samples/actions/workflows/validation-pilot.yml)
+to inspect the latest report and artifacts.
+
+## Current limits
+
+The delivered cadence is daily/manual and warm-project only. Cold provisioning,
+automated reaction or quarantine, broader Live-service coverage, and Rust Build
+readiness remain unfinished. The daily report is diagnostic evidence; it does
+not replace the pull request's required `trusted` merge check.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -164,7 +164,7 @@ jobs:
   #     yields a PRESENT, FAILING check and requires maintainer promotion.
   #   - Concurrency cancels superseded runs.
   #   - Live-service validation uses the pre-provisioned WARM project via SKIP_PROVISION=true (never provisions
-  #     per PR — cold provisioning is the cadence lane's sole job). OIDC federated login, no stored
+  #     per PR). Cold provisioning is not yet delivered. OIDC federated login, no stored
   #     secret. The legacy external environment identifier L4-validation MUST carry zero
   #     protection_rules: because this always-running job
   #     binds the environment, an environment reviewer rule would stall a fork instead of failing it.
@@ -185,8 +185,7 @@ jobs:
       group: validate-trusted-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     env:
-      # Reuse the warm project — never provision per PR (①-guardrail: cold provisioning belongs to
-      # the cadence lane only and must never be "warmed" here for speed).
+      # Reuse the warm project — never provision per PR. Cold provisioning remains future work.
       SKIP_PROVISION: "true"
     steps:
       # MUST remain first. A failed `needs` job normally skips dependents; the job-level

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,12 +12,12 @@ Before starting a substantial change, check for an existing issue. Open one when
 
 Sample contributions are currently limited to Microsoft Foundry teams with permission to create a branch in this repository. Fork pull requests cannot satisfy the intentionally failing `trusted` gate, so sample changes must use a same-repository branch.
 
-Contributors should always submit publishable changes through a public same-repository pull request. Maintainers may independently operate a separate bridge for approved eligible content already in the private repository; contributors must not dispatch it.
+Contributors should always submit publishable changes through a public same-repository pull request. Do not use a private staging repository or internal publication workflow as a contributor path. If you cannot create a branch in this repository, ask a repository maintainer for guidance.
 
 1. **Create a branch in this repository.** Use a same-repository branch for all sample changes.
 2. **Make a focused change.** Keep each pull request scoped to one sample, fix, or related set of updates. Follow the conventions in the surrounding sample.
-3. **Respect file ownership.** Review [CODEOWNERS](.github/CODEOWNERS) before editing. The listed owners will be requested when their files are changed.
-4. **Validate locally.** Run the setup, build, test, or sample-specific validation documented by the affected sample. Never commit credentials, local environment files, or generated secrets.
+3. **Respect file ownership.** Review [CODEOWNERS](.github/CODEOWNERS) before editing. The listed owners receive review requests when their files change; CODEOWNERS routing does not itself require an approving review.
+4. **Validate locally.** Run the setup, build, test, or sample-specific validation documented by the affected sample. For metadata-bearing samples, use the [per-sample validation contract](.github/scripts/validate-sample.README.md) as the source for Build-readiness behavior and Live-service opt-in. Never commit credentials, local environment files, or generated secrets.
 5. **Open a pull request against `main`.** In the pull request description, explain what changed, why it changed, and the local validation you ran. Link the relevant issue when one exists.
 
 ### Pull request checks
@@ -26,7 +26,11 @@ Pull requests run repository validation automatically:
 
 - The required `trusted` check must pass.
 - Review and address the other checks reported on the pull request.
-- Contributor pull requests are not merged automatically; after required checks and review, a maintainer triggers the merge.
+- Contributor pull requests are not merged automatically; after required checks pass, a maintainer considers review feedback and triggers the merge.
+
+The required check reports on the pull request. The separate
+[daily validation cadence](.github/validation-pilot.README.md) publishes its
+fleet report and diagnostic artifacts in GitHub Actions.
 
 ## Contributor License Agreement
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ This repository is entirely open source, guidance on how to contribute and links
 
 Use the samples in this repository to try out Microsoft Foundry scenarios on your local machine!
 
+## Validation
+
+Pull requests run the required `trusted` check. Sample authors can run the same
+per-sample Build-readiness validator locally and can opt a sample into
+sample-owned Live-service validation through `sample.yaml`. See the
+[per-sample validation contract](.github/scripts/validate-sample.README.md) for
+commands and language behavior.
+
+The [daily public validation cadence](.github/validation-pilot.README.md)
+discovers metadata-bearing samples and publishes a run summary plus diagnostic
+artifacts in GitHub Actions.
+
 ## Contributing
 
 Found a bug or have a suggestion? [Open an issue](https://github.com/microsoft-foundry/foundry-samples/issues/new) — we welcome feedback from everyone!


### PR DESCRIPTION
## Summary
- connect public contributor routing to the authoritative local and daily validation guides
- document exact Build-readiness defaults, Live-service opt-in, result artifacts, and schema compatibility
- distinguish delivered warm-project validation from pending cold provisioning, reaction/quarantine, Rust, and expanded coverage

## Validation
- python report tests (6 passed)
- python validation-pilot contracts (12 passed)
- workflow structure harness (39 passed)
- changed-sample detector harness (23 passed)
- relative Markdown links and git diff --check
- full validator harness deferred to Linux PR CI; latest live scripts-selftest run 32910376925 passed

ADO 5449675: https://msdata.visualstudio.com/Vienna/_workitems/edit/5449675